### PR TITLE
Bug caused by strict aliasing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,8 @@ script:
   # - if [[ "${TRAVIS_OS_NAME}" = "osx" ]] ; then make -s V=1 LIBTOOLFLAGS=--silent check ; fi
   # - make -s V=1 LIBTOOLFLAGS=--silent check
   # - make -s V=1 LIBTOOLFLAGS=--silent ptest
-  - make distcheck -s V=1 LIBTOOLFLAGS=--silent DISTCHECK_CONFIGURE_FLAGS="--silent --enable-profiling --enable-subfiling --enable-thread-safe --enable-burst_buffering --enable-shared pnc_ac_debug=yes"
+  - make distcheck -s V=1 LIBTOOLFLAGS=--silent DISTCHECK_CONFIGURE_FLAGS="--silent --enable-profiling --enable-subfiling --enable-thread-safe --enable-burst_buffering --enable-shared pnc_ac_debug=yes CFLAGS=-O3 CXXFLAGS=-O3 FCFLAGS=-O3 FFLAGS=-O3"
+
 
 after_success:
   - make -s distclean

--- a/src/drivers/common/ncx.m4
+++ b/src/drivers/common/ncx.m4
@@ -881,17 +881,25 @@ typedef long ix_int;
 static void
 get_ix_int(const void *xp, ix_int *ip)
 {
+#ifdef WORDS_BIGENDIAN
+    memcpy(ip, xp, 4);
+#else
     ix_int tmp;
     memcpy(&tmp, xp, 4);
     *ip = SWAP4(tmp);
+#endif
 }
 
 static void
 put_ix_int(void *xp, const ix_int *ip)
 {
+#ifdef WORDS_BIGENDIAN
+    memcpy(xp, ip, 4);
+#else
     ix_int xtmp, itmp = *ip;
     xtmp = SWAP4(itmp);
     memcpy(xp, &xtmp, 4);
+#endif
 }
 
 #if X_SIZEOF_INT != SIZEOF_INT
@@ -974,17 +982,25 @@ typedef ulong ix_uint;
 static void
 get_ix_uint(const void *xp, ix_uint *ip)
 {
+#ifdef WORDS_BIGENDIAN
+    memcpy(ip, xp, 4);
+#else
     ix_uint tmp;
     memcpy(&tmp, xp, 4);
     *ip = SWAP4(tmp);
+#endif
 }
 
 static void
 put_ix_uint(void *xp, const ix_uint *ip)
 {
+#ifdef WORDS_BIGENDIAN
+    memcpy(xp, ip, 4);
+#else
     ix_uint xtmp, itmp = *ip;
     xtmp = SWAP4(itmp);
     memcpy(xp, &xtmp, 4);
+#endif
 }
 
 #if X_SIZEOF_UINT != SIZEOF_UINT
@@ -1896,17 +1912,25 @@ typedef long ix_int64;
 static void
 get_ix_int64(const void *xp, ix_int64 *ip)
 {
+#ifdef WORDS_BIGENDIAN
+    memcpy(ip, xp, 8);
+#else
     ix_int64 tmp;
     memcpy(&tmp, xp, 8);
     *ip = SWAP8(tmp);
+#endif
 }
 
 static void
 put_ix_int64(void *xp, const ix_int64 *ip)
 {
+#ifdef WORDS_BIGENDIAN
+    memcpy(xp, ip, 8);
+#else
     ix_int64 xtmp, itmp = *ip;
     xtmp = SWAP8(itmp);
     memcpy(xp, &xtmp, 8);
+#endif
 }
 
 #if X_SIZEOF_INT64 != SIZEOF_LONGLONG
@@ -1960,17 +1984,25 @@ typedef ulong ix_uint64;
 static void
 get_ix_uint64(const void *xp, ix_uint64 *ip)
 {
+#ifdef WORDS_BIGENDIAN
+    memcpy(ip, xp, 8);
+#else
     ix_uint64 tmp;
     memcpy(&tmp, xp, 8);
     *ip = SWAP8(tmp);
+#endif
 }
 
 static void
 put_ix_uint64(void *xp, const ix_uint64 *ip)
 {
+#ifdef WORDS_BIGENDIAN
+    memcpy(xp, ip, 8);
+#else
     ix_uint64 xtmp, itmp = *ip;
     xtmp = SWAP8(itmp);
     memcpy(xp, &xtmp, 8);
+#endif
 }
 
 #if X_SIZEOF_UINT64 != SIZEOF_ULONGLONG
