### PR TITLE
Reuse length of name string, instead of calling strlen

### DIFF
--- a/src/drivers/ncmpio/ncmpio_NC.h
+++ b/src/drivers/ncmpio/ncmpio_NC.h
@@ -187,7 +187,8 @@ typedef struct NC_attrarray {
 
 /* Begin defined in attr.c --------------------------------------------------*/
 extern int
-ncmpio_new_NC_attr(char *name, nc_type xtype, MPI_Offset nelems, NC_attr **attrp);
+ncmpio_new_NC_attr(char *name, size_t name_len, nc_type xtype,
+                   MPI_Offset nelems, NC_attr **attrp);
 
 extern int
 ncmpio_NC_findattr(const NC_attrarray *ncap, const char *uname);
@@ -257,7 +258,7 @@ extern void
 ncmpio_free_NC_var(NC_var *varp);
 
 extern NC_var *
-ncmpio_new_NC_var(char *name, int ndims);
+ncmpio_new_NC_var(char *name, size_t name_len, int ndims);
 
 extern void
 ncmpio_free_NC_vararray(NC_vararray *ncap);

--- a/src/drivers/ncmpio/ncmpio_dim.c
+++ b/src/drivers/ncmpio/ncmpio_dim.c
@@ -40,8 +40,8 @@ dup_NC_dim(const NC_dim *rdimp, NC_dim **dimp)
     if (*dimp == NULL) DEBUG_RETURN_ERROR(NC_ENOMEM)
 
     (*dimp)->size     = rdimp->size;
-    (*dimp)->name_len = strlen(rdimp->name)+1;
-    (*dimp)->name     = (char*) NCI_Malloc((*dimp)->name_len);
+    (*dimp)->name_len = rdimp->name_len;
+    (*dimp)->name     = (char*) NCI_Malloc((*dimp)->name_len + 1);
     if ((*dimp)->name == NULL) DEBUG_RETURN_ERROR(NC_ENOMEM)
     strcpy((*dimp)->name, rdimp->name);
 

--- a/src/drivers/ncmpio/ncmpio_hash_func.c
+++ b/src/drivers/ncmpio/ncmpio_hash_func.c
@@ -26,7 +26,8 @@
 int ncmpio_jenkins_one_at_a_time_hash(const char *str_name)
 {
     unsigned int i, hash=0;
-    for (i=0; i<strlen(str_name); ++i) {
+    size_t len = strlen(str_name);
+    for (i=0; i<len; ++i) {
         hash += (unsigned int)str_name[i];
         hash += (hash << 10);
         hash ^= (hash >> 6);
@@ -112,8 +113,9 @@ int ncmpio_Pearson_hash(const char *str_name)
     for (i=len; i>0; ) hash = T[hash ^ str_name[--i]];
     return (int)hash;
 #else
-    unsigned int i, hash=strlen(str_name);
-    for (i=0; i<strlen(str_name); ++i)
+    size_t len=strlen(str_name);
+    unsigned int i, hash=len;
+    for (i=0; i<len; ++i)
         hash ^= str_name[i];
 
     return (int)((hash ^ (hash>>10) ^ (hash>>20)) & (HASH_TABLE_SIZE-1));

--- a/src/drivers/ncmpio/ncmpio_var.c
+++ b/src/drivers/ncmpio/ncmpio_var.c
@@ -54,7 +54,7 @@ ncmpio_free_NC_var(NC_var *varp)
 
 /*----< ncmpio_new_NC_var() >------------------------------------------------*/
 NC_var *
-ncmpio_new_NC_var(char *name, int ndims)
+ncmpio_new_NC_var(char *name, size_t name_len, int ndims)
 {
     NC_var *varp;
 
@@ -68,7 +68,7 @@ ncmpio_new_NC_var(char *name, int ndims)
     }
 
     varp->name     = name;         /* name has been malloc-ed */
-    varp->name_len = strlen(name); /* name has been NULL checked */
+    varp->name_len = name_len;     /* name has been NULL checked */
     varp->ndims    = ndims;
 
     return varp;
@@ -87,7 +87,7 @@ dup_NC_var(const NC_var *rvarp)
     strcpy(name, rvarp->name);
 
     /* allocate a NC_var object */
-    varp = ncmpio_new_NC_var(name, rvarp->ndims);
+    varp = ncmpio_new_NC_var(name, rvarp->name_len, rvarp->ndims);
     if (varp == NULL ) return NULL;
 
     varp->xtype = rvarp->xtype;
@@ -354,7 +354,7 @@ ncmpio_def_var(void       *ncdp,
     if (err != NC_NOERR) goto err_check;
 
     /* allocate a new NC_var object */
-    varp = ncmpio_new_NC_var(nname, ndims);
+    varp = ncmpio_new_NC_var(nname, strlen(nname), ndims);
     if (varp == NULL) {
         DEBUG_ASSIGN_ERROR(err, NC_ENOMEM)
         goto err_check;


### PR DESCRIPTION
In NetCDF format spec, object `name` consists of two parts: the number
of characters and the character string itself, i.e.
```
    name = nelems namestring
```
where `nelems` is the length of `namestring`.
This commit reuses `nelems` if it is previously calculated or already
available in the file header, so to avoid calls to `strlen()`.