### PR TITLE
Fix nc4 ldflags

### DIFF
--- a/benchmarks/C/Makefile.am
+++ b/benchmarks/C/Makefile.am
@@ -9,8 +9,8 @@
 SUFFIXES = .o .c
 
 AM_CPPFLAGS = -I$(top_builddir)/src/include
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-LDADD += $(top_builddir)/src/libs/libpnetcdf.la
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la
+LDADD  += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 check_PROGRAMS = aggregation \
                  write_block_read_column

--- a/configure.ac
+++ b/configure.ac
@@ -1568,7 +1568,7 @@ if test "x$enable_netcdf4" = "xyes" ; then
    # Validate netcdf library
    saved_LDFLAGS=$LDFLAGS
    saved_LIBS=$LIBS
-   LDFLAGS="-L$netcdf_libdir $LDFLAGS"
+   LDFLAGS="-L$netcdf_libs $LDFLAGS"
    AC_SEARCH_LIBS([nc_open], [netcdf], [], [AC_MSG_ERROR([Cannot find nc_open in NetCDF-4 library])])
    LDFLAGS=$saved_LDFLAGS
    LIBS=$saved_LIBS

--- a/examples/C/Makefile.am
+++ b/examples/C/Makefile.am
@@ -9,8 +9,8 @@
 SUFFIXES = .o .c
 AM_DEFAULT_SOURCE_EXT = .c
 AM_CPPFLAGS = -I$(top_builddir)/src/include
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-LDADD += $(top_builddir)/src/libs/libpnetcdf.la
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la
+LDADD  += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 check_PROGRAMS = collective_write \
                  nonblocking_write \

--- a/examples/CXX/Makefile.am
+++ b/examples/CXX/Makefile.am
@@ -11,7 +11,7 @@ SUFFIXES = .cpp .o
 AM_DEFAULT_SOURCE_EXT = .cpp
 
 AM_CPPFLAGS = -I$(top_builddir)/src/binding/cxx -I$(top_builddir)/src/include
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la
 LDADD += ${top_builddir}/src/libs/libpnetcdf.la
 
 check_PROGRAMS = collective_write \

--- a/examples/F77/Makefile.am
+++ b/examples/F77/Makefile.am
@@ -10,7 +10,7 @@ SUFFIXES = .o .f .F90
 
 AM_DEFAULT_SOURCE_EXT = .f
 AM_FFLAGS = -I$(top_builddir)/src/binding/f77
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la
 LDADD += ${top_builddir}/src/libs/libpnetcdf.la utils.o
 
 if SIZEOF_MPI_AINT_IS_4

--- a/examples/F90/Makefile.am
+++ b/examples/F90/Makefile.am
@@ -11,7 +11,7 @@ SUFFIXES = .o .f .F90 .f90
 
 AM_DEFAULT_SOURCE_EXT = .f90
 AM_FCFLAGS = ${FC_MODINC}$(top_builddir)/src/binding/f90
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la
 LDADD += ${top_builddir}/src/libs/libpnetcdf.la utils.o
 
 check_PROGRAMS = nonblocking_write \

--- a/examples/burst_buffer/Makefile.am
+++ b/examples/burst_buffer/Makefile.am
@@ -9,8 +9,8 @@
 SUFFIXES = .o .c
 AM_DEFAULT_SOURCE_EXT = .c
 AM_CPPFLAGS = -I$(top_builddir)/src/include
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-LDADD += $(top_builddir)/src/libs/libpnetcdf.la
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la
+LDADD  += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 check_PROGRAMS = create_open \
                  nonblocking

--- a/examples/tutorial/Makefile.am
+++ b/examples/tutorial/Makefile.am
@@ -13,7 +13,7 @@ AM_CPPFLAGS = -I$(top_builddir)/src/include
 
 AM_FFLAGS = -I$(top_builddir)/src/binding/f77
 AM_FCFLAGS = $(FC_MODINC)$(top_builddir)/src/binding/f90
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la
 LDADD += ${top_builddir}/src/libs/libpnetcdf.la
 
 check_PROGRAMS = pnetcdf-write-from-master \

