### PR TITLE
support Fortran flexible APIs for bufcount = -1

### DIFF
--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -3,7 +3,16 @@ This is essentially a placeholder for the next release note ...
 ------------------------------------------------------------------------------
 
 * New features
-  + none
+  + Flexible APIs now can be used as high-level APIs, when argument bufcount
+    is -1 and buftype is an MPI predefined data type. For example,
+    ```
+    ncmpi_put_vara_all(ncid, varid, start, count, buf, -1, MPI_FLOAT);
+    ```
+    is equivalent to
+    ```
+    ncmpi_put_vara_float_all(ncid, varid, start, count, buf);
+    ```
+    See [PR #82](https://github.com/Parallel-NetCDF/PnetCDF/pull/82).
 
 * New optimization
   + none
@@ -61,7 +70,7 @@ This is essentially a placeholder for the next release note ...
     "lustre", "daos", "testfs", "ime", or "quobyte", then the prefix name is
     not stripped. This change is for in case when the file name contains ':',
     but it is not for specifying the file system type.
-    See [PR #79](https://github.com/Parallel-NetCDF/PnetCDF/pull/79)
+    See [PR #79](https://github.com/Parallel-NetCDF/PnetCDF/pull/79).
 
 * Bug fixes
   + none

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -74,6 +74,7 @@ This is essentially a placeholder for the next release note ...
 
 * New test program
   + test/testcases/flexible_var.c - test flexible var API
+  + test/testcases/flexible_api.f - test flexible API when bufcount == -1
 
 * Issues with NetCDF library
   + none

--- a/src/binding/f77/defs
+++ b/src/binding/f77/defs
@@ -332,12 +332,14 @@ $returnType   = "int";
 #		'get_att_uchar-3'	=> 'in:addnull',
 #		'get_att_uchar-4'	=> 'out:charBufferOut',
 
-	'get_var1' => '2:3',
+	'get_var1' => '2:3:6',
 		'get_var1-2'		=> 'in:IntIndexIn',
 		'get_var1-3'		=> 'in:reorderOffsetArr:1',
-	'get_var1_all' => '2:3',
+		'get_var1-6'		=> 'in:datatypeArr',
+	'get_var1_all' => '2:3:6',
 		'get_var1_all-2'	=> 'in:IntIndexIn',
 		'get_var1_all-3'	=> 'in:reorderOffsetArr:1',
+		'get_var1_all-6'	=> 'in:datatypeArr',
 	'get_var1_text' => '2:3:4',
 		'get_var1_text-2'	=> 'in:IntIndexIn',
 		'get_var1_text-4'	=> 'out:charBufferOut',
@@ -383,10 +385,12 @@ $returnType   = "int";
 		'get_var1_longlong_all-2'	=> 'in:IntIndexIn',
 		'get_var1_longlong_all-3'	=> 'in:reorderOffsetArr:1',
 
-	'get_var' => '2',
+	'get_var' => '2:5',
 		'get_var-2'		=> 'in:IntIndexIn',
-	'get_var_all' => '2',
+		'get_var-5'     	=> 'in:datatypeArr',
+	'get_var_all' => '2:5',
 		'get_var_all-2'		=> 'in:IntIndexIn',
+		'get_var_all-5' 	=> 'in:datatypeArr',
 	'get_var_text' => '2:3',
 		'get_var_text-2'	=> 'in:IntIndexIn',
 		'get_var_text-3'	=> 'out:charBufferOut',
@@ -418,14 +422,16 @@ $returnType   = "int";
 	'get_var_longlong_all' => '2',
 		'get_var_longlong_all-2'	=> 'in:IntIndexIn',
 
-	'get_vara' => '2:3:4',
+	'get_vara' => '2:3:4:7',
 		'get_vara-2'		=> 'in:IntIndexIn',
 		'get_vara-3'		=> 'in:reorderOffsetArr:2',
 		'get_vara-4'		=> 'in:reorderOffsetArr',
-	'get_vara_all' => '2:3:4',
+		'get_vara-7'    	=> 'in:datatypeArr',
+	'get_vara_all' => '2:3:4:7',
 		'get_vara_all-2'	=> 'in:IntIndexIn',
 		'get_vara_all-3'	=> 'in:reorderOffsetArr:2',
 		'get_vara_all-4'	=> 'in:reorderOffsetArr',
+		'get_vara_all-7' 	=> 'in:datatypeArr',
 	'get_vara_text' => '2:3:4:5',
 		'get_vara_text-2'	=> 'in:IntIndexIn',
 		'get_vara_text-3'	=> 'in:reorderOffsetArr:2',
@@ -485,16 +491,18 @@ $returnType   = "int";
 		'get_vara_longlong_all-3'	=> 'in:reorderOffsetArr:2',
 		'get_vara_longlong_all-4'	=> 'in:reorderOffsetArr',
 
-	'get_vars' => '2:3:4:5',
+	'get_vars' => '2:3:4:5:8',
 		'get_vars-2'		=> 'in:IntIndexIn',
 		'get_vars-3'		=> 'in:reorderOffsetArr:3',
 		'get_vars-4'		=> 'in:reorderOffsetArr',
 		'get_vars-5'		=> 'in:reorderOffsetArr',
-	'get_vars_all' => '2:3:4:5',
+		'get_vars-8'    	=> 'in:datatypeArr',
+	'get_vars_all' => '2:3:4:5:8',
 		'get_vars_all-2'	=> 'in:IntIndexIn',
 		'get_vars_all-3'	=> 'in:reorderOffsetArr:3',
 		'get_vars_all-4'	=> 'in:reorderOffsetArr',
 		'get_vars_all-5'	=> 'in:reorderOffsetArr',
+		'get_vars_all-8' 	=> 'in:datatypeArr',
 	'get_vars_text' => '2:3:4:5:6',
 		'get_vars_text-2'	=> 'in:IntIndexIn',
 		'get_vars_text-3'	=> 'in:reorderOffsetArr:3',
@@ -568,18 +576,20 @@ $returnType   = "int";
 		'get_vars_longlong_all-4'	=> 'in:reorderOffsetArr',
 		'get_vars_longlong_all-5'	=> 'in:reorderOffsetArr',
 
-	'get_varm' => '2:3:4:5:6',
+	'get_varm' => '2:3:4:5:6:9',
 		'get_varm-2'		=> 'in:IntIndexIn',
 		'get_varm-3'		=> 'in:reorderOffsetArr:4',
 		'get_varm-4'		=> 'in:reorderOffsetArr',
 		'get_varm-5'		=> 'in:reorderOffsetArr',
 		'get_varm-6'		=> 'in:reorderOffsetArr',
-	'get_varm_all' => '2:3:4:5:6',
+		'get_varm-9'    	=> 'in:datatypeArr',
+	'get_varm_all' => '2:3:4:5:6:9',
 		'get_varm_all-2'	=> 'in:IntIndexIn',
 		'get_varm_all-3'	=> 'in:reorderOffsetArr:4',
 		'get_varm_all-4'	=> 'in:reorderOffsetArr',
 		'get_varm_all-5'	=> 'in:reorderOffsetArr',
 		'get_varm_all-6'	=> 'in:reorderOffsetArr',
+		'get_varm_all-9' 	=> 'in:datatypeArr',
 	'get_varm_text' => '2:3:4:5:6:7',
 		'get_varm_text-2'	=> 'in:IntIndexIn',
 		'get_varm_text-3'	=> 'in:reorderOffsetArr:4',
@@ -805,12 +815,14 @@ $returnType   = "int";
 #		'put_att_uchar-3'	=> 'in:charBufferIn',
 #		'put_att_uchar-5'	=> 'in:intToOffset',
 
-	'put_var1' => '2:3',
+	'put_var1' => '2:3:6',
 		'put_var1-2'		=> 'in:IntIndexIn',
 		'put_var1-3'		=> 'in:reorderOffsetArr:1',
-	'put_var1_all' => '2:3',
+		'put_var1-6'    	=> 'in:datatypeArr',
+	'put_var1_all' => '2:3:6',
 		'put_var1_all-2'	=> 'in:IntIndexIn',
 		'put_var1_all-3'	=> 'in:reorderOffsetArr:1',
+		'put_var1_all-6' 	=> 'in:datatypeArr',
 	'put_var1_text' => '2:3:4',
 		'put_var1_text-2'	=> 'in:IntIndexIn',
 		'put_var1_text-3'	=> 'in:reorderOffsetArr:1',
@@ -856,6 +868,12 @@ $returnType   = "int";
 		'put_var1_longlong_all-2'	=> 'in:IntIndexIn',
 		'put_var1_longlong_all-3'	=> 'in:reorderOffsetArr:1',
 
+	'put_var' => '2:5',
+		'put_var-2'		=> 'in:IntIndexIn',
+		'put_var-5'     	=> 'in:datatypeArr',
+	'put_var_all' => '2:5',
+		'put_var_all-2'		=> 'in:IntIndexIn',
+		'put_var_all-5' 	=> 'in:datatypeArr',
 	'put_var_text' => '2:3',
 		'put_var_text-2'	=> 'in:IntIndexIn',
 		'put_var_text-3'	=> 'in:charBufferIn',
@@ -887,16 +905,16 @@ $returnType   = "int";
 	'put_var_longlong_all' => '2',
 		'put_var_longlong_all-2'	=> 'in:IntIndexIn',
 
-	'put_var' => '2',
-		'put_var-2'		=> 'in:IntIndexIn',
-	'put_vara' => '2:3:4',
+	'put_vara' => '2:3:4:7',
 		'put_vara-2'		=> 'in:IntIndexIn',
 		'put_vara-3'		=> 'in:reorderOffsetArr:2',
 		'put_vara-4'		=> 'in:reorderOffsetArr',
-	'put_vara_all' => '2:3:4',
+		'put_vara-7'     	=> 'in:datatypeArr',
+	'put_vara_all' => '2:3:4:7',
 		'put_vara_all-2'	=> 'in:IntIndexIn',
 		'put_vara_all-3'	=> 'in:reorderOffsetArr:2',
 		'put_vara_all-4'	=> 'in:reorderOffsetArr',
+		'put_vara_all-7' 	=> 'in:datatypeArr',
 	'put_vara_text' => '2:3:4:5',
 		'put_vara_text-2'	=> 'in:IntIndexIn',
 		'put_vara_text-3'	=> 'in:reorderOffsetArr:2',
@@ -956,16 +974,18 @@ $returnType   = "int";
 		'put_vara_longlong_all-3'	=> 'in:reorderOffsetArr:2',
 		'put_vara_longlong_all-4'	=> 'in:reorderOffsetArr',
 
-	'put_vars' => '2:3:4:5',
+	'put_vars' => '2:3:4:5:8',
 		'put_vars-2'		=> 'in:IntIndexIn',
 		'put_vars-3'		=> 'in:reorderOffsetArr:3',
 		'put_vars-4'		=> 'in:reorderOffsetArr',
 		'put_vars-5'		=> 'in:reorderOffsetArr',
-	'put_vars_all' => '2:3:4:5',
+		'put_vars-8'     	=> 'in:datatypeArr',
+	'put_vars_all' => '2:3:4:5:8',
 		'put_vars_all-2'	=> 'in:IntIndexIn',
 		'put_vars_all-3'	=> 'in:reorderOffsetArr:3',
 		'put_vars_all-4'	=> 'in:reorderOffsetArr',
 		'put_vars_all-5'	=> 'in:reorderOffsetArr',
+		'put_vars_all-8' 	=> 'in:datatypeArr',
 	'put_vars_text' => '2:3:4:5:6',
 		'put_vars_text-2'	=> 'in:IntIndexIn',
 		'put_vars_text-3'	=> 'in:reorderOffsetArr:3',
@@ -1039,18 +1059,20 @@ $returnType   = "int";
 		'put_vars_longlong_all-4'	=> 'in:reorderOffsetArr',
 		'put_vars_longlong_all-5'	=> 'in:reorderOffsetArr',
 
-	'put_varm' => '2:3:4:5:6',
+	'put_varm' => '2:3:4:5:6:9',
 		'put_varm-2'		=> 'in:IntIndexIn',
 		'put_varm-3'		=> 'in:reorderOffsetArr:4',
 		'put_varm-4'		=> 'in:reorderOffsetArr',
 		'put_varm-5'		=> 'in:reorderOffsetArr',
 		'put_varm-6'		=> 'in:reorderOffsetArr',
-	'put_varm_all' => '2:3:4:5:6',
+		'put_varm-9'     	=> 'in:datatypeArr',
+	'put_varm_all' => '2:3:4:5:6:9',
 		'put_varm_all-2'	=> 'in:IntIndexIn',
 		'put_varm_all-3'	=> 'in:reorderOffsetArr:4',
 		'put_varm_all-4'	=> 'in:reorderOffsetArr',
 		'put_varm_all-5'	=> 'in:reorderOffsetArr',
 		'put_varm_all-6'	=> 'in:reorderOffsetArr',
+		'put_varm_all-9' 	=> 'in:datatypeArr',
 	'put_varm_text' => '2:3:4:5:6:7',
 		'put_varm_text-2'	=> 'in:IntIndexIn',
 		'put_varm_text-3'	=> 'in:reorderOffsetArr:4',
@@ -1138,11 +1160,16 @@ $returnType   = "int";
 		'put_varm_longlong_all-5'	=> 'in:reorderOffsetArr',
 		'put_varm_longlong_all-6'	=> 'in:reorderOffsetArr',
 
-	'get_varn' => '2:4:5',
+	'get_varn' => '2:4:5:8',
 		'get_varn-2'		=> 'in:IntIndexIn',
 		'get_varn-4'		=> 'in:reorderOffsetArr1DTo2D:true',
-		'get_varn-4'		=> 'in:reorderOffsetArr1DTo2D:true',
 		'get_varn-5'		=> 'in:reorderOffsetArr1DTo2D',
+		'get_varn-8'     	=> 'in:datatypeArr',
+	'get_varn_all' => '2:4:5:8',
+		'get_varn_all-2'	=> 'in:IntIndexIn',
+		'get_varn_all-4'	=> 'in:reorderOffsetArr1DTo2D:true',
+		'get_varn_all-5'	=> 'in:reorderOffsetArr1DTo2D',
+		'get_varn_all-8'     	=> 'in:datatypeArr',
 	'get_varn_text' => '2:4:5:6',
 		'get_varn_text-2'	=> 'in:IntIndexIn',
 		'get_varn_text-4'	=> 'in:reorderOffsetArr1DTo2D:true',
@@ -1173,10 +1200,6 @@ $returnType   = "int";
 		'get_varn_longlong-4'	=> 'in:reorderOffsetArr1DTo2D:true',
 		'get_varn_longlong-5'	=> 'in:reorderOffsetArr1DTo2D',
 
-	'get_varn_all' => '2:4:5',
-		'get_varn_all-2'		=> 'in:IntIndexIn',
-		'get_varn_all-4'		=> 'in:reorderOffsetArr1DTo2D:true',
-		'get_varn_all-5'		=> 'in:reorderOffsetArr1DTo2D',
 	'get_varn_text_all' => '2:4:5:6',
 		'get_varn_text_all-2'		=> 'in:IntIndexIn',
 		'get_varn_text_all-4'		=> 'in:reorderOffsetArr1DTo2D:true',
@@ -1207,10 +1230,16 @@ $returnType   = "int";
 		'get_varn_longlong_all-4'	=> 'in:reorderOffsetArr1DTo2D:true',
 		'get_varn_longlong_all-5'	=> 'in:reorderOffsetArr1DTo2D',
 
-	'put_varn' => '2:4:5',
+	'put_varn' => '2:4:5:8',
 		'put_varn-2'		=> 'in:IntIndexIn',
 		'put_varn-4'		=> 'in:reorderOffsetArr1DTo2D:true',
 		'put_varn-5'		=> 'in:reorderOffsetArr1DTo2D',
+		'put_varn-8'     	=> 'in:datatypeArr',
+	'put_varn_all' => '2:4:5:8',
+		'put_varn_all-2'	=> 'in:IntIndexIn',
+		'put_varn_all-4'	=> 'in:reorderOffsetArr1DTo2D:true',
+		'put_varn_all-5'	=> 'in:reorderOffsetArr1DTo2D',
+		'put_varn_all-8'     	=> 'in:datatypeArr',
 	'put_varn_text' => '2:4:5:6',
 		'put_varn_text-2'	=> 'in:IntIndexIn',
 		'put_varn_text-4'	=> 'in:reorderOffsetArr1DTo2D:true',
@@ -1241,10 +1270,6 @@ $returnType   = "int";
 		'put_varn_longlong-4'	=> 'in:reorderOffsetArr1DTo2D:true',
 		'put_varn_longlong-5'	=> 'in:reorderOffsetArr1DTo2D',
 
-	'put_varn_all' => '2:4:5',
-		'put_varn_all-2'		=> 'in:IntIndexIn',
-		'put_varn_all-4'		=> 'in:reorderOffsetArr1DTo2D:true',
-		'put_varn_all-5'		=> 'in:reorderOffsetArr1DTo2D',
 	'put_varn_text_all' => '2:4:5:6',
 		'put_varn_text_all-2'		=> 'in:IntIndexIn',
 		'put_varn_text_all-4'		=> 'in:reorderOffsetArr1DTo2D:true',
@@ -1275,18 +1300,23 @@ $returnType   = "int";
 		'put_varn_longlong_all-4'	=> 'in:reorderOffsetArr1DTo2D:true',
 		'put_varn_longlong_all-5'	=> 'in:reorderOffsetArr1DTo2D',
 
-	'get_vard' => '2',
+	'get_vard' => '2:6',
 		'get_vard-2'		=> 'in:IntIndexIn',
-	'put_vard' => '2',
+		'get_vard-6'     	=> 'in:datatypeArr',
+	'put_vard' => '2:6',
 		'put_vard-2'		=> 'in:IntIndexIn',
-	'get_vard_all' => '2',
+		'put_vard-6'     	=> 'in:datatypeArr',
+	'get_vard_all' => '2:6',
 		'get_vard_all-2'	=> 'in:IntIndexIn',
-	'put_vard_all' => '2',
+		'get_vard_all-6'     	=> 'in:datatypeArr',
+	'put_vard_all' => '2:6',
 		'put_vard_all-2'	=> 'in:IntIndexIn',
+		'put_vard_all-6'     	=> 'in:datatypeArr',
 
-	'iget_var1' => '2:3:7',
+	'iget_var1' => '2:3:6:7',
 		'iget_var1-2'		=> 'in:IntIndexIn',
 		'iget_var1-3'		=> 'in:reorderOffsetArr:1',
+		'iget_var1-6'     	=> 'in:datatypeArr',
 		'iget_var1-7'		=> 'out:intToFint',
 	'iget_var1_text' => '2:3:4:5',
 		'iget_var1_text-2'	=> 'in:IntIndexIn',
@@ -1318,8 +1348,9 @@ $returnType   = "int";
 		'iget_var1_longlong-3'	=> 'in:reorderOffsetArr:1',
 		'iget_var1_longlong-5'	=> 'out:intToFint',
 
-	'iget_var' => '2:6',
+	'iget_var' => '2:5:6',
 		'iget_var-2'		=> 'in:IntIndexIn',
+		'iget_var-5'     	=> 'in:datatypeArr',
 		'iget_var-6'		=> 'out:intToFint',
 	'iget_var_text' => '2:3:4',
 		'iget_var_text-2'	=> 'in:IntIndexIn',
@@ -1344,10 +1375,11 @@ $returnType   = "int";
 		'iget_var_longlong-2'	=> 'in:IntIndexIn',
 		'iget_var_longlong-4'	=> 'out:intToFint',
 
-	'iget_vara' => '2:3:4:8',
+	'iget_vara' => '2:3:4:7:8',
 		'iget_vara-2'		=> 'in:IntIndexIn',
 		'iget_vara-3'		=> 'in:reorderOffsetArr:2',
 		'iget_vara-4'		=> 'in:reorderOffsetArr',
+		'iget_vara-7'     	=> 'in:datatypeArr',
 		'iget_vara-8',		=> 'out:intToFint',
 	'iget_vara_text' => '2:3:4:5:6',
 		'iget_vara_text-2'	=> 'in:IntIndexIn',
@@ -1386,11 +1418,12 @@ $returnType   = "int";
 		'iget_vara_longlong-4'	=> 'in:reorderOffsetArr',
 		'iget_vara_longlong-6'	=> 'out:intToFint',
 
-	'iget_vars' => '2:3:4:5:9',
+	'iget_vars' => '2:3:4:5:8:9',
 		'iget_vars-2'		=> 'in:IntIndexIn',
 		'iget_vars-3'		=> 'in:reorderOffsetArr:3',
 		'iget_vars-4'		=> 'in:reorderOffsetArr',
 		'iget_vars-5'		=> 'in:reorderOffsetArr',
+		'iget_vars-8'     	=> 'in:datatypeArr',
 		'iget_vars-9'		=> 'out:intToFint',
 	'iget_vars_text' => '2:3:4:5:6:7',
 		'iget_vars_text-2'	=> 'in:IntIndexIn',
@@ -1436,12 +1469,13 @@ $returnType   = "int";
 		'iget_vars_longlong-5'	=> 'in:reorderOffsetArr',
 		'iget_vars_longlong-7'	=> 'out:intToFint',
 
-	'iget_varm' => '2:3:4:5:6:10',
+	'iget_varm' => '2:3:4:5:6:9:10',
 		'iget_varm-2'		=> 'in:IntIndexIn',
 		'iget_varm-3'		=> 'in:reorderOffsetArr:4',
 		'iget_varm-4'		=> 'in:reorderOffsetArr',
 		'iget_varm-5'		=> 'in:reorderOffsetArr',
 		'iget_varm-6'		=> 'in:reorderOffsetArr',
+		'iget_varm-9'     	=> 'in:datatypeArr',
 		'iget_varm-10'		=> 'out:intToFint',
 	'iget_varm_text' => '2:3:4:5:6:7:8',
 		'iget_varm_text-2'	=> 'in:IntIndexIn',
@@ -1494,9 +1528,10 @@ $returnType   = "int";
 		'iget_varm_longlong-6'	=> 'in:reorderOffsetArr',
 		'iget_varm_longlong-8'	=> 'out:intToFint',
 
-	'iput_var1' => '2:3:7',
+	'iput_var1' => '2:3:6:7',
 		'iput_var1-2'		=> 'in:IntIndexIn',
 		'iput_var1-3'		=> 'in:reorderOffsetArr:1',
+		'iput_var1-6'     	=> 'in:datatypeArr',
 		'iput_var1-7'		=> 'out:intToFint',
 	'iput_var1_text' => '2:3:4:5',
 		'iput_var1_text-2'	=> 'in:IntIndexIn',
@@ -1528,8 +1563,9 @@ $returnType   = "int";
 		'iput_var1_longlong-3'	=> 'in:reorderOffsetArr:1',
 		'iput_var1_longlong-5'	=> 'out:intToFint',
 
-	'iput_var' => '2:6',
+	'iput_var' => '2:5:6',
 		'iput_var-2'		=> 'in:IntIndexIn',
+		'iput_var-5'     	=> 'in:datatypeArr',
 		'iput_var-6'		=> 'out:intToFint',
 	'iput_var_text' => '2:3:4',
 		'iput_var_text-2'	=> 'in:IntIndexIn',
@@ -1554,10 +1590,11 @@ $returnType   = "int";
 		'iput_var_longlong-2'	=> 'in:IntIndexIn',
 		'iput_var_longlong-4'	=> 'out:intToFint',
 
-	'iput_vara' => '2:3:4:8',
+	'iput_vara' => '2:3:4:7:8',
 		'iput_vara-2'		=> 'in:IntIndexIn',
 		'iput_vara-3'		=> 'in:reorderOffsetArr:2',
 		'iput_vara-4'		=> 'in:reorderOffsetArr',
+		'iput_vara-7'     	=> 'in:datatypeArr',
 		'iput_vara-8'		=> 'out:intToFint',
 	'iput_vara_text' => '2:3:4:5:6',
 		'iput_vara_text-2'	=> 'in:IntIndexIn',
@@ -1596,11 +1633,12 @@ $returnType   = "int";
 		'iput_vara_longlong-4'	=> 'in:reorderOffsetArr',
 		'iput_vara_longlong-6'	=> 'out:intToFint',
 
-	'iput_vars' => '2:3:4:5:9',
+	'iput_vars' => '2:3:4:5:8:9',
 		'iput_vars-2'		=> 'in:IntIndexIn',
 		'iput_vars-3'		=> 'in:reorderOffsetArr:3',
 		'iput_vars-4'		=> 'in:reorderOffsetArr',
 		'iput_vars-5'		=> 'in:reorderOffsetArr',
+		'iput_vars-8'     	=> 'in:datatypeArr',
 		'iput_vars-9'		=> 'out:intToFint',
 	'iput_vars_text' => '2:3:4:5:6:7',
 		'iput_vars_text-2'	=> 'in:IntIndexIn',
@@ -1646,12 +1684,13 @@ $returnType   = "int";
 		'iput_vars_longlong-5'	=> 'in:reorderOffsetArr',
 		'iput_vars_longlong-7'	=> 'out:intToFint',
 
-	'iput_varm' => '2:3:4:5:6:10',
+	'iput_varm' => '2:3:4:5:6:9:10',
 		'iput_varm-2'		=> 'in:IntIndexIn',
 		'iput_varm-3'		=> 'in:reorderOffsetArr:4',
 		'iput_varm-4'		=> 'in:reorderOffsetArr',
 		'iput_varm-5'		=> 'in:reorderOffsetArr',
 		'iput_varm-6'		=> 'in:reorderOffsetArr',
+		'iput_varm-9'     	=> 'in:datatypeArr',
 		'iput_varm-10'		=> 'out:intToFint',
 	'iput_varm_text' => '2:3:4:5:6:7:8',
 		'iput_varm_text-2'	=> 'in:IntIndexIn',
@@ -1704,10 +1743,11 @@ $returnType   = "int";
 		'iput_varm_longlong-6'	=> 'in:reorderOffsetArr',
 		'iput_varm_longlong-8'	=> 'out:intToFint',
 
-	'iget_varn' => '2:4:5:9',
+	'iget_varn' => '2:4:5:8:9',
 		'iget_varn-2'		=> 'in:IntIndexIn',
 		'iget_varn-4'		=> 'in:reorderOffsetArr1DTo2D:true',
 		'iget_varn-5'		=> 'in:reorderOffsetArr1DTo2D',
+		'iget_varn-8'     	=> 'in:datatypeArr',
 		'iget_varn-9'		=> 'out:intToFint',
 	'iget_varn_text' => '2:4:5:6:7',
 		'iget_varn_text-2'	=> 'in:IntIndexIn',
@@ -1746,10 +1786,11 @@ $returnType   = "int";
 		'iget_varn_longlong-5'	=> 'in:reorderOffsetArr1DTo2D',
 		'iget_varn_longlong-7'	=> 'out:intToFint',
 
-	'iput_varn' => '2:4:5:9',
+	'iput_varn' => '2:4:5:8:9',
 		'iput_varn-2'		=> 'in:IntIndexIn',
 		'iput_varn-4'		=> 'in:reorderOffsetArr1DTo2D:true',
 		'iput_varn-5'		=> 'in:reorderOffsetArr1DTo2D',
+		'iput_varn-8'     	=> 'in:datatypeArr',
 		'iput_varn-9'		=> 'out:intToFint',
 	'iput_varn_text' => '2:4:5:6:7',
 		'iput_varn_text-2'	=> 'in:IntIndexIn',
@@ -1788,10 +1829,11 @@ $returnType   = "int";
 		'iput_varn_longlong-5'	=> 'in:reorderOffsetArr1DTo2D',
 		'iput_varn_longlong-7'	=> 'out:intToFint',
 
-	'bput_varn' => '2:4:5:9',
+	'bput_varn' => '2:4:5:8:9',
 		'bput_varn-2'		=> 'in:IntIndexIn',
 		'bput_varn-4'		=> 'in:reorderOffsetArr1DTo2D:true',
 		'bput_varn-5'		=> 'in:reorderOffsetArr1DTo2D',
+		'bput_varn-8'     	=> 'in:datatypeArr',
 		'bput_varn-9'		=> 'out:intToFint',
 	'bput_varn_text' => '2:4:5:6:7',
 		'bput_varn_text-2'	=> 'in:IntIndexIn',
@@ -1830,9 +1872,10 @@ $returnType   = "int";
 		'bput_varn_longlong-5'	=> 'in:reorderOffsetArr1DTo2D',
 		'bput_varn_longlong-7'	=> 'out:intToFint',
 
-	'bput_var1' => '2:3:7',
+	'bput_var1' => '2:3:6:7',
 		'bput_var1-2'		=> 'in:IntIndexIn',
 		'bput_var1-3'		=> 'in:reorderOffsetArr:1',
+		'bput_var1-6'     	=> 'in:datatypeArr',
 		'bput_var1-7'		=> 'out:intToFint',
 	'bput_var1_text' => '2:3:4:5',
 		'bput_var1_text-2'	=> 'in:IntIndexIn',
@@ -1864,8 +1907,9 @@ $returnType   = "int";
 		'bput_var1_longlong-3'	=> 'in:reorderOffsetArr:1',
 		'bput_var1_longlong-5'	=> 'out:intToFint',
 
-	'bput_var' => '2:6',
+	'bput_var' => '2:5:6',
 		'bput_var-2'		=> 'in:IntIndexIn',
+		'bput_var-5'     	=> 'in:datatypeArr',
 		'bput_var-6'		=> 'out:intToFint',
 	'bput_var_text' => '2:3:4',
 		'bput_var_text-2'	=> 'in:IntIndexIn',
@@ -1890,10 +1934,11 @@ $returnType   = "int";
 		'bput_var_longlong-2'	=> 'in:IntIndexIn',
 		'bput_var_longlong-4'	=> 'out:intToFint',
 
-	'bput_vara' => '2:3:4:8',
+	'bput_vara' => '2:3:4:7:8',
 		'bput_vara-2'		=> 'in:IntIndexIn',
 		'bput_vara-3'		=> 'in:reorderOffsetArr:2',
 		'bput_vara-4'		=> 'in:reorderOffsetArr',
+		'bput_vara-7'     	=> 'in:datatypeArr',
 		'bput_vara-8'		=> 'out:intToFint',
 	'bput_vara_text' => '2:3:4:5:6',
 		'bput_vara_text-2'	=> 'in:IntIndexIn',
@@ -1932,11 +1977,12 @@ $returnType   = "int";
 		'bput_vara_longlong-4'	=> 'in:reorderOffsetArr',
 		'bput_vara_longlong-6'	=> 'out:intToFint',
 
-	'bput_vars' => '2:3:4:5:9',
+	'bput_vars' => '2:3:4:5:8:9',
 		'bput_vars-2'		=> 'in:IntIndexIn',
 		'bput_vars-3'		=> 'in:reorderOffsetArr:3',
 		'bput_vars-4'		=> 'in:reorderOffsetArr',
 		'bput_vars-5'		=> 'in:reorderOffsetArr',
+		'bput_vars-8'     	=> 'in:datatypeArr',
 		'bput_vars-9'		=> 'out:intToFint',
 	'bput_vars_text' => '2:3:4:5:6:7',
 		'bput_vars_text-2'	=> 'in:IntIndexIn',
@@ -1982,12 +2028,13 @@ $returnType   = "int";
 		'bput_vars_longlong-5'	=> 'in:reorderOffsetArr',
 		'bput_vars_longlong-7'	=> 'out:intToFint',
 
-	'bput_varm' => '2:3:4:5:6:10',
+	'bput_varm' => '2:3:4:5:6:9:10',
 		'bput_varm-2'		=> 'in:IntIndexIn',
 		'bput_varm-3'		=> 'in:reorderOffsetArr:4',
 		'bput_varm-4'		=> 'in:reorderOffsetArr',
 		'bput_varm-5'		=> 'in:reorderOffsetArr',
 		'bput_varm-6'		=> 'in:reorderOffsetArr',
+		'bput_varm-9'     	=> 'in:datatypeArr',
 		'bput_varm-10'		=> 'out:intToFint',
 	'bput_varm_text' => '2:3:4:5:6:7:8',
 		'bput_varm_text-2'	=> 'in:IntIndexIn',
@@ -2251,6 +2298,50 @@ sub intToFintArr_ctof {
     }
     $free($lname);
     \n";
+}
+
+# ---------------------------------------------------------------------------
+# F2C converts a Fortran MPI predefined datatype to a C datatype
+# usage is
+#    'get_var1-6'  => 'in:datatypeArr',
+#
+sub datatypeArr_in_decl {
+    my $count = $_[0];
+    print $OUTFD "    MPI_Datatype l$count=MPI_Type_f2c(*v$count);\n";
+}
+sub datatypeArr_out_decl {
+}
+sub datatypeArr_ftoc {
+    my $count = $_[0];
+    my $prev = $count - 1;
+    print $OUTFD "
+    if (l$count != MPI_DATATYPE_NULL && *v$prev == -1) {
+        /* When bufcount == -1, buftype must be a predefine MPI datatype.
+         * Convert Fortran MPI predefined datatype to C datatype.
+         */
+             if (l$count == MPI_CHARACTER)        l$count = MPI_CHAR;
+        else if (l$count == MPI_INTEGER1)         l$count = MPI_SIGNED_CHAR;
+        else if (l$count == MPI_INTEGER2)         l$count = MPI_SHORT;
+        else if (l$count == MPI_INTEGER)          l$count = MPI_INT;
+        else if (l$count == MPI_INTEGER4)         l$count = MPI_INT;
+        else if (l$count == MPI_INTEGER8)         l$count = MPI_LONG_LONG_INT;
+        else if (l$count == MPI_REAL)             l$count = MPI_FLOAT;
+        else if (l$count == MPI_DOUBLE_PRECISION) l$count = MPI_DOUBLE;
+        else
+            return NC_EINVAL; /* not supported memory datatype */
+    }\n";
+}
+sub datatypeArr_out_ftoc {
+}
+sub datatypeArr_in_arg {
+    my $count = $_[0];
+    print $OUTFD "l$count";
+}
+sub datatypeArr_out_arg {
+}
+sub datatypeArr_in_ctof {
+}
+sub datatypeArr_ctof {
 }
 
 # ---------------------------------------------------------------------------

--- a/src/dispatchers/var_getput.m4
+++ b/src/dispatchers/var_getput.m4
@@ -336,6 +336,19 @@ APINAME($1,$2,$3,$4)(int ncid,
         err = check_start_count_stride(pncp, varid, IS_READ($1), api_kind,
                                        IndexArgs($2));')
 
+    ifelse(`$3',`',`
+    /* when bufcount == -1, buftype must be an MPI predefined datatype */
+    if (err == NC_NOERR &&
+        buftype != MPI_DATATYPE_NULL && bufcount == -1 &&
+        buftype != MPI_CHAR          &&
+        buftype != MPI_SIGNED_CHAR   && buftype != MPI_UNSIGNED_CHAR      &&
+        buftype != MPI_SHORT         && buftype != MPI_UNSIGNED_SHORT     &&
+        buftype != MPI_INT           && buftype != MPI_UNSIGNED           &&
+        buftype != MPI_FLOAT         && buftype != MPI_DOUBLE             &&
+        buftype != MPI_LONG_LONG_INT && buftype != MPI_UNSIGNED_LONG_LONG &&
+        buftype != MPI_LONG)
+        err = NC_EINVAL;')
+
     ifelse(`$4',`',`/* for independent API, return now if error encountered */
     if (err != NC_NOERR) return err;
     ifelse(`$3',`',`
@@ -465,7 +478,20 @@ NAPINAME($1,$2,$3)(int                ncid,
                                            api, starts[i], count, NULL);
             if (err != NC_NOERR) break;
         }
+        if (err != NC_NOERR) goto err_check;
     }
+
+    ifelse(`$2',`',`
+    /* when bufcount == -1, buftype must be an MPI predefined datatype */
+    if (buftype != MPI_DATATYPE_NULL && bufcount == -1 &&
+        buftype != MPI_CHAR          &&
+        buftype != MPI_SIGNED_CHAR   && buftype != MPI_UNSIGNED_CHAR      &&
+        buftype != MPI_SHORT         && buftype != MPI_UNSIGNED_SHORT     &&
+        buftype != MPI_INT           && buftype != MPI_UNSIGNED           &&
+        buftype != MPI_FLOAT         && buftype != MPI_DOUBLE             &&
+        buftype != MPI_LONG_LONG_INT && buftype != MPI_UNSIGNED_LONG_LONG &&
+        buftype != MPI_LONG)
+        err = NC_EINVAL;')
 
 err_check:
     ifelse(`$3',`',`/* for independent API, return now if error encountered */
@@ -577,6 +603,19 @@ MAPINAME($1,$2,$3,$4)(int                ncid,
             err = check_start_count_stride(pncp, varids[i], IS_READ($1),
                                            api_kind, MStartCount($2), stride);
             if (err != NC_NOERR) break;
+        }')
+        ifelse(`$3',`',`
+        /* when bufcounts[i] == -1, buftypes[i] must be an MPI predefined datatype */
+        if (buftypes[i] != MPI_DATATYPE_NULL && bufcounts[i] == -1 &&
+            buftypes[i] != MPI_CHAR          &&
+            buftypes[i] != MPI_SIGNED_CHAR   && buftypes[i] != MPI_UNSIGNED_CHAR      &&
+            buftypes[i] != MPI_SHORT         && buftypes[i] != MPI_UNSIGNED_SHORT     &&
+            buftypes[i] != MPI_INT           && buftypes[i] != MPI_UNSIGNED           &&
+            buftypes[i] != MPI_FLOAT         && buftypes[i] != MPI_DOUBLE             &&
+            buftypes[i] != MPI_LONG_LONG_INT && buftypes[i] != MPI_UNSIGNED_LONG_LONG &&
+            buftypes[i] != MPI_LONG) {
+            err = NC_EINVAL;
+            break;
         }')
     }
 
@@ -695,6 +734,18 @@ IAPINAME($1,$2,$3)(int ncid,
 
     ifelse(`$3',`',`if (buftype != MPI_DATATYPE_NULL && bufcount == 0) return NC_NOERR;')
 
+    ifelse(`$3',`',`
+    /* when bufcount == -1, buftype must be an MPI predefined datatype */
+    if (buftype != MPI_DATATYPE_NULL && bufcount == -1 &&
+        buftype != MPI_CHAR          &&
+        buftype != MPI_SIGNED_CHAR   && buftype != MPI_UNSIGNED_CHAR      &&
+        buftype != MPI_SHORT         && buftype != MPI_UNSIGNED_SHORT     &&
+        buftype != MPI_INT           && buftype != MPI_UNSIGNED           &&
+        buftype != MPI_FLOAT         && buftype != MPI_DOUBLE             &&
+        buftype != MPI_LONG_LONG_INT && buftype != MPI_UNSIGNED_LONG_LONG &&
+        buftype != MPI_LONG)
+        return NC_EINVAL;')
+
     ifelse(`$1',`bput',`reqMode |= IO_MODE($1) | FLEX_MODE($3);',`
     reqMode = IO_MODE($1) | NB_MODE($1) | FLEX_MODE($3);')
 
@@ -792,6 +843,18 @@ INAPINAME($1,$2)(int                ncid,
 
     ifelse(`$2',`',`if (buftype != MPI_DATATYPE_NULL && bufcount == 0) return NC_NOERR;')
 
+    ifelse(`$2',`',`
+    /* when bufcount == -1, buftype must be an MPI predefined datatype */
+    if (buftype != MPI_DATATYPE_NULL && bufcount == -1 &&
+        buftype != MPI_CHAR          &&
+        buftype != MPI_SIGNED_CHAR   && buftype != MPI_UNSIGNED_CHAR      &&
+        buftype != MPI_SHORT         && buftype != MPI_UNSIGNED_SHORT     &&
+        buftype != MPI_INT           && buftype != MPI_UNSIGNED           &&
+        buftype != MPI_FLOAT         && buftype != MPI_DOUBLE             &&
+        buftype != MPI_LONG_LONG_INT && buftype != MPI_UNSIGNED_LONG_LONG &&
+        buftype != MPI_LONG)
+        return NC_EINVAL;')
+
     ifelse(`$1',`bput',`reqMode |= IO_MODE($1) | FLEX_MODE($2);',`
     reqMode = IO_MODE($1) | NB_MODE($1) | FLEX_MODE($2);')
 
@@ -863,6 +926,18 @@ ncmpi_$1_vard$2(int           ncid,
     if (err != NC_NOERR) return err;
 
     err = sanity_check(pncp, varid, IO_TYPE($1), MPI_DATATYPE_NULL, IS_COLL($2));
+
+    /* when bufcount == -1, buftype must be an MPI predefined datatype */
+    if (err == NC_NOERR &&
+        buftype != MPI_DATATYPE_NULL && bufcount == -1 &&
+        buftype != MPI_CHAR          &&
+        buftype != MPI_SIGNED_CHAR   && buftype != MPI_UNSIGNED_CHAR      &&
+        buftype != MPI_SHORT         && buftype != MPI_UNSIGNED_SHORT     &&
+        buftype != MPI_INT           && buftype != MPI_UNSIGNED           &&
+        buftype != MPI_FLOAT         && buftype != MPI_DOUBLE             &&
+        buftype != MPI_LONG_LONG_INT && buftype != MPI_UNSIGNED_LONG_LONG &&
+        buftype != MPI_LONG)
+        err = NC_EINVAL;
 
     ifelse(`$2',`',
     `/* for independent API, return now if error encountered or zero request */

--- a/src/drivers/ncmpio/ncmpio_getput.m4
+++ b/src/drivers/ncmpio/ncmpio_getput.m4
@@ -147,12 +147,12 @@ put_varm(NC               *ncp,
         buftype = itype;
     }
 
-    /* When bufcount is -1, then this is called from a high-level API. Thus,
-     * buftype is an MPI primitive data type. If this is called from a Fortran
-     * program, buftype will be Fortran MPI datatype, e.g. MPI_INTEGER. buftype
-     * must be translated to C datatype, itype.
+    /* When bufcount is -1, this is called from a high-level API. In this case,
+     * buftype must be an MPI predefined data type. If this is called from a
+     * Fortran program, buftype has already been converted to its corresponding
+     * C type, e.g. MPI_INTEGER is converted to MPI_INT.
+     * if (bufcount == -1) assert(buftype == itype);
      */
-    if (bufcount == -1) buftype = itype;
 
     /* because bnelems will be used as the argument "count" in MPI-IO
      * write calls and the argument "count" is of type int */
@@ -404,12 +404,12 @@ get_varm(NC               *ncp,
         buftype = itype;
     }
 
-    /* When bufcount is -1, then this is called from a high-level API. Thus,
-     * buftype is an MPI primitive data type. If this is called from a Fortran
-     * program, buftype will be Fortran MPI datatype, e.g. MPI_INTEGER. buftype
-     * must be translated to C datatype, itype.
+    /* When bufcount is -1, this is called from a high-level API. In this case,
+     * buftype must be an MPI predefined data type. If this is called from a
+     * Fortran program, buftype has already been converted to its corresponding
+     * C type, e.g. MPI_INTEGER is converted to MPI_INT.
+     * if (bufcount == -1) assert(buftype == itype);
      */
-    if (bufcount == -1) buftype = itype;
 
     /* because bnelems will be used as the argument "count" in MPI-IO
      * write calls and the argument "count" is of type int */

--- a/src/drivers/ncmpio/ncmpio_getput.m4
+++ b/src/drivers/ncmpio/ncmpio_getput.m4
@@ -147,6 +147,13 @@ put_varm(NC               *ncp,
         buftype = itype;
     }
 
+    /* When bufcount is -1, then this is called from a high-level API. Thus,
+     * buftype is an MPI primitive data type. If this is called from a Fortran
+     * program, buftype will be Fortran MPI datatype, e.g. MPI_INTEGER. buftype
+     * must be translated to C datatype, itype.
+     */
+    if (bufcount == -1) buftype = itype;
+
     /* because bnelems will be used as the argument "count" in MPI-IO
      * write calls and the argument "count" is of type int */
     if (bnelems > INT_MAX) {
@@ -396,6 +403,13 @@ get_varm(NC               *ncp,
         bufcount = bnelems;
         buftype = itype;
     }
+
+    /* When bufcount is -1, then this is called from a high-level API. Thus,
+     * buftype is an MPI primitive data type. If this is called from a Fortran
+     * program, buftype will be Fortran MPI datatype, e.g. MPI_INTEGER. buftype
+     * must be translated to C datatype, itype.
+     */
+    if (bufcount == -1) buftype = itype;
 
     /* because bnelems will be used as the argument "count" in MPI-IO
      * write calls and the argument "count" is of type int */

--- a/src/drivers/ncmpio/ncmpio_i_getput.m4
+++ b/src/drivers/ncmpio/ncmpio_i_getput.m4
@@ -163,22 +163,7 @@ ncmpio_igetput_varm(NC               *ncp,
     xtype = ncmpii_nc2mpitype(varp->xtype);
     MPI_Type_size(xtype, &xsize);
 
-    if (bufcount == -1) { /* buftype is an MPI primitive data type */
-        /* In this case, this subroutine is called from a high-level API.
-         * buftype is one of the MPI primitive data type. We set itype to
-         * buftype. itype is the MPI element type in internal representation.
-         * In addition, it means the user buf is contiguous.
-         */
-        int isderived;
-        err = ncmpii_dtype_decode(buftype, &itype, NULL, NULL, &isderived, NULL);
-        if (err != NC_NOERR) goto fn_exit;
-        if (itype == MPI_DATATYPE_NULL || isderived)
-            DEBUG_RETURN_ERROR(NC_EUNSPTETYPE)
-
-        MPI_Type_size(itype, &isize); /* buffer element size */
-        buftype = itype;
-    }
-    else if (buftype == MPI_DATATYPE_NULL) {
+    if (buftype == MPI_DATATYPE_NULL) {
         /* In this case, bufcount is ignored and the internal buffer data type
          * match the external variable data type. No data conversion will be
          * done. In addition, it means buf is contiguous. Hereinafter, buftype
@@ -186,6 +171,15 @@ ncmpio_igetput_varm(NC               *ncp,
          */
         itype = xtype;
         isize = xsize;
+    }
+    else if (bufcount == -1) {
+        /* In this case, this subroutine is called from a high-level API and
+         * buftype must be one of the MPI predefined datatype. We set itype to
+         * buftype. itype is the MPI element type in internal representation.
+         * In addition, it means the user buf is contiguous.
+         */
+        itype = buftype;
+        MPI_Type_size(itype, &isize); /* buffer element size */
     }
     else { /* (bufcount > 0) */
         /* When bufcount > 0, this subroutine is called from a flexible API. If

--- a/src/drivers/ncmpio/ncmpio_i_getput.m4
+++ b/src/drivers/ncmpio/ncmpio_i_getput.m4
@@ -169,8 +169,14 @@ ncmpio_igetput_varm(NC               *ncp,
          * buftype. itype is the MPI element type in internal representation.
          * In addition, it means the user buf is contiguous.
          */
-        itype = buftype;
+        int isderived;
+        err = ncmpii_dtype_decode(buftype, &itype, NULL, NULL, &isderived, NULL);
+        if (err != NC_NOERR) goto fn_exit;
+        if (itype == MPI_DATATYPE_NULL || isderived)
+            DEBUG_RETURN_ERROR(NC_EUNSPTETYPE)
+
         MPI_Type_size(itype, &isize); /* buffer element size */
+        buftype = itype;
     }
     else if (buftype == MPI_DATATYPE_NULL) {
         /* In this case, bufcount is ignored and the internal buffer data type

--- a/test/testcases/Makefile.am
+++ b/test/testcases/Makefile.am
@@ -109,13 +109,15 @@ if HAS_FORTRAN
                    attrf \
                    buftype_freef \
                    put_parameter \
-                   test_vardf
+                   test_vardf \
+                   flexible_api
 
        varn_intf_SOURCES = varn_intf.f
            attrf_SOURCES = attrf.f
    buftype_freef_SOURCES = buftype_freef.f
    put_parameter_SOURCES = put_parameter.f
       test_vardf_SOURCES = test_vardf.F
+    flexible_api_SOURCES = flexible_api.f
 if HAVE_MPI_MOD
    TESTPROGRAMS += inq_num_varsf \
                    inq_recsizef \

--- a/test/testcases/flexible_api.f
+++ b/test/testcases/flexible_api.f
@@ -1,0 +1,220 @@
+!
+!   Copyright (C) 2022, Northwestern University
+!   See COPYRIGHT notice in top-level directory.
+!
+! This program tests if PnetCDF handles Fortran predefine datatypes when
+! bufcount argument in the flexible APIs is -1 and buftype argument is a
+! predefined MPI datatype
+!
+       INTEGER FUNCTION XTRIM(STRING)
+           CHARACTER*(*) STRING
+           INTEGER I, N
+           N = LEN(STRING)
+           DO I = N, 1, -1
+              IF (STRING(I:I) .NE. ' ') GOTO 10
+           ENDDO
+ 10        XTRIM = I
+       END ! FUNCTION XTRIM
+
+      subroutine check(err, message)
+          implicit none
+          include "mpif.h"
+          include "pnetcdf.inc"
+          integer err, XTRIM
+          character*(*) message
+          character*128 msg
+
+          ! It is a good idea to check returned value for possible error
+          if (err .NE. NF_NOERR) then
+              write(6,*) message(1:XTRIM(message)), nfmpi_strerror(err)
+              msg = '*** TESTING F77 flexible_api.f for flexible API '
+              call pass_fail(1, msg)
+              STOP 2
+          end if
+      end ! subroutine check
+
+      program main
+          implicit none
+          include "mpif.h"
+          include "pnetcdf.inc"
+
+          character*256 filename, cmd, msg
+          integer XTRIM
+          integer err, ierr, nerrs, nprocs, rank, i, j
+          integer cmode, ncid, varid, dimid(2), ghost_len, get_args
+          integer*8 nx, ny, global_nx, global_ny
+          integer*8 starts(2), counts(2), bufcount
+          PARAMETER(nx=5, ny=4, ghost_len=3)
+          integer buf(nx+2*ghost_len, ny+2*ghost_len)
+          integer subarray, req(1), st(1)
+          integer array_of_sizes(2), array_of_subsizes(2)
+          integer array_of_starts(2)
+          integer*8 malloc_size, sum_size
+          logical verbose
+          integer dummy
+
+          call MPI_Init(err)
+          call MPI_Comm_rank(MPI_COMM_WORLD, rank, err)
+          call MPI_Comm_size(MPI_COMM_WORLD, nprocs, err)
+
+          ! take filename from command-line argument if there is any
+          if (rank .EQ. 0) then
+              verbose = .TRUE.
+              filename = "testfile.nc"
+              ierr = get_args(cmd, filename)
+          endif
+          call MPI_Bcast(ierr, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, err)
+          if (ierr .EQ. 0) goto 999
+
+          call MPI_Bcast(verbose, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD,
+     +                   err)
+          call MPI_Bcast(filename, 256, MPI_CHARACTER, 0,
+     +                   MPI_COMM_WORLD, err)
+
+          nerrs = 0
+
+          ! set parameters
+          global_nx = nx
+          global_ny = ny * nprocs
+
+          ! first initialize the entire buffer to -1
+          do j=1, ny+2*ghost_len
+             do i=1, nx+2*ghost_len
+                buf(i, j) = -1
+             enddo
+          enddo
+          ! assign values for non-ghost cells
+          do j=ghost_len+1, ny+ghost_len
+             do i=ghost_len+1, nx+ghost_len
+                 buf(i, j) = rank
+             enddo
+          enddo
+
+          ! define an MPI datatype using MPI_Type_create_subarray()
+          array_of_sizes(1)    = nx + 2*ghost_len
+          array_of_sizes(2)    = ny + 2*ghost_len
+          array_of_subsizes(1) = nx
+          array_of_subsizes(2) = ny
+          array_of_starts(1)   = ghost_len  ! MPI start index starts with 0
+          array_of_starts(2)   = ghost_len
+          call MPI_Type_create_subarray(2, array_of_sizes,
+     +         array_of_subsizes, array_of_starts, MPI_ORDER_FORTRAN,
+     +         MPI_INTEGER, subarray, err)
+          call MPI_Type_commit(subarray, err)
+
+          ! create file, truncate it if exists
+          cmode = IOR(NF_CLOBBER, NF_64BIT_DATA)
+          err = nfmpi_create(MPI_COMM_WORLD, filename, cmode,
+     +                       MPI_INFO_NULL, ncid)
+          call check(err, 'In nfmpi_create: ')
+
+          ! define dimensions x and y
+          err = nfmpi_def_dim(ncid, "y", global_ny, dimid(2))
+          call check(err, 'In nfmpi_def_dim y: ')
+          err = nfmpi_def_dim(ncid, "x", global_nx, dimid(1))
+          call check(err, 'In nfmpi_def_dim x: ')
+
+          ! define a 2D variable of integer type
+          err = nfmpi_def_var(ncid, "var", NF_INT, 2, dimid, varid)
+          call check(err, 'In nfmpi_def_var: ')
+
+          ! do not forget to exit define mode
+          err = nfmpi_enddef(ncid)
+          call check(err, 'In nfmpi_enddef: ')
+
+          ! now we are in data mode
+
+          ! Note that in Fortran, array indices start with 1
+          starts(1) = 1
+          starts(2) = ny * rank + 1
+          counts(1) = nx
+          counts(2) = ny
+          bufcount  = 1
+
+          ! In Fortran, subarray buffer type can also use array index ranges
+          ! for example in this case
+          !    buf(1+ghost_len:nx+ghost_len, 1+ghost_len:ny+ghost_len)
+          ! However, this does not work for nonblocking APIs because
+          ! wait/wait_all is called separately from the nonblocking calls
+          ! Fortran the subarray indexing is lost in the wait call
+          err = nfmpi_put_vara_all(ncid, varid, starts, counts, buf,
+     +                             bufcount, subarray)
+          call check(err, 'In nfmpi_put_vara_all: ')
+          call MPI_Type_free(subarray, err)
+
+          ! test blocking and nonblocking APIs when bufcount argument is 1
+          ! and buftype argument is a predefined MPI datatype
+
+          bufcount = -1
+
+          err = nfmpi_put_vara_all(ncid, varid, starts, counts, buf,
+     +                             bufcount, MPI_INTEGER)
+          call check(err, 'In nfmpi_put_vara_all: ')
+
+          err = nfmpi_put_var1_all(ncid, varid, starts, buf,
+     +                             bufcount, MPI_INTEGER)
+          call check(err, 'In nfmpi_put_var1_all: ')
+
+          err = nfmpi_iput_vara(ncid, varid, starts, counts, buf,
+     +                          bufcount, MPI_INTEGER, req)
+          call check(err, 'In nfmpi_iput_vara: ')
+
+          err = nfmpi_wait_all(ncid, 1, req, st)
+          call check(err, 'In nfmpi_wait_all:')
+
+          err = nfmpi_iput_var1(ncid, varid, starts, buf,
+     +                          bufcount, MPI_INTEGER, req)
+          call check(err, 'In nfmpi_iput_var1: ')
+
+          err = nfmpi_wait_all(ncid, 1, req, st)
+          call check(err, 'In nfmpi_wait_all:')
+
+          err = nfmpi_get_vara_all(ncid, varid, starts, counts, buf,
+     +                             bufcount, MPI_INTEGER)
+          call check(err, 'In nfmpi_get_vara_all: ')
+
+          err = nfmpi_get_var1_all(ncid, varid, starts, buf,
+     +                             bufcount, MPI_INTEGER)
+          call check(err, 'In nfmpi_get_var1_all: ')
+
+          err = nfmpi_iget_vara(ncid, varid, starts, counts, buf,
+     +                          bufcount, MPI_INTEGER, req)
+          call check(err, 'In nfmpi_iget_vara: ')
+
+          err = nfmpi_wait_all(ncid, 1, req, st)
+          call check(err, 'In nfmpi_wait_all:')
+
+          err = nfmpi_iget_var1(ncid, varid, starts, buf,
+     +                          bufcount, MPI_INTEGER, req)
+          call check(err, 'In nfmpi_iget_var1: ')
+
+          err = nfmpi_wait_all(ncid, 1, req, st)
+          call check(err, 'In nfmpi_wait_all:')
+
+          ! close the file
+          err = nfmpi_close(ncid)
+          call check(err, 'In nfmpi_close: ')
+
+          ! check if there is any PnetCDF internal malloc residue
+ 998      format(A,I13,A)
+          err = nfmpi_inq_malloc_size(malloc_size)
+          if (err .EQ. NF_NOERR) then
+              call MPI_Reduce(malloc_size, sum_size, 1, MPI_INTEGER8,
+     +                        MPI_SUM, 0, MPI_COMM_WORLD, err)
+              if (rank .EQ. 0 .AND. sum_size .GT. 0)
+     +            print 998,
+     +            'heap memory allocated by PnetCDF internally has ',
+     +            sum_size, ' bytes yet to be freed'
+          endif
+
+          if (rank .eq. 0) then
+              msg = '*** TESTING F77 '//cmd(1:XTRIM(cmd))//
+     +              ' for bufcount=-1 & buftype predefined'
+              call pass_fail(nerrs, msg)
+          endif
+
+ 999      call MPI_Finalize(ierr)
+          if (nerrs .GT. 0) stop 2
+
+      end ! program main
+

--- a/test/testcases/flexible_var.c
+++ b/test/testcases/flexible_var.c
@@ -69,8 +69,8 @@
 }
 
 #define INIT_PUT_BUF_GHOST(Y, X, G, buf) \
-    for (i=0; i<Y; i++) { \
-        for (j=0; j<X; j++) { \
+    for (i=0; i<Y+2*G; i++) { \
+        for (j=0; j<X+2*G; j++) { \
             if (i < G || G+Y <= i || j < G || G+X <= j) \
                 buf[i][j] = -1; \
             else \


### PR DESCRIPTION
When argument bufcount == -1, buftype should be one of MPI predefined
data type that describes the I/O buffer. For example,
```
integer*8 bufcount
integer buf(100, 100)
...
bufcount = -1
nfmpi_put_vara_all(ncid, varid, start, count, buf, bufcount, MPI_INTEGER)
```
is equivalent to
```
nfmpi_put_vara_int_all(ncid, varid, start, count, buf)
```
In this case, the I/O buffer, `buf`, should be of Fortran type `integer`.