### PR TITLE
Add Fortran fix/free form flags

### DIFF
--- a/benchmarks/FLASH-IO/Makefile.am
+++ b/benchmarks/FLASH-IO/Makefile.am
@@ -15,7 +15,7 @@ FC = $(MPIF90)
 flash_benchmark_io_LDADD = -lpnetcdf
 
 if BUILD_BENCHMARKS_IN_PNETCDF
-   AM_FCFLAGS = $(FC_MODINC)${top_builddir}/src/binding/f90
+   AM_FCFLAGS = $(FC_MODINC)${top_builddir}/src/binding/f90 $(FFREEFORMFLAG)
    AM_LDFLAGS = -L${top_builddir}/src/libs
    flash_benchmark_io_LDADD += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@
 else

--- a/examples/F77/Makefile.am
+++ b/examples/F77/Makefile.am
@@ -9,7 +9,7 @@
 SUFFIXES = .o .f .F90
 
 AM_DEFAULT_SOURCE_EXT = .f
-AM_FFLAGS = -I$(top_builddir)/src/binding/f77
+AM_FFLAGS = -I$(top_builddir)/src/binding/f77 $(FFIXEDFORMFLAG)
 LDADD  = ${top_builddir}/src/libs/libpnetcdf.la utils.o
 LDADD += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@
 

--- a/examples/F90/Makefile.am
+++ b/examples/F90/Makefile.am
@@ -10,7 +10,7 @@
 SUFFIXES = .o .f .F90 .f90
 
 AM_DEFAULT_SOURCE_EXT = .f90
-AM_FCFLAGS = ${FC_MODINC}$(top_builddir)/src/binding/f90
+AM_FCFLAGS = ${FC_MODINC}$(top_builddir)/src/binding/f90 $(FFREEFORMFLAG)
 LDADD  = ${top_builddir}/src/libs/libpnetcdf.la utils.o
 LDADD += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@
 

--- a/examples/tutorial/Makefile.am
+++ b/examples/tutorial/Makefile.am
@@ -11,8 +11,8 @@ SUFFIXES = .o .c .f .f90 .F90
 AM_DEFAULT_SOURCE_EXT = .c
 AM_CPPFLAGS = -I$(top_builddir)/src/include
 
-AM_FFLAGS = -I$(top_builddir)/src/binding/f77
-AM_FCFLAGS = $(FC_MODINC)$(top_builddir)/src/binding/f90
+AM_FFLAGS = -I$(top_builddir)/src/binding/f77 $(FFIXEDFORMFLAG)
+AM_FCFLAGS = $(FC_MODINC)$(top_builddir)/src/binding/f90 $(FFREEFORMFLAG)
 LDADD  = ${top_builddir}/src/libs/libpnetcdf.la
 LDADD += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@
 

--- a/test/F90/Makefile.am
+++ b/test/F90/Makefile.am
@@ -11,7 +11,7 @@ SUFFIXES = .o .f90
 AM_DEFAULT_SOURCE_EXT = .f90
 
 AM_FCFLAGS = $(FC_MODINC)$(top_builddir)/src/binding/f90 \
-             $(FC_MODINC)../common
+             $(FC_MODINC)../common $(FFREEFORMFLAG)
 
 LDADD  = $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
 LDADD += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@

--- a/test/fandc/Makefile.am
+++ b/test/fandc/Makefile.am
@@ -31,15 +31,17 @@ TESTPROGRAMS = pnctest \
                csnap
 
 if HAS_FORTRAN
-TESTPROGRAMS += pnf_test pnctestf fixedform
-pnf_test_SOURCES = pnf_test.f
-pnctestf_SOURCES = pnctestf.f
-fixedform_SOURCES = fixedform.f90
-fixedform_FCFLAGS = $(FFIXEDFORMFLAG) $(FC_MODINC)$(top_builddir)/src/binding/f90 $(FC_MODINC)$(srcdir)/../common -I$(top_builddir)/src/binding/f77
+   TESTPROGRAMS += pnf_test pnctestf fixedform
+   pnf_test_SOURCES = pnf_test.f
+   pnf_test_FFLAGS = $(FFIXEDFORMFLAG) $(AM_FFLAGS)
+   pnctestf_SOURCES = pnctestf.f
+   pnctestf_FFLAGS = $(FFIXEDFORMFLAG) $(AM_FFLAGS)
+   fixedform_SOURCES = fixedform.f90
+   fixedform_FCFLAGS = $(FFIXEDFORMFLAG) $(AM_FCFLAGS) $(AM_FFLAGS)
 if HAVE_F77_SUPPORT_FREEFORM
