### PR TITLE
Bug fix ncmpidiff when comparing dimension names of 2 variables

### DIFF
--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -67,6 +67,8 @@ This is essentially a placeholder for the next release note ...
     `--enable-null-byte-header-padding`.
 
 * Bug fixes
+  + Fix ncmpidiff when comparing dimension names of 2 variables between files
+    whose dimension define orders are different.
   + Fix error checking for programs in examples/C to ignore NC_ENOTENABLED
     if PnetCDF was not built with --enable-profiling. Thanks to Bruno Pagani
     and see [Issue #34](https://github.com/Parallel-NetCDF/PnetCDF/issues/34).

--- a/src/utils/ncmpidiff/ncmpidiff.c
+++ b/src/utils/ncmpidiff/ncmpidiff.c
@@ -495,7 +495,7 @@ int main(int argc, char **argv)
                     /* get dim name for each dim ID */
                     err = ncmpi_inq_dim(ncid1, dimids1[j], dimname1, &dimlen1);
                     HANDLE_ERROR
-                    err = ncmpi_inq_dim(ncid1, dimids2[j], dimname2, &dimlen2);
+                    err = ncmpi_inq_dim(ncid2, dimids2[j], dimname2, &dimlen2);
                     HANDLE_ERROR
                     if (verbose)
                         printf("\tdimension %d:\n",j);


### PR DESCRIPTION
The bug happens when the dimension define orders are different in 2 files under comparison, but all other metadata contents are the same.