### PR TITLE
limit flush buffer to 2GiB if large_req is off

### DIFF
--- a/src/drivers/ncbbio/ncbbio_log_flush.c
+++ b/src/drivers/ncbbio/ncbbio_log_flush.c
@@ -100,6 +100,13 @@ int log_flush(NC_bb *ncbbp) {
     if (ncbbp->flushbuffersize > 0 && databuffersize > ncbbp->flushbuffersize){
         databuffersize = ncbbp->flushbuffersize;
     }
+    /* Without enabling large_req, we can not post requests larger than 2GiB */
+#ifndef ENABLE_LARGE_REQ
+    if (databuffersize > 2147483648){
+        databuffersize = 2147483648;
+    }
+#endif
+    /* We assume user will not issue single request larger than 2GiB wwithout enabling large_req */
     if (databuffersize < ncbbp->maxentrysize){
         databuffersize = ncbbp->maxentrysize;
     }


### PR DESCRIPTION
limit flush buffer to 2GiB if large_req is off 