--- a/src/utils/ncmpidiff/Makefile.am
+++ b/src/utils/ncmpidiff/Makefile.am
@@ -11,8 +11,8 @@ AM_CPPFLAGS += -I$(top_builddir)/src/include
 
 bin_PROGRAMS = ncmpidiff
 ncmpidiff_SOURCES = ncmpidiff.c
-ncmpidiff_LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-ncmpidiff_LDADD += $(top_builddir)/src/libs/libpnetcdf.la
+ncmpidiff_LDADD = $(top_builddir)/src/libs/libpnetcdf.la
+ncmpidiff_LDADD  += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 $(top_builddir)/src/libs/libpnetcdf.la:
 	set -e; cd $(top_builddir)/src/libs && $(MAKE) $(MFLAGS)

--- a/src/utils/ncmpidump/Makefile.am
+++ b/src/utils/ncmpidump/Makefile.am
@@ -13,8 +13,8 @@ NCGEN = ../ncmpigen/ncmpigen
 
 bin_PROGRAMS = ncmpidump
 ncmpidump_SOURCES = ncmpidump.c vardata.c dumplib.c
-ncmpidump_LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-ncmpidump_LDADD += $(top_builddir)/src/libs/libpnetcdf.la
+ncmpidump_LDADD = $(top_builddir)/src/libs/libpnetcdf.la
+ncmpidump_LDADD  += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 $(top_builddir)/src/libs/libpnetcdf.la:
 	set -e; cd $(top_builddir)/src/libs && $(MAKE) $(MFLAGS)

--- a/src/utils/ncmpigen/Makefile.am
+++ b/src/utils/ncmpigen/Makefile.am
@@ -15,8 +15,8 @@ AM_CPPFLAGS += -I$(top_builddir)/src/drivers/ncmpio
 
 bin_PROGRAMS = ncmpigen
 ncmpigen_SOURCES = main.c load.c escapes.c getfill.c init.c genlib.c ncmpigentab.c
-ncmpigen_LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-ncmpigen_LDADD += $(top_builddir)/src/libs/libpnetcdf.la
+ncmpigen_LDADD = $(top_builddir)/src/libs/libpnetcdf.la
+ncmpigen_LDADD  += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 $(top_builddir)/src/libs/libpnetcdf.la:
 	set -e; cd $(top_builddir)/src/libs && $(MAKE) $(MFLAGS)

--- a/src/utils/ncmpilogdump/Makefile.am
+++ b/src/utils/ncmpilogdump/Makefile.am
@@ -12,8 +12,8 @@ AM_CPPFLAGS += -I$(top_builddir)/src/include
 noinst_bindir =
 noinst_bin_PROGRAMS = ncmpilogdump
 nodist_ncmpilogdump_SOURCES = ncmpilogdump.c
-ncmpilogdump_LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-ncmpilogdump_LDADD += $(top_builddir)/src/libs/libpnetcdf.la
+ncmpilogdump_LDADD = $(top_builddir)/src/libs/libpnetcdf.la
+ncmpilogdump_LDADD  += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 M4_SRCS  = ncmpilogdump.m4
 

--- a/src/utils/ncvalidator/Makefile.am
+++ b/src/utils/ncvalidator/Makefile.am
@@ -22,8 +22,8 @@ dist_man_MANS = ncvalidator.1
 
 check_PROGRAMS = $(bin_PROGRAMS) tst_open
 
-tst_open_LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-tst_open_LDADD += $(top_builddir)/src/libs/libpnetcdf.la
+tst_open_LDADD = $(top_builddir)/src/libs/libpnetcdf.la
+tst_open_LDADD  += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 $(top_builddir)/src/libs/libpnetcdf.la:
 	set -e; cd $(top_builddir)/src/libs && $(MAKE) $(MFLAGS)

