### PR TITLE
Add configure option --enable-install-examples

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -182,6 +182,13 @@ AC_ARG_ENABLE(echo,
    [set -x]
 )
 
+AC_ARG_ENABLE(install-examples,
+   [AS_HELP_STRING([--enable-install-examples],
+                   [Install example programs under $prefix/examples. @<:@default: disabled@:>@])],
+   [install_examples=yes], [install_examples=no]
+)
+AM_CONDITIONAL(INSTALL_EXAMPLES, [test x$install_examples = xyes])
+
 MPI_INSTALL=
 AC_ARG_WITH(mpi,
    [AS_HELP_STRING([--with-mpi=DIR],

--- a/examples/C/Makefile.am
+++ b/examples/C/Makefile.am
@@ -39,6 +39,12 @@ check_PROGRAMS = collective_write \
                  vard_mvars \
                  time_var
 
+if INSTALL_EXAMPLES
+   example_execbin_PROGRAMS = $(check_PROGRAMS)
+   example_execbindir = $(exec_prefix)/pnetcdf_examples/C
+   example_execbin_SCRIPTS = run_c_examples.sh
+endif
+
 if ENABLE_THREAD_SAFE
    check_PROGRAMS += pthread
 endif
@@ -64,7 +70,7 @@ NC_FILES = $(check_PROGRAMS:%=$(TESTOUTDIR)/%.nc) \
 CLEANFILES = core core.* *.gcda *.gcno *.gcov gmon.out \
              $(NC_FILES) $(TESTOUTDIR)/pthread.nc.* $(TESTOUTDIR)/testfile.nc
 
-EXTRA_DIST = parallel_run.sh
+EXTRA_DIST = parallel_run.sh run_c_examples.sh
 
 ptest ptest4: $(check_PROGRAMS)
 	@echo "==========================================================="
@@ -94,4 +100,9 @@ ptest2 ptest6 ptest10:
 tests-local: all $(check_PROGRAMS)
 
 .PHONY: ptest ptests ptest2 ptest3 ptest4 ptest6 ptest8 ptest10
+
+install-exec-hook:
+	@if test "x$(example_execbindir)" != x ; then \
+	$(SED_I) -e 's|check_PROGRAMS|$(check_PROGRAMS)|g ; s|TESTOUTDIR|$(TESTOUTDIR)|g ; s|TESTMPIRUN|$(TESTMPIRUN)|g ; s|SED_CMD|$(SED)|g ; s|ENABLE_BURST_BUFFER|$(ENABLE_BURST_BUFFER)|g ; s|ENABLE_NETCDF4|$(ENABLE_NETCDF4)|g' $(DESTDIR)$(example_execbindir)/run_c_examples.sh ; \
+	fi
 

--- a/examples/C/run_c_examples.sh
+++ b/examples/C/run_c_examples.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+#
+# Copyright (C) 2022, Northwestern University and Argonne National Laboratory
+# See COPYRIGHT notice in top-level directory.
+#
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+NPROCS=4
+if test "x$1" != x ; then
+   NPROCS=$1
+fi
+OUTDIR=TESTOUTDIR
+MPIRUN="TESTMPIRUN"
+MPIRUN=`echo ${MPIRUN} | SED_CMD -e "s/NP/${NPROCS}/g"`
+run_BURST_BUFFER=ENABLE_BURST_BUFFER
+run_NETCDF4=ENABLE_NETCDF4
+
+for i in check_PROGRAMS ; do
+    if test $i = get_vara ; then
+       # get_vara reads the file 'put_vara.nc' created by put_vara
+       ${MPIRUN} ./$i -q ${OUTDIR}/put_vara.nc
+    else
+       ${MPIRUN} ./$i -q ${OUTDIR}/$i.nc
+    fi
+    if test $? = 0 ; then
+       echo "PASS:  C  parallel run on ${NPROCS} processes --------------- $i"
+    fi
+
+    if test "x${run_BURST_BUFFER}" = x1 ; then
+       # echo "test burst buffering feature"
+       export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${OUTDIR};nc_burst_buf_overwrite=enable"
+       if test $i = get_vara ; then
+          ${MPIRUN} ./$i -q ${OUTDIR}/put_vara.bb.nc
+       else
+          ${MPIRUN} ./$i -q ${OUTDIR}/$i.bb.nc
+       fi
+       if test $? = 0 ; then
+          echo "PASS:  C  parallel run on ${NPROCS} processes --------------- $i"
+       fi
+       unset PNETCDF_HINTS
+    fi
+
+    if test "x${run_NETCDF4}" = x1 ; then
+       # echo "test netCDF-4 feature"
+       ${MPIRUN} ./$i ${OUTDIR}/$i.nc4 4
+    fi
+
+    # delete output file
+    if test $i = get_vara ; then
+       rm -f ${OUTDIR}/put_vara.nc
+       rm -f ${OUTDIR}/put_vara.bb.nc
+    elif test $i != put_vara ; then
+       rm -f ${OUTDIR}/$i.nc
+       rm -f ${OUTDIR}/$i.bb.nc
+    fi
+done
+

--- a/examples/CXX/Makefile.am
+++ b/examples/CXX/Makefile.am
@@ -30,6 +30,12 @@ check_PROGRAMS = collective_write \
                  fill_mode \
                  SimpleXyWr
 
+if INSTALL_EXAMPLES
+   example_execbin_PROGRAMS = $(check_PROGRAMS)
+   example_execbindir = $(exec_prefix)/pnetcdf_examples/CXX
+   example_execbin_SCRIPTS = run_cxx_examples.sh
+endif
+
 # parallel runs only
 # TESTS = $(check_PROGRAMS)
 
@@ -49,7 +55,7 @@ NC_FILES = $(check_PROGRAMS:%=$(TESTOUTDIR)/%.nc) \
 CLEANFILES = core core.* *.gcda *.gcno *.gcov gmon.out \
              $(NC_FILES) a.out
 
-EXTRA_DIST = parallel_run.sh
+EXTRA_DIST = parallel_run.sh run_cxx_examples.sh
 
 ptest ptest4: $(check_PROGRAMS)
 	@echo "==========================================================="
@@ -77,6 +83,11 @@ ptest2 ptest6 ptest10:
 
 # build check targets but not invoke
 tests-local: all $(check_PROGRAMS)
+
+install-exec-hook:
+	@if test "x$(example_execbindir)" != x ; then \
+	$(SED_I) -e 's|check_PROGRAMS|$(check_PROGRAMS)|g ; s|TESTOUTDIR|$(TESTOUTDIR)|g ; s|TESTMPIRUN|$(TESTMPIRUN)|g ; s|SED_CMD|$(SED)|g ; s|ENABLE_BURST_BUFFER|$(ENABLE_BURST_BUFFER)|g ; s|ENABLE_NETCDF4|$(ENABLE_NETCDF4)|g' $(DESTDIR)$(example_execbindir)/run_cxx_examples.sh ; \
+	fi
 
 .PHONY: ptest ptests ptest2 ptest3 ptest4 ptest6 ptest8 ptest10
 

--- a/examples/CXX/run_cxx_examples.sh
+++ b/examples/CXX/run_cxx_examples.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+#
+# Copyright (C) 2022, Northwestern University and Argonne National Laboratory
+# See COPYRIGHT notice in top-level directory.
+#
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+NPROCS=4
+if test "x$1" != x ; then
+   NPROCS=$1
+fi
+OUTDIR=TESTOUTDIR
+MPIRUN="TESTMPIRUN"
+MPIRUN=`echo ${MPIRUN} | SED_CMD -e "s/NP/${NPROCS}/g"`
+run_BURST_BUFFER=ENABLE_BURST_BUFFER
+run_NETCDF4=ENABLE_NETCDF4
+
+for i in check_PROGRAMS ; do
+    if test $i = get_vara ; then
+       # get_vara reads the file 'put_vara.nc' created by put_vara
+       ${MPIRUN} ./$i -q ${OUTDIR}/put_vara.nc
+    else
+       ${MPIRUN} ./$i -q ${OUTDIR}/$i.nc
+    fi
+    if test $? = 0 ; then
+       echo "PASS: CXX parallel run on ${NPROCS} processes --------------- $i"
+    fi
+
+    if test "x${run_BURST_BUFFER}" = x1 ; then
+       # echo "test burst buffering feature"
+       export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${OUTDIR};nc_burst_buf_overwrite=enable"
+       if test $i = get_vara ; then
+          ${MPIRUN} ./$i -q ${OUTDIR}/put_vara.bb.nc
+       else
+          ${MPIRUN} ./$i -q ${OUTDIR}/$i.bb.nc
+       fi
+       if test $? = 0 ; then
+          echo "PASS: CXX parallel run on ${NPROCS} processes --------------- $i"
+       fi
+       unset PNETCDF_HINTS
+    fi
+
+    if test "x${run_NETCDF4}" = x1 ; then
+       # echo "test netCDF-4 feature"
+       ${MPIRUN} ./$i ${OUTDIR}/$i.nc4 4
+    fi
+    # delete output file
+    if test $i = get_vara ; then
+       rm -f ${OUTDIR}/put_vara.nc
+       rm -f ${OUTDIR}/put_vara.bb.nc
+    elif test $i != put_vara ; then
+       rm -f ${OUTDIR}/$i.nc
+       rm -f ${OUTDIR}/$i.bb.nc
+    fi
+done
+

--- a/examples/F77/Makefile.am
+++ b/examples/F77/Makefile.am
@@ -33,7 +33,13 @@ check_PROGRAMS = nonblocking_write \
                  vard_int \
                  time_var
 
-EXTRA_DIST = utils.F90
+if INSTALL_EXAMPLES
+   example_execbin_PROGRAMS = $(check_PROGRAMS)
+   example_execbindir = $(exec_prefix)/pnetcdf_examples/F77
+   example_execbin_SCRIPTS = run_f77_examples.sh
+endif
+
+EXTRA_DIST = utils.F90 run_f77_examples.sh
 
 utils.o: $(srcdir)/utils.F90
 	$(FC) $(FC_DEFS) $(AM_FCFLAGS) $(FCFLAGS) -c -o $@ $<
@@ -85,6 +91,11 @@ ptest2 ptest6 ptest10:
 
 # build check targets but not invoke
 tests-local: all $(check_PROGRAMS)
+
+install-exec-hook:
+	@if test "x$(example_execbindir)" != x ; then \
+	$(SED_I) -e 's|check_PROGRAMS|$(check_PROGRAMS)|g ; s|TESTOUTDIR|$(TESTOUTDIR)|g ; s|TESTMPIRUN|$(TESTMPIRUN)|g ; s|SED_CMD|$(SED)|g ; s|ENABLE_BURST_BUFFER|$(ENABLE_BURST_BUFFER)|g ; s|ENABLE_NETCDF4|$(ENABLE_NETCDF4)|g' $(DESTDIR)$(example_execbindir)/run_f77_examples.sh ; \
+	fi
 
 .PHONY: ptest ptests ptest2 ptest3 ptest4 ptest6 ptest8 ptest10
 

--- a/examples/F77/run_f77_examples.sh
+++ b/examples/F77/run_f77_examples.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# Copyright (C) 2022, Northwestern University and Argonne National Laboratory
+# See COPYRIGHT notice in top-level directory.
+#
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+NPROCS=4
+if test "x$1" != x ; then
+   NPROCS=$1
+fi
+OUTDIR=TESTOUTDIR
+MPIRUN="TESTMPIRUN"
+MPIRUN=`echo ${MPIRUN} | SED_CMD -e "s/NP/${NPROCS}/g"`
+run_BURST_BUFFER=ENABLE_BURST_BUFFER
+run_NETCDF4=ENABLE_NETCDF4
+
+for i in check_PROGRAMS ; do
+    if test $i = get_vara ; then
+       # get_vara reads the file 'put_vara.nc' created by put_vara
+       ${MPIRUN} ./$i -q ${OUTDIR}/put_vara.nc
+    else
+       ${MPIRUN} ./$i -q ${OUTDIR}/$i.nc
+    fi
+    if test $? = 0 ; then
+       echo "PASS: F77 parallel run on ${NPROCS} processes --------------- $i"
+    fi
+
+    if test "x${run_BURST_BUFFER}" = x1 ; then
+       # echo "test burst buffering feature"
+       export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${OUTDIR};nc_burst_buf_overwrite=enable"
+       if test $i = get_vara ; then
+          ${MPIRUN} ./$i -q ${OUTDIR}/put_vara.bb.nc
+       else
+          ${MPIRUN} ./$i -q ${OUTDIR}/$i.bb.nc
+       fi
+       if test $? = 0 ; then
+          echo "PASS: F77 parallel run on ${NPROCS} processes --------------- $i"
+       fi
+       unset PNETCDF_HINTS
+    fi
+
+    if test "x${run_NETCDF4}" = x1 ; then
+       # echo "test netCDF-4 feature"
+       ${MPIRUN} ./$i ${OUTDIR}/$i.nc4 4
+    fi
+    # delete output file
+    rm -f ${OUTDIR}/$i.nc
+    rm -f ${OUTDIR}/$i.bb.nc
+done
+

--- a/examples/F90/Makefile.am
+++ b/examples/F90/Makefile.am
@@ -27,7 +27,13 @@ check_PROGRAMS = nonblocking_write \
                  fill_mode \
                  vard_int
 
-EXTRA_DIST = utils.F90
+if INSTALL_EXAMPLES
+   example_execbin_PROGRAMS = $(check_PROGRAMS)
+   example_execbindir = $(exec_prefix)/pnetcdf_examples/F90
+   example_execbin_SCRIPTS = run_f90_examples.sh
+endif
+
+EXTRA_DIST = utils.F90 run_f90_examples.sh
 
 utils.o: utils.F90
 	$(FC) $(FC_DEFS) $(AM_FCFLAGS) $(FCFLAGS) -c -o $@ $<
@@ -79,6 +85,11 @@ ptest2 ptest6 ptest10:
 
 # build check targets but not invoke
 tests-local: all $(check_PROGRAMS)
+
+install-exec-hook:
+	@if test "x$(example_execbindir)" != x ; then \
+	$(SED_I) -e 's|check_PROGRAMS|$(check_PROGRAMS)|g ; s|TESTOUTDIR|$(TESTOUTDIR)|g ; s|TESTMPIRUN|$(TESTMPIRUN)|g ; s|SED_CMD|$(SED)|g ; s|ENABLE_BURST_BUFFER|$(ENABLE_BURST_BUFFER)|g ; s|ENABLE_NETCDF4|$(ENABLE_NETCDF4)|g' $(DESTDIR)$(example_execbindir)/run_f90_examples.sh ; \
+	fi
 
 .PHONY: ptest ptests ptest2 ptest3 ptest4 ptest6 ptest8 ptest10
 

--- a/examples/F90/run_f90_examples.sh
+++ b/examples/F90/run_f90_examples.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# Copyright (C) 2022, Northwestern University and Argonne National Laboratory
+# See COPYRIGHT notice in top-level directory.
+#
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+NPROCS=4
+if test "x$1" != x ; then
+   NPROCS=$1
+fi
+OUTDIR=TESTOUTDIR
+MPIRUN="TESTMPIRUN"
+MPIRUN=`echo ${MPIRUN} | SED_CMD -e "s/NP/${NPROCS}/g"`
+run_BURST_BUFFER=ENABLE_BURST_BUFFER
+run_NETCDF4=ENABLE_NETCDF4
+
+for i in check_PROGRAMS ; do
+    if test $i = get_vara ; then
+       # get_vara reads the file 'put_vara.nc' created by put_vara
+       ${MPIRUN} ./$i -q ${OUTDIR}/put_vara.nc
+    else
+       ${MPIRUN} ./$i -q ${OUTDIR}/$i.nc
+    fi
+    if test $? = 0 ; then
+       echo "PASS: F90 parallel run on ${NPROCS} processes --------------- $i"
+    fi
+
+    if test "x${run_BURST_BUFFER}" = x1 ; then
+       # echo "test burst buffering feature"
+       export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${OUTDIR};nc_burst_buf_overwrite=enable"
+       if test $i = get_vara ; then
+          ${MPIRUN} ./$i -q ${OUTDIR}/put_vara.bb.nc
+       else
+          ${MPIRUN} ./$i -q ${OUTDIR}/$i.bb.nc
+       fi
+       if test $? = 0 ; then
+          echo "PASS: F90 parallel run on ${NPROCS} processes --------------- $i"
+       fi
+       unset PNETCDF_HINTS
+    fi
+
+    if test "x${run_NETCDF4}" = x1 ; then
+       # echo "test netCDF-4 feature"
+       ${MPIRUN} ./$i ${OUTDIR}/$i.nc4 4
+    fi
+    # delete output file
+    rm -f ${OUTDIR}/$i.nc
+    rm -f ${OUTDIR}/$i.bb.nc
+done
+

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -21,7 +21,10 @@ This is essentially a placeholder for the next release note ...
   + none
 
 * Update configure options
-  + none
+  + `--enable-install-examples` to install example programs under folder
+    `${prefix}/pnetcdf_examples` along with run script files. An example is
+    `${prefix}/pnetcdf_examples/C/run_c_examples.sh`. The default of this
+    option is `disabled`.
 
 * New constants
   + none


### PR DESCRIPTION
On some parallel computers, the batch scheduler copies the executable files to a
location, e.g. `/var/opt/cray/alps/spool/`, before running them. When configure option
`--enabled-shared` is used to build PnetCDF, all executables are actually wrapper
scripts of libtool. Only running `make install` will create true executables. This PR
enables an option to install the executables from example programs under folder
`./examples`.
* Running command `make install` will install examples programs in the installation
  folder `${prefix}/pnetcdf_examples`
* It also installs script files to run the examples in parallel. See an example in
  `${prefix}/pnetcdf_examples/C/run_c_examples.sh`
* The default of this configure option is `disabled`.