### PR TITLE
Bug fix: when using MPI whose Fortran feature was disabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -112,6 +112,8 @@ AC_SUBST(PACKAGE_VERSION)
 AC_SUBST(CONFIGURE_ARGS_CLEAN)
 
 dnl autoheader only adds these templates to the first invocation of AC_CONFIG_HEADERS
+AH_TEMPLATE([ENABLE_FORTRAN],           [Define if to enable Fortran feature])
+AH_TEMPLATE([ENABLE_CXX],               [Define if to enable C++ feature])
 AH_TEMPLATE([NCBYTE_T],                 [Type of NC_BYTE])
 AH_TEMPLATE([NCSHORT_T],                [Type of NC_SHORT])
 AH_TEMPLATE([NF_DOUBLEPRECISION_IS_C_], [C type for Fortran double])
@@ -525,6 +527,14 @@ if test "x${has_mpicxx}" = xyes ; then
       fi
    fi
 fi
+if test "x${has_mpicxx}" = xyes ; then
+   ENABLE_CXX=1
+   AC_DEFINE(ENABLE_CXX)
+else
+   ENABLE_CXX=0
+fi
+AC_SUBST(ENABLE_CXX)
+
 AC_SUBST(has_mpicxx)dnl for src/utils/pnetcdf-config.in
 UD_MSG_DEBUG(has_mpicxx=$has_mpicxx)
 AM_CONDITIONAL(HAS_MPICXX, [test x$has_mpicxx = xyes])
@@ -758,6 +768,14 @@ if test "x${has_fortran}" = xyes ; then
       AC_SUBST(USE_MPIF_HEADER)
    fi
 fi
+if test "x${has_fortran}" = xyes ; then
+   ENABLE_FORTRAN=1
+   AC_DEFINE(ENABLE_FORTRAN)
+else
+   ENABLE_FORTRAN=0
+fi
+AC_SUBST(ENABLE_FORTRAN)
+
 AC_SUBST(has_fortran)dnl for src/utils/pnetcdf-config.in
 AM_CONDITIONAL(HAS_FORTRAN, [test x$has_fortran = xyes])
 AM_CONDITIONAL(HAVE_MPI_MOD, [test x$mpi_mod = xyes])

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -51,7 +51,15 @@ This is essentially a placeholder for the next release note ...
   + none
 
 * Bug fixes