--- a/test/C/Makefile.am
+++ b/test/C/Makefile.am
@@ -14,8 +14,8 @@ AM_CPPFLAGS  = -I$(top_srcdir)/src/include
 AM_CPPFLAGS += -I$(srcdir)/../common
 AM_CPPFLAGS += -I$(top_builddir)/src/include
 
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-LDADD += $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
+LDADD  += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 if DECL_MPI_OFFSET
    AM_CPPFLAGS += -DHAVE_DECL_MPI_OFFSET

--- a/test/CXX/Makefile.am
+++ b/test/CXX/Makefile.am
@@ -15,8 +15,8 @@ AM_CPPFLAGS += -I$(top_builddir)/src/binding/cxx
 AM_CPPFLAGS += -I$(srcdir)/../common
 AM_CPPFLAGS += -I$(top_builddir)/src/include
 
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-LDADD += $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
+LDADD  += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 if DECL_MPI_OFFSET
    AM_CPPFLAGS += -DHAVE_DECL_MPI_OFFSET

--- a/test/F90/Makefile.am
+++ b/test/F90/Makefile.am
@@ -13,7 +13,7 @@ AM_DEFAULT_SOURCE_EXT = .f90
 AM_FCFLAGS = $(FC_MODINC)$(top_builddir)/src/binding/f90 \
              $(FC_MODINC)../common
 
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la
 LDADD += ${top_builddir}/src/libs/libpnetcdf.la ../common/libtestutils.la
 
 TESTPROGRAMS = tst_f90 \

--- a/test/burst_buffer/Makefile.am
+++ b/test/burst_buffer/Makefile.am
@@ -14,8 +14,8 @@ AM_CPPFLAGS  = -I$(srcdir)/../common
 AM_CPPFLAGS += -I$(top_srcdir)/src/include
 AM_CPPFLAGS += -I$(top_builddir)/src/include
 
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-LDADD += $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
+LDADD  += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 AM_CFLAGS =
 if IS_BIGENDIAN

--- a/test/cdf_format/Makefile.am
+++ b/test/cdf_format/Makefile.am
@@ -12,8 +12,8 @@ AM_CPPFLAGS  = -I$(top_srcdir)/src/include
 AM_CPPFLAGS += -I$(srcdir)/../common
 AM_CPPFLAGS += -I$(top_builddir)/src/include
 
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-LDADD += $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
+LDADD  += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 if DECL_MPI_OFFSET
    # Do not add to AM_CPPFLAGS, as it will also be used by Fortran programs

--- a/test/fandc/Makefile.am
+++ b/test/fandc/Makefile.am
@@ -16,7 +16,7 @@ AM_FFLAGS   = -I$(top_builddir)/src/binding/f77
 AM_FCFLAGS  = $(FC_MODINC)$(top_builddir)/src/binding/f90 \
               $(FC_MODINC)$(srcdir)/../common
 
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la
 LDADD += ${top_builddir}/src/libs/libpnetcdf.la ../common/libtestutils.la -lm
 
 if DECL_MPI_OFFSET

--- a/test/header/Makefile.am
+++ b/test/header/Makefile.am
@@ -12,8 +12,8 @@ AM_CPPFLAGS  = -I$(top_srcdir)/src/include
 AM_CPPFLAGS += -I$(srcdir)/../common
 AM_CPPFLAGS += -I$(top_builddir)/src/include
 
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-LDADD += $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
+LDADD  += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 if DECL_MPI_OFFSET
    # Do not add to AM_CPPFLAGS, as it will also be used by Fortran programs

--- a/test/largefile/Makefile.am
+++ b/test/largefile/Makefile.am
@@ -14,8 +14,8 @@ AM_CPPFLAGS  = -I$(srcdir)/../common
 AM_CPPFLAGS += -I$(top_srcdir)/src/include
 AM_CPPFLAGS += -I$(top_builddir)/src/include
 
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-LDADD += $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
+LDADD  += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 if IS_BIGENDIAN
    # Do not add to AM_CPPFLAGS, as it will also be used by Fortran programs

