### PR TITLE
Bug fix to ignore NC_ENOTENABLED

### DIFF
--- a/examples/C/block_cyclic.c
+++ b/examples/C/block_cyclic.c
@@ -121,7 +121,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/bput_varn_int64.c
+++ b/examples/C/bput_varn_int64.c
@@ -142,7 +142,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/bput_varn_uint.c
+++ b/examples/C/bput_varn_uint.c
@@ -118,7 +118,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/collective_write.c
+++ b/examples/C/collective_write.c
@@ -110,7 +110,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/column_wise.c
+++ b/examples/C/column_wise.c
@@ -108,7 +108,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/create_open.c
+++ b/examples/C/create_open.c
@@ -72,7 +72,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/fill_mode.c
+++ b/examples/C/fill_mode.c
@@ -105,7 +105,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/flexible_api.c
+++ b/examples/C/flexible_api.c
@@ -122,7 +122,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/get_info.c
+++ b/examples/C/get_info.c
@@ -83,7 +83,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/get_vara.c
+++ b/examples/C/get_vara.c
@@ -101,7 +101,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/ghost_cell.c
+++ b/examples/C/ghost_cell.c
@@ -117,7 +117,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/global_attributes.c
+++ b/examples/C/global_attributes.c
@@ -79,7 +79,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/hints.c
+++ b/examples/C/hints.c
@@ -79,7 +79,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/i_varn_int64.c
+++ b/examples/C/i_varn_int64.c
@@ -119,7 +119,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/mput.c
+++ b/examples/C/mput.c
@@ -92,7 +92,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/nonblocking_write.c
+++ b/examples/C/nonblocking_write.c
@@ -83,7 +83,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/nonblocking_write_in_def.c
+++ b/examples/C/nonblocking_write_in_def.c
@@ -85,7 +85,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/pthread.c
+++ b/examples/C/pthread.c
@@ -114,7 +114,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/put_vara.c
+++ b/examples/C/put_vara.c
@@ -106,7 +106,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/put_varn_float.c
+++ b/examples/C/put_varn_float.c
@@ -84,7 +84,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/put_varn_int.c
+++ b/examples/C/put_varn_int.c
@@ -92,7 +92,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/req_all.c
+++ b/examples/C/req_all.c
@@ -100,7 +100,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/time_var.c
+++ b/examples/C/time_var.c
@@ -107,7 +107,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/transpose.c
+++ b/examples/C/transpose.c
@@ -81,7 +81,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/transpose2D.c
+++ b/examples/C/transpose2D.c
@@ -102,7 +102,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/vard_int.c
+++ b/examples/C/vard_int.c
@@ -92,7 +92,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/examples/C/vard_mvars.c
+++ b/examples/C/vard_mvars.c
@@ -130,7 +130,7 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
             printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
                    sum_size);
     }
-    else {
+    else if (err != NC_ENOTENABLED) {
         printf("Error at %s:%d: %s\n", __FILE__,__LINE__,ncmpi_strerror(err));
         nerrs++;
     }

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -11,7 +11,7 @@ This is essentially a placeholder for the next release note ...
 * New Limitations
   + When building with NetCDF-4 feature, using NetCDF-4 library built with
     PnetCDF enabled, i.e. --enable-pnetcdf, is not supported. See
-    [Issue #33](https://github.com/Parallel-NetCDF/PnetCDF/issues/33)
+    [Issue #33](https://github.com/Parallel-NetCDF/PnetCDF/issues/33).
 
 * Update configure options
   + none
@@ -53,7 +53,9 @@ This is essentially a placeholder for the next release note ...
   + none
 
 * Bug fixes
-  + none
+  + Fix error checking for programs in examples/C to ignore NC_ENOTENABLED
+    if PnetCDF was not built with --enable-profiling. Thanks to Bruno Pagani
+    and see [Issue #34](https://github.com/Parallel-NetCDF/PnetCDF/issues/34).
 
 * New example programs
   + none


### PR DESCRIPTION
Fix test programs that call `ncmpi_inq_malloc_max_size()` but PnetCDF was not built with --enable-profiling to ignore `NC_ENOTENABLED`.