@@ -2020,9 +2052,13 @@ APIPrefix`x_put_size_t'(void **xpp, const size_t *ulp)
  * APIPrefix`x_put_uint32'()
  */
 {
+#ifdef WORDS_BIGENDIAN
+    memcpy(*xpp, ulp, 4);
+#else
     size_t xtmp, itmp = *ulp;
     xtmp = SWAP4(itmp);
     memcpy(*xpp, &xtmp, 4);
+#endif
 
     *xpp = (void *)((char *)(*xpp) + X_SIZEOF_SIZE_T);
     return NC_NOERR;
@@ -2039,9 +2075,13 @@ APIPrefix`x_get_size_t'(const void **xpp, size_t *ulp)
  * APIPrefix`x_get_uint32'()
  */
 {
+#ifdef WORDS_BIGENDIAN
+    memcpy(ulp, *xpp, 4);
+#else
     size_t tmp;
     memcpy(&tmp, *xpp, 4);
     *ulp = SWAP4(tmp);
+#endif
 
     *xpp = (const void *)((const char *)(*xpp) + X_SIZEOF_SIZE_T);
     return NC_NOERR;
@@ -2062,13 +2102,21 @@ APIPrefix`x_put_off_t'(void **xpp, const off_t *lp, size_t sizeof_off_t)
     assert(sizeof_off_t == 4 || sizeof_off_t == 8);
 
     if (sizeof_off_t == 4) {
+#ifdef WORDS_BIGENDIAN
+        memcpy(*xpp, lp, 4);
+#else
         int xtmp, itmp = *lp;
         xtmp = SWAP4(itmp);
         memcpy(*xpp, &xtmp, 4);
+#endif
     } else {
+#ifdef WORDS_BIGENDIAN
+        memcpy(*xpp, lp, 8);
+#else
         off_t xtmp, itmp = *lp;
         xtmp = SWAP8(itmp);
         memcpy(*xpp, &xtmp, 8);
+#endif
     }
     *xpp = (void *)((char *)(*xpp) + sizeof_off_t);
     return NC_NOERR;
@@ -2082,13 +2130,21 @@ APIPrefix`x_get_off_t'(const void **xpp, off_t *lp, size_t sizeof_off_t)
     assert(sizeof_off_t == 4 || sizeof_off_t == 8);
 
     if (sizeof_off_t == 4) {
+#ifdef WORDS_BIGENDIAN
+        memcpy(lp, *xpp, 4);
+#else
         int tmp;
         memcpy(&tmp, *xpp, 4);
         *lp = (off_t) SWAP4(tmp);
+#endif
     } else {
+#ifdef WORDS_BIGENDIAN
+        memcpy(lp, *xpp, 8);
+#else
         long long tmp;
         memcpy(&tmp, *xpp, 8);
         *lp = (off_t) SWAP8(tmp);
+#endif
     }
     *xpp = (const void *)((const char *)(*xpp) + sizeof_off_t);
     return NC_NOERR;

--- a/src/drivers/include/ncx_h.m4
+++ b/src/drivers/include/ncx_h.m4
@@ -68,7 +68,7 @@ dnl
  * If compiled with support for "large files", then
  * netcdf will use a 64 bit off_t and it can then write a file
  * using 64 bit offsets.
- *  see also X_SIZE_MAX, X_OFF_MAX below
+ *  see also X_SIZE_T_MAX, X_OFF_MAX below
  */
 /* #define X_SIZEOF_OFF_T	(sizeof(off_t)) */
 #define X_SIZEOF_OFF_T		SIZEOF_OFF_T
@@ -105,7 +105,7 @@ dnl
 #define X_DOUBLE_MIN	(-X_DOUBLE_MAX)
 #define X_DBL_MAX	X_DOUBLE_MAX	/* alias compatible with limits.h */
 
-#define X_SIZE_MAX	X_UINT_MAX
+#define X_SIZE_T_MAX	X_UINT_MAX
 #define X_OFF_MAX	X_INT_MAX
 
 

--- a/test/cdf_format/test_inq_format.c
+++ b/test/cdf_format/test_inq_format.c
@@ -15,7 +15,7 @@
 #include <testutils.h>
 
 int main(int argc, char **argv) {
-    char dir_name[256], filename[256];
+    char dir_name[256], filename[512];
     int err, rank, nerrs=0, format, ncid;
 
     MPI_Init(&argc, &argv);

--- a/test/cdf_format/tst_corrupt.c
+++ b/test/cdf_format/tst_corrupt.c
@@ -61,7 +61,7 @@ int main(int argc, char** argv) {
     char *bad_dimid[3] ={"bad_dimid.nc1",  "bad_dimid.nc2",  "bad_dimid.nc5"};
     char *bad_nattrs[3]={"bad_nattrs.nc1", "bad_nattrs.nc2", "bad_nattrs.nc5"};
 
-    char filename[512], dirname[512];
+    char filename[1024], dirname[512];
     int i, rank, err, ncid, nerrs=0;
 
     MPI_Init(&argc, &argv);

--- a/test/nc_test/test_put.m4
+++ b/test/nc_test/test_put.m4
@@ -339,8 +339,23 @@ check_atts_$1(int ncid, int numGatts, int numVars)
                 IF (err != NC_NOERR)
                     EXPECT_ERR(NC_NOERR, err)
             } else {
-                IF (err != NC_NOERR && err != NC_ERANGE)
+                IF (err != NC_NOERR && err != NC_ERANGE) {
                     EXPECT_ERR(NC_NOERR or NC_ERANGE, err)
+                    if (verbose) {
+                        error("\n expect NC_NOERR or NC_ERANGE, err ");
+                        error("varid: %d, ", i);
+                        error("att_name: %s, ", ATT_NAME(i,j));
+                        error("att_type: %s, ", s_nc_type(ATT_TYPE(i,j)));
+                        error("num elements: %d, ", length);
+                        error("nInExtRange: %d, ", nInExtRange);
+                        error("nInIntRange: %d, ", nInIntRange);
+                        for (k = 0; k < length; k++) {
+                            error("element number: %d ", k);
+                            error("expect: %g, ", expect[k]);
+                            error("got: %g ", (double) value[k]);
+                        }
+                    }
+                }
             }
             for (k = 0; k < length; k++) {
                 if (CheckNumRange($1, expect[k], datatype)) {
@@ -363,7 +378,7 @@ check_atts_$1(int ncid, int numGatts, int numVars)
                             error("att_type: %s, ", s_nc_type(ATT_TYPE(i,j)));
                             error("element number: %d ", k);
                             error("expect: %g, ", expect[k]);
-                            error("got: %g", (double) value[k]);
+                            error("got: %g ", (double) value[k]);
                         }
                     } else {
                         nok++;

--- a/test/nonblocking/mcoll_perf.c
+++ b/test/nonblocking/mcoll_perf.c
@@ -99,7 +99,7 @@ int ncmpi_diff(char *filename1, char *filename2)
     int i, j, err, rank, nprocs, nerrs=0;
     int ncid1, ndims1, nvars1, natts1, unlimdimid1, *dimids1;
     int ncid2, ndims2, nvars2, natts2, unlimdimid2, *dimids2;
-    char str[512], name1[NC_MAX_NAME], name2[NC_MAX_NAME], name[NC_MAX_NAME];
+    char str[1024], name1[NC_MAX_NAME], name2[NC_MAX_NAME], name[NC_MAX_NAME];
     MPI_Offset *shape, *start;
     MPI_Offset varsize, attlen1, dimlen1, attlen2, dimlen2;
     nc_type type1, type2;
@@ -304,8 +304,8 @@ int main(int argc, char **argv)
     int array_of_psizes[3];
     int err, nerrs=0;
     MPI_Offset array_of_starts[3], stride[3];
-    char fbasename[256], filename[256];
-    char filename1[256], filename2[256], filename3[256];
+    char fbasename[256], filename[512];
+    char filename1[512], filename2[512], filename3[512];
     char dimname[20], varname[20];
     int ncid, dimids0[3], dimids1[3], rank_dim[3], *varid;
     MPI_Info info;


### PR DESCRIPTION
The solution is to use memcpy() instead of directly byte-swapping
on the buffer pointed by a pointer. This PR solves the issue #55.