### PR TITLE
fix bug of checking interleaved access for scalar variables

### DIFF
--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -98,6 +98,7 @@ This is essentially a placeholder for the next release note ...
     burst buffers for each user write request.
 
 * Bug fixes
+  + Fix bug of checking interleaved requests for scalar variables.
   + When building PnetCDF using the IBM xlc compiler with -O optimization
     option on Little Endian platforms, users may encounter errors related to
     strict ANSI C aliasing rules. Thanks to Jim Edwards for reporting and Rafik

--- a/src/drivers/ncmpio/ncmpio_wait.c
+++ b/src/drivers/ncmpio/ncmpio_wait.c
@@ -2270,18 +2270,17 @@ wait_getput(NC         *ncp,
         if (req->lead->varp->ndims == 0) { /* scalar variable */
             req->offset_start = req->lead->varp->begin;
             req->offset_end   = req->lead->varp->begin + req->lead->varp->xsz;
-            continue;
         }
+        else {
+            /* start/count/stride are in the same contiguously allocated array */
+            count  = req->start + req->lead->varp->ndims;
+            stride = (fIsSet(req->lead->flag, NC_REQ_STRIDE_NULL)) ? NULL :
+                     count + req->lead->varp->ndims;
 
-        /* start/count/stride are in the same contiguously allocated array */
-        count  = req->start + req->lead->varp->ndims;
-        stride = (fIsSet(req->lead->flag, NC_REQ_STRIDE_NULL)) ? NULL :
-                 count + req->lead->varp->ndims;
-
-        /* calculate access range of this request */
-        calculate_access_range(ncp, req->lead->varp, req->start, count, stride,
-                               &req->offset_start, &req->offset_end);
-
+            /* calculate access range of this request */
+            calculate_access_range(ncp, req->lead->varp, req->start, count, stride,
+                                   &req->offset_start, &req->offset_end);
+        }
         if (i > 0) {
             /* check for interleaved requests */
             if (req->offset_start < reqs[i-1].offset_end) {


### PR DESCRIPTION
When aggregating nonblocking requests of scalar and non-scalar variables, the offset-len interleaving checking is skipped for scalar variables, which should not be skipped.