### PR TITLE
fix warning PGC-W-0158-Use of escape \%, \ ignored (ncmpilogdump.c: 107)

### DIFF
--- a/src/utils/ncmpilogdump/ncmpilogdump.m4
+++ b/src/utils/ncmpilogdump/ncmpilogdump.m4
@@ -121,7 +121,7 @@ int main(int argc, char *argv[]) {
         printf("Data representation:\t\tinternal\n");
     }
     printf("Max number of dimensions:\t%lld\n", Header->max_ndims);
-    printf("Begin of entry record:\t\t\%lld\n", Header->entry_begin);
+    printf("Begin of entry record:\t\t%lld\n", Header->entry_begin);
     printf("Number of entries:\t\t\t%lld\n", Header->num_entries);
 
     printf("\nData log header:%.8s\n", Header->magic);

--- a/test/burst_buffer/wrap_runs.sh
+++ b/test/burst_buffer/wrap_runs.sh
@@ -12,7 +12,7 @@ VALIDATOR=../../src/utils/ncvalidator/ncvalidator
 for j in 0 1 ; do
     export PNETCDF_SAFE_MODE=$j
     # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
-    export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR}"
+    export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
     ${TESTSEQRUN} $1              ${TESTOUTDIR}/$1.nc
     unset PNETCDF_HINTS
     ${TESTSEQRUN} ${VALIDATOR} -q ${TESTOUTDIR}/$1.nc


### PR DESCRIPTION
Fix the warning in ncmpilogdump