### PR TITLE
Check file system type prefix against the ones known to ROMIO

### DIFF
--- a/src/dispatchers/file.c
+++ b/src/dispatchers/file.c
@@ -1185,13 +1185,12 @@ ncmpi_inq_file_format(const char *filename,
 
     *formatp = NC_FORMAT_UNKNOWN;
 
-    /* remove the file system type prefix name if there is any.
-     * For example, when filename = "lustre:/home/foo/testfile.nc", remove
-     * "lustre:" to make path = "/home/foo/testfile.nc" in open() below
+    /* remove the file system type prefix name if there is any.  For example,
+     * when filename = "lustre:/home/foo/testfile.nc", remove "lustre:" to make
+     * path pointing to "/home/foo/testfile.nc", so it can be used in POSIX
+     * open() below
      */
-    path = strchr(filename, ':');
-    if (path == NULL) path = filename; /* no prefix */
-    else              path++;
+    path = ncmpii_remove_file_system_type_prefix(filename);
 
     /* must include config.h on 32-bit machines, as AC_SYS_LARGEFILE is called
      * at the configure time and it defines _FILE_OFFSET_BITS to 64 if large

--- a/src/drivers/include/common.h
+++ b/src/drivers/include/common.h
@@ -242,5 +242,7 @@ extern char *strdup(const char *s);
 extern int strcasecmp(const char *s1, const char *s2);
 #endif
 
+char* ncmpii_remove_file_system_type_prefix(const char *filename);
+
 #endif
 

--- a/src/drivers/nc4io/nc4io_file.c
+++ b/src/drivers/nc4io/nc4io_file.c
@@ -61,13 +61,12 @@ nc4io_create(MPI_Comm     comm,
     int err, ncidtmp;
     NC_nc4 *nc4p;
 
-    /* remove the file system type prefix name if there is any.
-     * For example, path=="lustre:/home/foo/testfile.nc",
-     * use "/home/foo/testfile.nc" when calling nc_create_par()
+    /* remove the file system type prefix name if there is any.  For example,
+     * when path = "lustre:/home/foo/testfile.nc", remove "lustre:" to make
+     * filename pointing to "/home/foo/testfile.nc", so it can be used in
+     * nc_create_par() below
      */
-    filename = strchr(path, ':');
-    if (filename == NULL) filename = (char*)path; /* no prefix */
-    else                  filename++;
+    filename = ncmpii_remove_file_system_type_prefix(path);
 
     /* add NC_MPIIO in case NetCDF 4.6.1 and earlier is used.
      * NC_MPIIO is ignored in 4.6.2 and after.
@@ -120,13 +119,12 @@ nc4io_open(MPI_Comm     comm,
     int err, ncidtmp;
     NC_nc4 *nc4p;
 
-    /* remove the file system type prefix name if there is any.
-     * For example, path=="lustre:/home/foo/testfile.nc",
-     * use "/home/foo/testfile.nc" when calling nc_open_par()
+    /* remove the file system type prefix name if there is any.  For example,
+     * when path = "lustre:/home/foo/testfile.nc", remove "lustre:" to make
+     * filename pointing to "/home/foo/testfile.nc", so it can be used in
+     * nc_open_par() below
      */
-    filename = strchr(path, ':');
-    if (filename == NULL) filename = (char*)path; /* no prefix */
-    else                  filename++;
+    filename = ncmpii_remove_file_system_type_prefix(path);
 
     /* add NC_MPIIO in case NetCDF 4.6.1 and earlier is used.
      * NC_MPIIO is ignored in 4.6.2 and after.

--- a/src/drivers/ncbbio/ncbbio_log.c
+++ b/src/drivers/ncbbio/ncbbio_log.c
@@ -73,29 +73,17 @@ int ncbbio_log_create(NC_bb* ncbbp,
 
     /* Read environment variable for burst buffer path */
 
-    /* Remove romio driver specifier form the beginning of path */
-    path = strchr(ncbbp->path, ':');
-    if (path == NULL) {
-        /* No driver specifier, use full path */
-        path = ncbbp->path;
-    }
-    else {
-        /* Skip until after the first ':' */
-        path += 1;
-    }
+    /* remove the file system type prefix name if there is any.  For example,
+     * when ncbbp->path = "lustre:/home/foo/testfile.nc", remove "lustre:" to
+     * make path pointing to "/home/foo/testfile.nc", so it can be used in
+     * POSIX realpath() below
+     */
+    path = ncmpii_remove_file_system_type_prefix(ncbbp->path);
 
     /* Determine log base */
     if (ncbbp->logbase[0] != '\0') {
-        /* We don't need driver specifier in logbase as well */
-        logbasep = strchr(ncbbp->logbase, ':');
-        if (logbasep == NULL) {
-            /* No driver specifier, use full path */
-            logbasep = ncbbp->logbase;
-        }
-        else {
-            /* Skip until after the first ':' */
-            logbasep += 1;
-        }
+        /* remove the file system type prefix name if there is any */
+        logbasep = ncmpii_remove_file_system_type_prefix(ncbbp->logbase);
     }
     else {
         i = strlen(path);

--- a/src/drivers/ncmpio/ncmpio_create.c
+++ b/src/drivers/ncmpio/ncmpio_create.c
@@ -70,12 +70,11 @@ ncmpio_create(MPI_Comm     comm,
     mpiomode = MPI_MODE_RDWR | MPI_MODE_CREATE;
 
     /* remove the file system type prefix name if there is any.  For example,
-     * path=="lustre:/home/foo/testfile.nc", use "/home/foo/testfile.nc" when
-     * calling access()
+     * when path = "lustre:/home/foo/testfile.nc", remove "lustre:" to make
+     * filename pointing to "/home/foo/testfile.nc", so it can be used in POSIX
+     * access() below
      */
-    filename = strchr(path, ':');
-    if (filename == NULL) filename = (char*)path; /* no prefix */
-    else                  filename++;
+    filename = ncmpii_remove_file_system_type_prefix(path);
 
 #ifdef HAVE_ACCESS
     /* if access() is available, use it to check whether file already exists

--- a/test/common/testutils.c
+++ b/test/common/testutils.c
@@ -7,7 +7,7 @@
 
 #include <stdio.h>
 #include <limits.h>
-#include <string.h>
+#include <string.h> /* strchr(), strerror(), strdup(), strcpy(), strlen() */
 #include <mpi.h>
 
 #include <pnetcdf.h>
@@ -253,5 +253,40 @@ inq_env_hint(char *hint_key, char **hint_value)
         free(env_str_cpy);
     }
     return 0;
+}
+
+/* File system types recognized by ROMIO in MPICH 4.0.0 */
+static const char* fstypes[] = {"ufs", "nfs", "xfs", "pvfs2", "gpfs", "panfs", "lustre", "daos", "testfs", "ime", "quobyte", NULL};
+
+/* Return a pointer to filename by removing the file system type prefix name if
+ * there is any.  For example, when filename = "lustre:/home/foo/testfile.nc",
+ * remove "lustre:" to return a pointer to "/home/foo/testfile.nc", so the name
+ * can be used in POSIX open() calls.
+ */
+char* remove_file_system_type_prefix(const char *filename)
+{
+    char *prefix, *colon, *ret_filename;
+
+    if (filename == NULL) return NULL;
+
+    ret_filename = (char*)filename;
+    prefix = strdup(filename);
+
+    colon = strchr(prefix, ':');
+    if (colon != NULL) { /* there is a prefix end with : */
+        int i=0;
+        *colon = '\0';
+        /* check if prefix is one of recognized file system types */
+        while (fstypes[i] != NULL) {
+            if (!strcmp(prefix, fstypes[i])) { /* found */
+                ret_filename += colon - prefix + 1;
+                break;
+            }
+            i++;
+        }
+    }
+    free(prefix);
+
+    return ret_filename;
 }
 

--- a/test/common/testutils.h
+++ b/test/common/testutils.h
@@ -68,4 +68,6 @@ extern char *strdup(const char *s);
 extern int strcasecmp(const char *s1, const char *s2);
 #endif
 
+char* remove_file_system_type_prefix(const char *filename);
+
 #endif

--- a/test/nc4/rd_compressed.c
+++ b/test/nc4/rd_compressed.c
@@ -88,13 +88,12 @@ int main(int argc, char **argv) {
 
     /* rank 0 creates a NETCDF4 file */
     if (rank == 0) {
-        /* remove the file system type prefix name if there is any.
-         * For example, when filename = "lustre:/home/foo/testfile.nc", remove
-         * "lustre:" to make path = "/home/foo/testfile.nc" in open() below
+        /* remove the file system type prefix name if there is any.  For example,
+         * when filename = "lustre:/home/foo/testfile.nc", remove "lustre:" to make
+         * path pointing to "/home/foo/testfile.nc", so it can be used in
+         * create_nc4() below
          */
-        char *path = strchr(filename, ':');
-        if (path == NULL) path = filename; /* no prefix */
-        else              path++;
+        char *path = remove_file_system_type_prefix(filename);
 
         err = create_nc4(path);
         if (err) {

--- a/test/nc_test/test_write.m4
+++ b/test/nc_test/test_write.m4
@@ -2723,13 +2723,12 @@ APIFunc(get_file_version)(char *filename, int *version)
    if (!version || !filename)
       return NC_EINVAL;
 
-    /* remove the file system type prefix name if there is any.
-     * For example, when filename = "lustre:/home/foo/testfile.nc", remove
-     * "lustre:" to make path = "/home/foo/testfile.nc" in open() below
-     */
-    path = strchr(filename, ':');
-    if (path == NULL) path = filename; /* no prefix */
-    else              path++;
+   /* remove the file system type prefix name if there is any.  For example,
+    * when filename = "lustre:/home/foo/testfile.nc", remove "lustre:" to make
+    * path pointing to "/home/foo/testfile.nc", so it can be used in POSIX
+    * open() below
+    */
+   path = remove_file_system_type_prefix(filename);
 
    /* Figure out if this is a netcdf or hdf5 file. */
    fd = open(path, O_RDONLY, 0600);

--- a/test/nc_test/tst_misc.c
+++ b/test/nc_test/tst_misc.c
@@ -48,13 +48,12 @@ main(int argc, char **argv)
     if (rank == 0) printf("%-66s ------ ", cmd_str);
     free(cmd_str);
 
-    /* remove the file system type prefix name if there is any.
-     * For example, when filename = "lustre:/home/foo/testfile.nc", remove
-     * "lustre:" to make path = "/home/foo/testfile.nc" in open() below
+    /* remove the file system type prefix name if there is any.  For example,
+     * when filename = "lustre:/home/foo/testfile.nc", remove "lustre:" to make
+     * path pointing to "/home/foo/testfile.nc", so it can be used in POSIX
+     * fopen() below
      */
-    path = strchr(filename, ':');
-    if (path == NULL) path = filename; /* no prefix */
-    else              path++;
+    path = remove_file_system_type_prefix(filename);
 
 /*
    printf("\n*** Testing some extra stuff.\n");

--- a/test/testcases/erange_fill.m4
+++ b/test/testcases/erange_fill.m4
@@ -333,7 +333,7 @@ int main(int argc, char** argv) {
 
     if (rank == 0) {
         char *cmd_str = (char*)malloc(strlen(argv[0]) + 256);
-        sprintf(cmd_str, "*** TESTING C   %s for checking for type conflict ", basename(argv[0]));
+        sprintf(cmd_str, "*** TESTING C   %s for erange elements are filled ", basename(argv[0]));
         printf("%-66s ------ ", cmd_str); fflush(stdout);
         free(cmd_str);
     }

--- a/test/testcases/modes.c
+++ b/test/testcases/modes.c
@@ -41,13 +41,13 @@ int check_modes(char *filename)
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
     /* delete the file and ignore error */
-    /* remove the file system type prefix name if there is any.
-     * For example, when filename = "lustre:/home/foo/testfile.nc", remove
-     * "lustre:" to make path = "/home/foo/testfile.nc" in open() below
+
+    /* remove the file system type prefix name if there is any.  For example,
+     * when filename = "lustre:/home/foo/testfile.nc", remove "lustre:" to make
+     * path pointing to "/home/foo/testfile.nc", so it can be used in POSIX
+     * unlink() and access() below
      */
-    path = strchr(filename, ':');
-    if (path == NULL) path = filename; /* no prefix */
-    else              path++;
+    path = remove_file_system_type_prefix(filename);
 
     if (rank == 0) unlink(path);
     MPI_Barrier(MPI_COMM_WORLD);


### PR DESCRIPTION
In all prior versions, the file name was checked whether it contains
character ':'. The prefix name ending with ':' is considered by ROMIO as
the file system type name. The prefix name, if found, is then stripped, so
the file name can be used in the successive POSIX function calls. However,
the prefix was not checked against the file system type names recognized
by ROMIO. Starting from this release, the prefix is checked against the
known file system type names to ROMIO. If the prefix is not one of the
recognized types, then the prefix name is
not stripped. This change is for in case when the file name contains ':',
but it is not for specifying the file system type.

Currently (ROMIO in MPICH 4.0.1), the following file system types are defined:
* "ufs"
* "nfs"
* "xfs"
* "pvfs2"
* "gpfs"
* "panfs"
* "lustre"
* "daos"
* "testfs"
* "ime"
* "quobyte"

