### PR TITLE
Sort lead pending queue based on var begin

### DIFF
--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -7,9 +7,9 @@ This is essentially a placeholder for the next release note ...
 
 * New optimization
   + When inserting nonblocking requests into pending queues, keep the queues
-    sorted (insert sort) in the increasing order of variable IDs. This can
-    avoid a sorting (quick sort) when flushing the pending requests. See
-    [pull request #36](https://github.com/Parallel-NetCDF/PnetCDF/pull/36).
+    sorted (insert sort) in the increasing order of variable starting file
+    offsets. This can avoid a sorting (quick sort) when flushing the pending
+    requests. See [pull request #37](https://github.com/Parallel-NetCDF/PnetCDF/pull/37).
 
 * New Limitations
   + When building with NetCDF-4 feature, using NetCDF-4 library built with

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -8,7 +8,8 @@ This is essentially a placeholder for the next release note ...
 * New optimization
   + When inserting nonblocking requests into pending queues, keep the queues
     sorted (insert sort) in the increasing order of variable IDs. This can
-    avoid a sorting (quick sort) when flushing the pending requests.
+    avoid a sorting (quick sort) when flushing the pending requests. See
+    [pull request #36](https://github.com/Parallel-NetCDF/PnetCDF/pull/36).
 
 * New Limitations
   + When building with NetCDF-4 feature, using NetCDF-4 library built with

--- a/src/dispatchers/file.c
+++ b/src/dispatchers/file.c
@@ -1280,6 +1280,7 @@ ncmpi_inq_unlimdim(int  ncid,
 
 /*----< ncmpi_inq_path() >---------------------------------------------------*/
 /* Get the file pathname which was used to open/create the ncid's file.
+ * pathlen and path must already be allocated. Ignored if NULL.
  * This is an independent subroutine.
  */
 int
@@ -1300,14 +1301,13 @@ ncmpi_inq_path(int   ncid,
                                   NULL, NULL, NULL, NULL, NULL, NULL,
                                   NULL, NULL, NULL, NULL, NULL);
 #endif
-    /* Get the file pathname which was used to open/create the ncid's file.
-     * path must already be allocated. Ignored if NULL */
-    if (pncp->path == NULL) {
-        if (pathlen != NULL) *pathlen = 0;
-        if (path    != NULL) *path = '\0';
-    } else {
-        if (pathlen != NULL) *pathlen = (int)strlen(pncp->path);
-        if (path    != NULL) strcpy(path, pncp->path);
+    if (pathlen != NULL) {
+        if (pncp->path == NULL) *pathlen = 0;
+        else                    *pathlen = (int)strlen(pncp->path);
+    }
+    if (path != NULL) {
+        if (pncp->path == NULL) *path = '\0';
+        else                    strcpy(path, pncp->path);
     }
     return NC_NOERR;
 }

--- a/src/drivers/ncmpio/ncmpio_file_misc.c
+++ b/src/drivers/ncmpio/ncmpio_file_misc.c
@@ -308,12 +308,13 @@ ncmpio_inq_misc(void       *ncdp,
 
     /* Get the file pathname which was used to open/create the ncid's file.
      * path must already be allocated. Ignored if NULL */
-    if (ncp->path == NULL) {
-        if (pathlen != NULL) *pathlen = 0;
-        if (path    != NULL) *path = '\0';
-    } else {
-        if (pathlen != NULL) *pathlen = (int)strlen(ncp->path);
-        if (path    != NULL) strcpy(path, ncp->path);
+    if (pathlen != NULL) {
+        if (ncp->path == NULL) *pathlen = 0;
+        else                   *pathlen = (int)strlen(ncp->path);
+    }
+    if (path != NULL) {
+        if (ncp->path == NULL) *path = '\0';
+        else                   strcpy(path, ncp->path);
     }
 
     /* obtain the number of fixed-size variables */

--- a/src/drivers/ncmpio/ncmpio_i_getput.m4
+++ b/src/drivers/ncmpio/ncmpio_i_getput.m4
@@ -310,13 +310,13 @@ ncmpio_igetput_varm(NC               *ncp,
             ncp->put_list = (NC_req*) NCI_Realloc(ncp->put_list, req_alloc);
         }
 
-#define SORT_LEAD_LIST_BASED_ON_VARID
-#ifdef SORT_LEAD_LIST_BASED_ON_VARID
+#define SORT_LEAD_LIST_BASED_ON_VAR_BEGIN
+#ifdef SORT_LEAD_LIST_BASED_ON_VAR_BEGIN
         /* add the new request to put_lead_list and keep put_lead_list sorted,
-         * in an increasing order of variable IDs
+         * in an increasing order of variable begin offsets
          */
         for (i=ncp->numLeadPutReqs-1; i>=0; i--) {
-            if (ncp->put_lead_list[i].varp->varid <= varp->varid)
+            if (ncp->put_lead_list[i].varp->begin <= varp->begin)
                 break;
             /* make space for new lead request */
             ncp->put_lead_list[i+1] = ncp->put_lead_list[i];
@@ -391,7 +391,7 @@ ncmpio_igetput_varm(NC               *ncp,
          * in an increasing order of variable IDs
          */
         for (i=ncp->numLeadGetReqs-1; i>=0; i--) {
-            if (ncp->get_lead_list[i].varp->varid <= varp->varid)
+            if (ncp->get_lead_list[i].varp->begin <= varp->begin)
                 break;
             /* make space for new lead request */
             ncp->get_lead_list[i+1] = ncp->get_lead_list[i];

--- a/src/drivers/ncmpio/ncmpio_i_varn.m4
+++ b/src/drivers/ncmpio/ncmpio_i_varn.m4
@@ -250,13 +250,13 @@ igetput_varn(NC                *ncp,
             ncp->put_list = (NC_req*) NCI_Realloc(ncp->put_list, req_alloc);
         }
 
-#define SORT_LEAD_LIST_BASED_ON_VARID
-#ifdef SORT_LEAD_LIST_BASED_ON_VARID
+#define SORT_LEAD_LIST_BASED_ON_VAR_BEGIN
+#ifdef SORT_LEAD_LIST_BASED_ON_VAR_BEGIN
         /* add the new request to put_lead_list and keep put_lead_list sorted,
-         * in an increasing order of variable IDs
+         * in an increasing order of variable begin offsets
          */
         for (i=ncp->numLeadPutReqs-1; i>=0; i--) {
-            if (ncp->put_lead_list[i].varp->varid <= varp->varid)
+            if (ncp->put_lead_list[i].varp->begin <= varp->begin)
                 break;
             /* make space for new lead request */
             ncp->put_lead_list[i+1] = ncp->put_lead_list[i];
@@ -364,12 +364,12 @@ igetput_varn(NC                *ncp,
             ncp->get_list = (NC_req*) NCI_Realloc(ncp->get_list, req_alloc);
         }
 
-#ifdef SORT_LEAD_LIST_BASED_ON_VARID
+#ifdef SORT_LEAD_LIST_BASED_ON_VAR_BEGIN
         /* add the new request to get_lead_list and keep get_lead_list sorted,
-         * in an increasing order of variable IDs
+         * in an increasing order of variable begin offsets
          */
         for (i=ncp->numLeadGetReqs-1; i>=0; i--) {
-            if (ncp->get_lead_list[i].varp->varid <= varp->varid)
+            if (ncp->get_lead_list[i].varp->begin <= varp->begin)
                 break;
             /* make space for new lead request */
             ncp->get_lead_list[i+1] = ncp->get_lead_list[i];


### PR DESCRIPTION
In #36, the lead pending nonblocking request queues are sorted in an increasing order of variable IDs. This PR changes the sorting order to be based on variable beginning file offsets. Variable IDs are generated based on the order of variable definition. Fixed-size and record variables may be defined in an arbitrary order. In netCDF file layout, fixed-size variables are always stored before record variables. Thus, sorting based on the variable's begin offsets make better sense.