--- a/test/nc4/Makefile.am
+++ b/test/nc4/Makefile.am
@@ -15,7 +15,7 @@ AM_CPPFLAGS += -I$(srcdir)/../common
 AM_CPPFLAGS += -I$(top_builddir)/src/include
 AM_CPPFLAGS += @NETCDF4_INC@
 
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la
 LDADD += ${top_builddir}/src/libs/libpnetcdf.la ../common/libtestutils.la -lm
 
 if DECL_MPI_OFFSET

--- a/test/nc_test/Makefile.am
+++ b/test/nc_test/Makefile.am
@@ -14,8 +14,8 @@ AM_CPPFLAGS  = -I$(top_srcdir)/src/include
 AM_CPPFLAGS += -I$(srcdir)/../common
 AM_CPPFLAGS += -I$(top_builddir)/src/include
 
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-LDADD += $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la -lm
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la -lm
+LDADD  += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 if DECL_MPI_OFFSET
    AM_CPPFLAGS += -DHAVE_DECL_MPI_OFFSET

--- a/test/nf90_test/Makefile.am
+++ b/test/nf90_test/Makefile.am
@@ -19,7 +19,7 @@ AM_FCFLAGS  = $(FC_MODINC)$(top_builddir)/src/binding/f90 \
               $(FC_MODINC)../common
 AM_CFLAGS   =
 
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la
 LDADD += ${top_builddir}/src/libs/libpnetcdf.la ../common/libtestutils.la
 
 if RELAX_COORD_BOUND

--- a/test/nf_test/Makefile.am
+++ b/test/nf_test/Makefile.am
@@ -17,7 +17,7 @@ AM_CPPFLAGS  = -I$(top_builddir)/src/include \
 AM_CFLAGS =
 AM_FFLAGS =
 
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la
 LDADD += ${top_builddir}/src/libs/libpnetcdf.la ../common/libtestutils.la
 
 M4FLAGS += -I${top_srcdir}/m4

--- a/test/nonblocking/Makefile.am
+++ b/test/nonblocking/Makefile.am
@@ -19,7 +19,7 @@ AM_FCFLAGS  = $(FC_MODINC)$(top_builddir)/src/binding/f90 \
               $(FC_MODINC)$(srcdir)/../common
 AM_FFLAGS   = -I$(top_builddir)/src/binding/f77
 
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la
 LDADD += ${top_builddir}/src/libs/libpnetcdf.la ../common/libtestutils.la -lm
 
 if DECL_MPI_OFFSET

--- a/test/subfile/Makefile.am
+++ b/test/subfile/Makefile.am
@@ -14,8 +14,8 @@ AM_CPPFLAGS  = -I$(top_srcdir)/src/include
 AM_CPPFLAGS += -I$(srcdir)/../common
 AM_CPPFLAGS += -I$(top_builddir)/src/include
 
-LDADD  = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-LDADD += $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
+LDADD = $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
+LDADD  += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 if DECL_MPI_OFFSET
    # Do not add to AM_CPPFLAGS, as it will also be used by Fortran programs

--- a/test/testcases/Makefile.am
+++ b/test/testcases/Makefile.am
@@ -19,8 +19,8 @@ AM_FCFLAGS  = $(FC_MODINC)$(top_builddir)/src/binding/f90 \
               $(FC_MODINC)$(srcdir)/../common
 AM_FFLAGS   = -I$(top_builddir)/src/binding/f77
 
-LDADD       = @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
-LDADD      += ${top_builddir}/src/libs/libpnetcdf.la ../common/libtestutils.la -lm
+LDADD      = ${top_builddir}/src/libs/libpnetcdf.la ../common/libtestutils.la -lm
+LDADD      += @NETCDF4_LDFLAGS@ @NETCDF4_LIBS@
 
 if SIZEOF_MPI_AINT_IS_4
    AM_FFLAGS += $(FC_DEFINE)SIZEOF_MPI_AINT_IS_4


### PR DESCRIPTION
Fix nc_open not found issue due to HDF5 library path not included in nc-config --libdir
Fix undefined reference error due to misplaced nc4 ldflag.
