### PR TITLE
fix hash_map

### DIFF
--- a/src/drivers/common/hash_map.c
+++ b/src/drivers/common/hash_map.c
@@ -27,6 +27,7 @@ int hash_map_init(hash_map *map, int size, unsigned int (*hash)(const char* key)
     if (map->table == NULL){
         DEBUG_RETURN_ERROR(NC_ENOMEM);
     }
+    memset(map->table, 0, sizeof(hash_map_node*) * size);
     map->size = size;
     
     return NC_NOERR;

--- a/src/drivers/common/hash_map.c
+++ b/src/drivers/common/hash_map.c
@@ -23,11 +23,10 @@
 
 int hash_map_init(hash_map *map, int size, unsigned int (*hash)(const char* key)){
     map->hash = hash;
-    map->table = (hash_map_node**)NCI_Malloc(sizeof(hash_map_node*) * size);
+    map->table = (hash_map_node**)NCI_Calloc(size, sizeof(hash_map_node*));
     if (map->table == NULL){
         DEBUG_RETURN_ERROR(NC_ENOMEM);
     }
-    memset(map->table, 0, sizeof(hash_map_node*) * size);
     map->size = size;
     
     return NC_NOERR;

--- a/src/drivers/ncbbio/ncbbio_log.c
+++ b/src/drivers/ncbbio/ncbbio_log.c
@@ -146,8 +146,7 @@ int ncbbio_log_create(NC_bb* ncbbp, MPI_Info info) {
 
     /* Communicator for processes sharing log files */
     if (ncbbp->hints & NC_LOG_HINT_LOG_SHARE) {
-//#if MPI_VERSION >= 3
-#if 0
+#if MPI_VERSION >= 3
         err = MPI_Comm_split_type(ncbbp->comm, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL,
                         &(ncbbp->logcomm));
         if (err != NC_NOERR){

--- a/test/largefile/Makefile.am
+++ b/test/largefile/Makefile.am
@@ -92,7 +92,7 @@ ptest ptest4: $(TESTPROGRAMS)
 	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
 	if [ -n "$(TESTBB)" ]; then ( \
 	export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};" ; \
-	$(TESTMPIRUN6) ./$$i $(TESTOUTDIR)/$$i.nc ; \
+	$(TESTMPIRUN4) ./$$i $(TESTOUTDIR)/$$i.nc ; \
 	unset PNETCDF_HINTS ; \
 	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
 	) ; fi ; \
@@ -107,7 +107,7 @@ ptest2: $(TESTPROGRAMS)
 	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
     if [ -n "$(TESTBB)" ]; then ( \
 	export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};" ; \
-	$(TESTMPIRUN6) ./$$i $(TESTOUTDIR)/$$i.nc ; \
+	$(TESTMPIRUN2) ./$$i $(TESTOUTDIR)/$$i.nc ; \
 	unset PNETCDF_HINTS ; \
 	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
 	) ; fi ; \

--- a/test/largefile/Makefile.am
+++ b/test/largefile/Makefile.am
@@ -58,7 +58,7 @@ endif
 if RUN_LARGE_FILE_TEST
 TESTPROGRAMS = $(check_PROGRAMS)
 else
-TESTPROGRAMS =
+TESTPROGRAMS = $(check_PROGRAMS)
 endif
 
 # autimake 1.11.3 has not yet implemented AM_TESTS_ENVIRONMENT
@@ -87,11 +87,8 @@ ptest ptest4: $(TESTPROGRAMS)
 	for j in 0 ; do { \
 	export PNETCDF_SAFE_MODE=$$j ; \
 	set -e ; for i in $(TESTPROGRAMS) ; do ( \
-	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
-	$(TESTMPIRUN4) ./$$i $(TESTOUTDIR)/$$i.nc ; \
-	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
-	if [ -n "$(TESTBB)" ]; then ( \
-	export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};" ; \
+	if [ -n "1" ]; then ( \
+	export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_shared_logfs=enable;nc_burst_buf_overwrite=enable;nc_burst_buf_del_on_close=disable" ; \
 	$(TESTMPIRUN6) ./$$i $(TESTOUTDIR)/$$i.nc ; \
 	unset PNETCDF_HINTS ; \
 	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
@@ -102,11 +99,8 @@ ptest2: $(TESTPROGRAMS)
 	for j in 0 ; do { \
 	export PNETCDF_SAFE_MODE=$$j ; \
 	set -e ; for i in $(TESTPROGRAMS); do ( \
-	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
-	$(TESTMPIRUN2) ./$$i $(TESTOUTDIR)/$$i.nc ; \
-	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
-    if [ -n "$(TESTBB)" ]; then ( \
-	export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};" ; \
+    if [ -n "1" ]; then ( \
+	export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_shared_logfs=enable;nc_burst_buf_overwrite=enable;nc_burst_buf_del_on_close=disable" ; \
 	$(TESTMPIRUN6) ./$$i $(TESTOUTDIR)/$$i.nc ; \
 	unset PNETCDF_HINTS ; \
 	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
@@ -117,11 +111,8 @@ ptest6: $(TESTPROGRAMS)
 	for j in 0 ; do { \
 	export PNETCDF_SAFE_MODE=$$j ; \
 	set -e ; for i in $(TESTPROGRAMS); do ( \
-	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
-	$(TESTMPIRUN6) ./$$i $(TESTOUTDIR)/$$i.nc ; \
-	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
-	if [ -n "$(TESTBB)" ]; then ( \
-	export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};" ; \
+	if [ -n "1" ]; then ( \
+	export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_shared_logfs=enable;nc_burst_buf_overwrite=enable;nc_burst_buf_del_on_close=disable" ; \
 	$(TESTMPIRUN6) ./$$i $(TESTOUTDIR)/$$i.nc ; \
 	unset PNETCDF_HINTS ; \
 	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \

--- a/test/largefile/Makefile.am
+++ b/test/largefile/Makefile.am
@@ -58,7 +58,7 @@ endif
 if RUN_LARGE_FILE_TEST
 TESTPROGRAMS = $(check_PROGRAMS)
 else
-TESTPROGRAMS = $(check_PROGRAMS)
+TESTPROGRAMS =
 endif
 
 # autimake 1.11.3 has not yet implemented AM_TESTS_ENVIRONMENT
@@ -87,8 +87,11 @@ ptest ptest4: $(TESTPROGRAMS)
 	for j in 0 ; do { \
 	export PNETCDF_SAFE_MODE=$$j ; \
 	set -e ; for i in $(TESTPROGRAMS) ; do ( \
-	if [ -n "1" ]; then ( \
-	export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_shared_logfs=enable;nc_burst_buf_overwrite=enable;nc_burst_buf_del_on_close=disable" ; \
+	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
+	$(TESTMPIRUN4) ./$$i $(TESTOUTDIR)/$$i.nc ; \
+	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
+	if [ -n "$(TESTBB)" ]; then ( \
+	export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};" ; \
 	$(TESTMPIRUN6) ./$$i $(TESTOUTDIR)/$$i.nc ; \
 	unset PNETCDF_HINTS ; \
 	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
@@ -99,8 +102,11 @@ ptest2: $(TESTPROGRAMS)
 	for j in 0 ; do { \
 	export PNETCDF_SAFE_MODE=$$j ; \
 	set -e ; for i in $(TESTPROGRAMS); do ( \
-    if [ -n "1" ]; then ( \
-	export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_shared_logfs=enable;nc_burst_buf_overwrite=enable;nc_burst_buf_del_on_close=disable" ; \
+	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
+	$(TESTMPIRUN2) ./$$i $(TESTOUTDIR)/$$i.nc ; \
+	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
+    if [ -n "$(TESTBB)" ]; then ( \
+	export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};" ; \
 	$(TESTMPIRUN6) ./$$i $(TESTOUTDIR)/$$i.nc ; \
 	unset PNETCDF_HINTS ; \
 	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
@@ -111,8 +117,11 @@ ptest6: $(TESTPROGRAMS)
 	for j in 0 ; do { \
 	export PNETCDF_SAFE_MODE=$$j ; \
 	set -e ; for i in $(TESTPROGRAMS); do ( \
-	if [ -n "1" ]; then ( \
-	export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_shared_logfs=enable;nc_burst_buf_overwrite=enable;nc_burst_buf_del_on_close=disable" ; \
+	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
+	$(TESTMPIRUN6) ./$$i $(TESTOUTDIR)/$$i.nc ; \
+	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \
+	if [ -n "$(TESTBB)" ]; then ( \
+	export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};" ; \
 	$(TESTMPIRUN6) ./$$i $(TESTOUTDIR)/$$i.nc ; \
 	unset PNETCDF_HINTS ; \
 	$(RM) -f $(TESTOUTDIR)/$$i.nc ; \


### PR DESCRIPTION
fix table not initialized problem in hashmap.
fix using built in comm_split_type on MPI 3.