-TESTPROGRAMS += freeform
-freeform_SOURCES = freeform.f
-freeform_FFLAGS = $(FFREEFORMFLAG) -I$(top_builddir)/src/binding/f77
+   TESTPROGRAMS += freeform
+   freeform_SOURCES = freeform.f
+   freeform_FFLAGS = $(FFREEFORMFLAG) $(AM_FFLAGS)
 endif
 endif
 

--- a/test/largefile/Makefile.am
+++ b/test/largefile/Makefile.am
@@ -34,12 +34,12 @@ TESTPROGRAMS = large_files \
 if HAS_FORTRAN
    TESTPROGRAMS += bigrecords
    bigrecords_SOURCES = bigrecords.f
-   AM_FFLAGS = -I$(top_builddir)/src/binding/f77
+   AM_FFLAGS = -I$(top_builddir)/src/binding/f77 $(FFIXEDFORMFLAG)
 if HAVE_MPI_MOD
    TESTPROGRAMS += tst_flarge
    tst_flarge_SOURCES = tst_flarge.f90
    AM_FCFLAGS = $(FC_MODINC)$(top_builddir)/src/binding/f90 \
-                $(FC_MODINC)../common
+                $(FC_MODINC)../common $(FFREEFORMFLAG)
 endif
 endif
 

--- a/test/nf90_test/Makefile.am
+++ b/test/nf90_test/Makefile.am
@@ -16,7 +16,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/src/include \
               -I$(top_builddir)/src/binding/f77
 
 AM_FCFLAGS  = $(FC_MODINC)$(top_builddir)/src/binding/f90 \
-              $(FC_MODINC)../common
+              $(FC_MODINC)../common $(FFREEFORMFLAG)
 AM_CFLAGS   =
 
 LDADD  = $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la

--- a/test/nf_test/Makefile.am
+++ b/test/nf_test/Makefile.am
@@ -15,7 +15,7 @@ AM_CPPFLAGS  = -I$(top_builddir)/src/include \
                -I$(top_builddir)/src/binding/f77 \
                -I$(top_srcdir)/src/binding/f77
 AM_CFLAGS =
-AM_FFLAGS =
+AM_FFLAGS = $(FFIXEDFORMFLAG)
 
 LDADD  = $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
 LDADD += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@

--- a/test/nonblocking/Makefile.am
+++ b/test/nonblocking/Makefile.am
@@ -16,8 +16,8 @@ AM_CPPFLAGS = -I$(top_srcdir)/src/include \
               -I$(top_builddir)/src/binding/f77
 
 AM_FCFLAGS  = $(FC_MODINC)$(top_builddir)/src/binding/f90 \
-              $(FC_MODINC)$(srcdir)/../common
-AM_FFLAGS   = -I$(top_builddir)/src/binding/f77
+              $(FC_MODINC)$(srcdir)/../common $(FFREEFORMFLAG)
+AM_FFLAGS   = -I$(top_builddir)/src/binding/f77 $(FFIXEDFORMFLAG)
 
 LDADD  = ${top_builddir}/src/libs/libpnetcdf.la ../common/libtestutils.la
 LDADD += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@ -lm

--- a/test/testcases/Makefile.am
+++ b/test/testcases/Makefile.am
@@ -16,8 +16,8 @@ AM_CPPFLAGS = -I$(top_srcdir)/src/include \
               -I$(top_builddir)/src/binding/f77
 
 AM_FCFLAGS  = $(FC_MODINC)$(top_builddir)/src/binding/f90 \
-              $(FC_MODINC)$(srcdir)/../common
-AM_FFLAGS   = -I$(top_builddir)/src/binding/f77
+              $(FC_MODINC)$(srcdir)/../common $(FFREEFORMFLAG)
+AM_FFLAGS   = -I$(top_builddir)/src/binding/f77 $(FFIXEDFORMFLAG)
 
 LDADD       = ${top_builddir}/src/libs/libpnetcdf.la ../common/libtestutils.la
 LDADD      += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@ -lm


### PR DESCRIPTION
IBM XLF compiler on Summit at OLCF requires -qfixed compile flag when
compiling Fortran programs written in fixed form. This PR adds the fixed
form flag detected at configure time to AM_FFLAGS when compiling fixed
form programs. Similarly, it added the free form flag to AM_FCFLAGS when
compiling free form programs.