-  + none
+  + When using an MPI compiler whose Fortran feature was disabled, the MPI
+    Fortran constants and datatypes may not be defined in the header file
+    mpi.h. This is the case for OpenMPI (tested with 4.0.2). PnetCDF used some
+    Fortran datatypes without checking whether they are defined, which can fail
+    at 'make' time. A fix has been added that checks whether the Fortran
+    feature is disabled and wraps around the Fortran datatypes with 'ifdef
+    ENABLE_FORTRAN' directive. Thanks Bert Wesarg for reporting this bug.
+    See issue [#68](https://github.com/Parallel-NetCDF/PnetCDF/issues/68) and
+    pull request [#69](https://github.com/Parallel-NetCDF/PnetCDF/pull/69).
 
 * New example programs
   + none

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -51,7 +51,7 @@ This is essentially a placeholder for the next release note ...
   + none
 
 * Bug fixes
-  + When using an MPI compiler whose Fortran feature was disabled, the MPI
+  + When using an MPI implementation whose Fortran feature was disabled, the MPI
     Fortran constants and datatypes may not be defined in the header file
     mpi.h. This is the case for Open MPI (tested with 4.0.2). PnetCDF used some
     Fortran datatypes without checking whether they are defined, which can fail

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -53,7 +53,7 @@ This is essentially a placeholder for the next release note ...
 * Bug fixes
   + When using an MPI compiler whose Fortran feature was disabled, the MPI
     Fortran constants and datatypes may not be defined in the header file
-    mpi.h. This is the case for OpenMPI (tested with 4.0.2). PnetCDF used some
+    mpi.h. This is the case for Open MPI (tested with 4.0.2). PnetCDF used some
     Fortran datatypes without checking whether they are defined, which can fail
     at 'make' time. A fix has been added that checks whether the Fortran
     feature is disabled and wraps around the Fortran datatypes with 'ifdef
@@ -84,4 +84,3 @@ This is essentially a placeholder for the next release note ...
 
 * Clarifications
   + none
-

--- a/src/drivers/common/dtype_decode.c
+++ b/src/drivers/common/dtype_decode.c
@@ -34,8 +34,10 @@ static MPI_Datatype
 dtype_filter(MPI_Datatype type)
 {
     /* char types */
-    if (type == MPI_CHARACTER)
+#if defined(ENABLE_FORTRAN) && (ENABLE_FORTRAN == 1)
+    if (type == MPI_CHARACTER) /* a Fortran datatype */
         return  MPI_CHAR;
+#endif
     if (type == MPI_CHAR)
         return  MPI_CHAR;
 
@@ -47,15 +49,19 @@ dtype_filter(MPI_Datatype type)
     if (type == MPI_SIGNED_CHAR)
         return  MPI_SIGNED_CHAR;
 
-    if (type == MPI_INTEGER1)
+#if defined(ENABLE_FORTRAN) && (ENABLE_FORTRAN == 1)
+    if (type == MPI_INTEGER1) /* a Fortran datatype */
         return  MPI_SIGNED_CHAR;
+#endif
     if (type == MPI_BYTE)
         return  MPI_BYTE;
 
     /* 2-byte integer types (only supported if MPI_SHORT is 2-bytes). */
 #if (SIZEOF_SHORT == 2)
-    if (type == MPI_INTEGER2)
+#if defined(ENABLE_FORTRAN) && (ENABLE_FORTRAN == 1)
+    if (type == MPI_INTEGER2) /* a Fortran datatype */
         return  MPI_SHORT;
+#endif
     if (type == MPI_SHORT)
         return  MPI_SHORT;
 
@@ -86,10 +92,12 @@ dtype_filter(MPI_Datatype type)
 #endif
 #endif
 
-    if (type == MPI_INTEGER)
+#if defined(ENABLE_FORTRAN) && (ENABLE_FORTRAN == 1)
+    if (type == MPI_INTEGER) /* a Fortran datatype */
         return int_4byte;
-    if (type == MPI_INTEGER4)
+    if (type == MPI_INTEGER4) /* a Fortran datatype */
         return int_4byte;
+#endif
 #if (SIZEOF_LONG == 4)
     if (type == MPI_LONG)
         return int_4byte;
@@ -113,12 +121,14 @@ dtype_filter(MPI_Datatype type)
       * is 8-bytes).
       */
 #if (SIZEOF_INT == 8) || (SIZEOF_LONG == 8)
-    if (type == MPI_INTEGER8)
+  #if defined(ENABLE_FORTRAN) && (ENABLE_FORTRAN == 1)
+    if (type == MPI_INTEGER8) /* a Fortran datatype */
       #if (SIZEOF_INT == 8)
         return MPI_INT;
       #else
         return MPI_LONG;
       #endif
+  #endif
 
   #if (SIZEOF_INT == 8)
     if (type == MPI_INT)
@@ -143,18 +153,22 @@ dtype_filter(MPI_Datatype type)
 #endif
 
     /* 4-byte float types (we assume float is 4-bytes). */
-    if (type == MPI_REAL)
+#if defined(ENABLE_FORTRAN) && (ENABLE_FORTRAN == 1)
+    if (type == MPI_REAL) /* a Fortran datatype */
         return  MPI_FLOAT;
-    if (type == MPI_REAL4)
+    if (type == MPI_REAL4) /* a Fortran datatype */
         return  MPI_FLOAT;
+#endif
     if (type == MPI_FLOAT)
         return  MPI_FLOAT;
 
     /* 8-byte float types (we assume double is 8-bytes). */
-    if (type == MPI_REAL8)
+#if defined(ENABLE_FORTRAN) && (ENABLE_FORTRAN == 1)
+    if (type == MPI_REAL8) /* a Fortran datatype */
         return MPI_DOUBLE;
-    if (type == MPI_DOUBLE_PRECISION)
+    if (type == MPI_DOUBLE_PRECISION) /* a Fortran datatype */
         return  MPI_DOUBLE;
+#endif
     if (type == MPI_DOUBLE)
         return  MPI_DOUBLE;
 

--- a/src/include/pnetcdf.h.in
+++ b/src/include/pnetcdf.h.in
@@ -21,6 +21,8 @@
 /* List of PnetCDF features enabled/disabled at configure time.
  * 0: disabled, 1: enabled, -1: auto
  */
+#define PNETCDF_ENABLE_FORTRAN           @ENABLE_FORTRAN@
+#define PNETCDF_ENABLE_CXX               @ENABLE_CXX@
 #define PNETCDF_ERANGE_FILL              @ENABLE_ERANGE_FILL@
 #define PNETCDF_SUBFILING                @ENABLE_SUBFILING@
 #define PNETCDF_RELAX_COORD_BOUND        @RELAX_COORD_BOUND@
@@ -31,6 +33,7 @@
 #define PNETCDF_BURST_BUFFERING          @ENABLE_BURST_BUFFER@
 #define PNETCDF_THREAD_SAFE              @ENABLE_THREAD_SAFE@
 #define PNETCDF_DRIVER_NETCDF4           @ENABLE_NETCDF4@
+#define PNETCDF_DRIVER_ADIOS             @ENABLE_ADIOS@
 
 #if defined(__cplusplus)
 extern "C" {


### PR DESCRIPTION
Check if PnetCDF's Fortran feature is disabled and avoid to use the MPI Fortran datatypes.
This PR fixes issue #68 