### PR TITLE
Remove inline directive

### DIFF
--- a/src/dispatchers/error_codes.c
+++ b/src/dispatchers/error_codes.c
@@ -18,7 +18,7 @@
 #include <string.h> /* contains prototype for ansi libc function strerror() */
 #else
 /* provide a strerror function for older unix systems */
-inline static char *
+static char *
 strerror(int errnum)
 {
     extern int sys_nerr;

--- a/src/drivers/common/Makefile.am
+++ b/src/drivers/common/Makefile.am
@@ -43,6 +43,13 @@ C_SRCS    = utf8proc.c \
 libcommon_la_SOURCES = $(C_SRCS) $(H_SRCS)
 nodist_libcommon_la_SOURCES = $(M4_SRCS:.m4=.c)
 
+# Thanks to Rafik Zurob to provide the fix and point out when using the IBM xlc
+# compilers, ncx.c breaks strict ANSI C aliasing rules in regards to how
+# put_ix_float / get_ix_float are used. That's why the file was miscompiled.
+# The file should either be changed to follow strict ANSI C aliasing, or
+# -fno-strict-aliasing should be used to compile.
+ncx.lo: LTCOMPILE += -fno-strict-aliasing
+
 $(M4_SRCS:.m4=.c): Makefile
 
 .m4.c:

--- a/src/drivers/common/mem_alloc.c
+++ b/src/drivers/common/mem_alloc.c
@@ -70,7 +70,7 @@ typedef struct {
     char   *filename;
 } ncmpii_mem_entry;
 
-inline static
+static
 int ncmpii_cmp(const void *a, const void *b) {
     ncmpii_mem_entry *fa = (ncmpii_mem_entry*)a;
     ncmpii_mem_entry *fb = (ncmpii_mem_entry*)b;
@@ -80,7 +80,7 @@ int ncmpii_cmp(const void *a, const void *b) {
     return 0;
 }
 
-inline static
+static
 void walker(const void *node, const VISIT which, const int depth) {
     ncmpii_mem_entry *f;
     f = *(ncmpii_mem_entry **)node;

--- a/src/drivers/common/ncx.m4
+++ b/src/drivers/common/ncx.m4
@@ -294,7 +294,7 @@ static const char nada[X_ALIGN] = {0, 0, 0, 0};
                    (((a) & 0xFF00000000000000ULL) >> 56) )
 
 
-inline static void
+static void
 swapn2b(void *dst, const void *src, IntType nn)
 {
     /* it is OK if dst == src */
@@ -338,7 +338,7 @@ swapn2b(void *dst, const void *src, IntType nn)
 }
 
 # ifndef vax
-inline static void
+static void
 swap4b(void *dst, const void *src)
 {
     /* copy over, make the below swap in-place */
@@ -383,7 +383,7 @@ swap4b(void *dst, const void *src)
 }
 # endif /* !vax */
 
-inline static void
+static void
 swapn4b(void *dst, const void *src, IntType nn)
 {
     int i;
@@ -445,7 +445,7 @@ swapn4b(void *dst, const void *src, IntType nn)
 }
 
 # ifndef vax
-inline static void
+static void
 swap8b(void *dst, const void *src)
 {
 #ifdef FLOAT_WORDS_BIGENDIAN
@@ -495,7 +495,7 @@ swap8b(void *dst, const void *src)
 # endif /* !vax */
 
 # ifndef vax
-inline static void
+static void
 swapn8b(void *dst, const void *src, IntType nn)
 {
 #if 0
@@ -1204,7 +1204,7 @@ NCX_PUT1F(uint, double)
 
 #if X_SIZEOF_FLOAT == SIZEOF_FLOAT && !defined(NO_IEEE_FLOAT)
 
-inline static void
+static void
 get_ix_float(const void *xp, float *ip)
 {
 #ifdef WORDS_BIGENDIAN
@@ -1214,7 +1214,7 @@ get_ix_float(const void *xp, float *ip)
 #endif
 }
 
-inline static void
+static void
 put_ix_float(void *xp, const float *ip)
 {
 #ifdef WORDS_BIGENDIAN

--- a/src/drivers/ncmpio/ncmpio_attr.m4
+++ b/src/drivers/ncmpio/ncmpio_attr.m4
@@ -49,7 +49,7 @@ include(`utils.m4')dnl
 /* How much space will 'nelems' of 'xtype' take in external representation.
  * Note the space is aligned in 4-byte boundary.
  */
-inline static MPI_Offset
+static MPI_Offset
 x_len_NC_attrV(nc_type    xtype,
                MPI_Offset nelems)
 {

--- a/src/drivers/ncmpio/ncmpio_dim.c
+++ b/src/drivers/ncmpio/ncmpio_dim.c
@@ -112,7 +112,7 @@ NC_finddim(const NC_dimarray *ncap,
 /* dimarray */
 
 /*----< ncmpio_free_NC_dimarray() >------------------------------------------*/
-inline void
+void
 ncmpio_free_NC_dimarray(NC_dimarray *ncap)
 {
     int i;

--- a/src/drivers/ncmpio/ncmpio_filetype.c
+++ b/src/drivers/ncmpio/ncmpio_filetype.c
@@ -32,7 +32,7 @@
  * record variables, the stride across two records of a variable can be too
  * large for a 4-byte integer to represent.
  */
-inline static int
+static int
 check_recsize_too_big(MPI_Offset recsize)
 {
     int ret = NC_NOERR;

--- a/src/drivers/ncmpio/ncmpio_header_get.c
+++ b/src/drivers/ncmpio/ncmpio_header_get.c
@@ -119,7 +119,7 @@ hdr_len_NC_name(const NC_string *ncstrp, int sizeof_NON_NEG)
 #endif
 
 /*----< hdr_len_NC_dim() >---------------------------------------------------*/
-inline static MPI_Offset
+static MPI_Offset
 hdr_len_NC_dim(const NC_dim *dimp, int sizeof_NON_NEG)
 {
     /* netCDF file format:
@@ -172,7 +172,7 @@ hdr_len_NC_dimarray(const NC_dimarray *ncap, int sizeof_NON_NEG)
 }
 
 /*----< hdr_len_NC_attr() >--------------------------------------------------*/
-inline static MPI_Offset
+static MPI_Offset
 hdr_len_NC_attr(const NC_attr *attrp, int sizeof_NON_NEG)
 {
     /* netCDF file format:

--- a/src/drivers/ncmpio/ncmpio_header_put.c
+++ b/src/drivers/ncmpio/ncmpio_header_put.c
@@ -30,7 +30,7 @@ static const char ncmagic2[] = {'C', 'D', 'F', 0x02};
 static const char ncmagic5[] = {'C', 'D', 'F', 0x05};
 
 /*----< hdr_put_NC_name() >--------------------------------------------------*/
-inline static int
+static int
 hdr_put_NC_name(bufferinfo *pbp,
                 const char *name)
 {
@@ -60,7 +60,7 @@ hdr_put_NC_name(bufferinfo *pbp,
 }
 
 /*----< hdr_put_NC_dim() >---------------------------------------------------*/
-inline static int
+static int
 hdr_put_NC_dim(bufferinfo   *pbp,
                const NC_dim *dimp)
 {
@@ -90,7 +90,7 @@ hdr_put_NC_dim(bufferinfo   *pbp,
 }
 
 /*----< hdr_put_NC_dimarray() >----------------------------------------------*/
-inline static int
+static int
 hdr_put_NC_dimarray(bufferinfo        *pbp,
                     const NC_dimarray *ncap)
 {
@@ -147,7 +147,7 @@ hdr_put_NC_dimarray(bufferinfo        *pbp,
 /*
  * Put the values of an attribute
  */
-inline static int
+static int
 hdr_put_NC_attrV(bufferinfo    *pbp,
                  const NC_attr *attrp)
 {
@@ -188,7 +188,7 @@ hdr_put_NC_attrV(bufferinfo    *pbp,
 }
 
 /*----< hdr_put_NC_attr() >--------------------------------------------------*/
-inline static int
+static int
 hdr_put_NC_attr(bufferinfo    *pbp,
                 const NC_attr *attrp)
 {
@@ -228,7 +228,7 @@ hdr_put_NC_attr(bufferinfo    *pbp,
 }
 
 /*----< hdr_put_NC_attrarray() >---------------------------------------------*/
-inline static int
+static int
 hdr_put_NC_attrarray(bufferinfo         *pbp,
                      const NC_attrarray *ncap)
 {

--- a/src/drivers/ncmpio/ncmpio_var.c
+++ b/src/drivers/ncmpio/ncmpio_var.c
@@ -34,7 +34,7 @@
 
 /*----< ncmpio_free_NC_var() >-----------------------------------------------*/
 /* Free NC_var object */
-inline void
+void
 ncmpio_free_NC_var(NC_var *varp)
 {
     if (varp == NULL) return;
@@ -117,7 +117,7 @@ dup_NC_var(const NC_var *rvarp)
 /* vararray */
 
 /*----< ncmpio_free_NC_vararray() >------------------------------------------*/
-inline void
+void
 ncmpio_free_NC_vararray(NC_vararray *ncap)
 {
     int i;

--- a/test/testcases/test_erange.c
+++ b/test/testcases/test_erange.c
@@ -162,7 +162,12 @@ int test_cdf12(char *filename, int bb_enabled, int cmode)
 
     /* expect NC_ERANGE */
     dbuf = NC_MAX_DOUBLE/2.0;
-    err = ncmpi_put_var_double_all(ncid, fvid, &dbuf); EXP_ERR(NC_ERANGE)
+    err = ncmpi_put_var_double_all(ncid, fvid, &dbuf);
+    if (bb_enabled) {
+        CHECK_ERR
+        err = ncmpi_flush(ncid);
+    }
+    EXP_ERR(NC_ERANGE)
 
     /* write a value > NC_MAX_FLOAT */
     err = ncmpi_put_var_double_all(ncid, dvid, &dbuf); CHECK_ERR

--- a/test/testcases/test_erange.c
+++ b/test/testcases/test_erange.c
@@ -40,10 +40,11 @@
 static
 int test_cdf12(char *filename, int bb_enabled, int cmode)
 {
-    int err, nerrs=0, ncid, vid, dimid;
+    int err, nerrs=0, ncid, vid, fvid, dvid, dimid;
     unsigned char uc[1];
     signed char sc[1];
     int si[1];
+    double dbuf;
 
     cmode |= NC_CLOBBER;
     err = ncmpi_create(MPI_COMM_WORLD, filename, cmode, MPI_INFO_NULL, &ncid); CHECK_ERR
@@ -71,8 +72,34 @@ int test_cdf12(char *filename, int bb_enabled, int cmode)
         nerrs++;
     }
 
+    /* expect NC_ERANGE */
+    dbuf=NC_MAX_DOUBLE/2.0;
+    err = ncmpi_put_att_double(ncid, NC_GLOBAL, "attf", NC_FLOAT, 1, &dbuf);
+    EXP_ERR(NC_ERANGE)
+
+    /* add a new attribute of NC_DOUBLE with a value > NC_MAX_FLOAT */
+    err = ncmpi_put_att_double(ncid, NC_GLOBAL, "attd", NC_DOUBLE, 1, &dbuf);
+    CHECK_ERR
+
+#if defined(PNETCDF_ERANGE_FILL) && PNETCDF_ERANGE_FILL == 1
+    if (! (cmode & NC_NETCDF4)) {
+        float fbuf;
+        /* read back attf and expect NC_FILL_FLOAT */
+        dbuf = 0.0;
+        err = ncmpi_get_att_double(ncid, NC_GLOBAL, "attf", &dbuf); CHECK_ERR
+        if (dbuf != NC_FILL_FLOAT) {
+            printf("Error at line %d: unexpected read value %f (expecting %f)\n",__LINE__,dbuf,NC_FILL_FLOAT);
+            nerrs++;
+        }
+        /* read back attd as float and expect NC_ERANGE */
+        err = ncmpi_get_att_float(ncid, NC_GLOBAL, "attd", &fbuf); EXP_ERR(NC_ERANGE)
+    }
+#endif
+
     err = ncmpi_def_dim(ncid, "x", 1, &dimid); CHECK_ERR
     err = ncmpi_def_var(ncid, "var_byte", NC_BYTE, 1, &dimid, &vid); CHECK_ERR
+    err = ncmpi_def_var(ncid, "var_flt", NC_FLOAT, 1, &dimid, &fvid); CHECK_ERR
+    err = ncmpi_def_var(ncid, "var_dbl", NC_DOUBLE, 1, &dimid, &dvid); CHECK_ERR
     err = ncmpi_enddef(ncid); CHECK_ERR
 
     /* No NC_ERANGE should be returned for CDF-1 and 2 */
@@ -132,6 +159,29 @@ int test_cdf12(char *filename, int bb_enabled, int cmode)
         printf("Error at line %d: unexpected read value %d (expecting -128)\n",__LINE__,si[0]);
         nerrs++;
     }
+
+    /* expect NC_ERANGE */
+    dbuf = NC_MAX_DOUBLE/2.0;
+    err = ncmpi_put_var_double_all(ncid, fvid, &dbuf); EXP_ERR(NC_ERANGE)
+
+    /* write a value > NC_MAX_FLOAT */
+    err = ncmpi_put_var_double_all(ncid, dvid, &dbuf); CHECK_ERR
+
+#if defined(PNETCDF_ERANGE_FILL) && PNETCDF_ERANGE_FILL == 1
+    if (! (cmode & NC_NETCDF4)) {
+        float fbuf;
+        /* read back and expect NC_FILL_FLOAT */
+        dbuf = 0.0;
+        err = ncmpi_get_var_double_all(ncid, fvid, &dbuf); CHECK_ERR
+        if (dbuf != NC_FILL_FLOAT) {
+            printf("Error at line %d: unexpected read value %f (expecting %f)\n",__LINE__,dbuf,NC_FILL_FLOAT);
+            nerrs++;
+        }
+
+        /* read back dvid as float and expect NC_ERANGE */
+        err = ncmpi_get_var_float_all(ncid, dvid, &fbuf); EXP_ERR(NC_ERANGE)
+    }
+#endif
 
     err = ncmpi_close(ncid); CHECK_ERR
 


### PR DESCRIPTION
Using inline directives breaks strict ANSI C aliasing rules for IBM xl compilers.
See issue #23 and [netcdf #500](https://github.com/Unidata/netcdf-c/issues/500)