### PR TITLE
Add a new constant NC_COUNT_IGNORE

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,8 @@ Northwestern University and Argonne National Laboratory.
   popular systems.
 
 ### Current build status
-* Github Actions [![ubuntu_mpich](https://github.com/Parallel-NetCDF/PnetCDF/actions/workflows/ubuntu_mpich.yml/badge.svg)](https://github.com/Parallel-NetCDF/PnetCDF/actions/workflows/ubuntu_mpich.yml)
-* [Travis CI ![Build Status](https://travis-ci.org/Parallel-NetCDF/PnetCDF.svg?branch=master)](https://travis-ci.org/Parallel-NetCDF/PnetCDF)
-* [Coverity Scan ![Build Status](https://scan.coverity.com/projects/15801/badge.svg)](https://scan.coverity.com/projects/parallel-netcdf-pnetcdf)
+* Github Actions: [![MPICH](https://github.com/Parallel-NetCDF/PnetCDF/actions/workflows/ubuntu_mpich.yml/badge.svg)](https://github.com/Parallel-NetCDF/PnetCDF/actions/workflows/ubuntu_mpich.yml)
+[![OpenMPI](https://github.com/Parallel-NetCDF/PnetCDF/actions/workflows/ubuntu_openmpi.yml/badge.svg)](https://github.com/Parallel-NetCDF/PnetCDF/actions/workflows/ubuntu_openmpi.yml)
 
 ### PnetCDF user guide
 * C references: http://cucis.ece.northwestern.edu/projects/PnetCDF/doc/pnetcdf-c

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -4,15 +4,16 @@ This is essentially a placeholder for the next release note ...
 
 * New features
   + Flexible APIs now can be used as high-level APIs, when argument bufcount
-    is -1 and buftype is an MPI predefined data type. For example,
+    is NC_COUNT_IGNORE and buftype is an MPI predefined data type. See
+    [PR #82](https://github.com/Parallel-NetCDF/PnetCDF/pull/82). Below is an
+    example of writing from a memory buffer of type float.
     ```
-    ncmpi_put_vara_all(ncid, varid, start, count, buf, -1, MPI_FLOAT);
+    ncmpi_put_vara_all(ncid, varid, start, count, buf, NC_COUNT_IGNORE, MPI_FLOAT);
     ```
     is equivalent to
     ```
     ncmpi_put_vara_float_all(ncid, varid, start, count, buf);
     ```
-    See [PR #82](https://github.com/Parallel-NetCDF/PnetCDF/pull/82).
 
 * New optimization
   + none
@@ -27,7 +28,10 @@ This is essentially a placeholder for the next release note ...
     option is `disabled`.
 
 * New constants
-  + none
+  + NC_COUNT_IGNORE - This is used in flexible APIs. When argument bufcount is
+    NC_COUNT_IGNORE, buftype must be a predefine MPI datatype and the APIs
+    operate as the high-level APIs. Fortran equivalents are NF_COUNT_IGNORE and
+    NF90_COUNT_IGNORE.
 
 * New APIs
   + none

--- a/src/binding/f77/defs
+++ b/src/binding/f77/defs
@@ -2120,9 +2120,9 @@ sub datatypeArr_ftoc {
     my $count = $_[0];
     my $prev = $count - 1;
     print $OUTFD "
-    if (l$count != MPI_DATATYPE_NULL && *v$prev == -1) {
-        /* When bufcount == -1, buftype must be a predefine MPI datatype.
-         * Convert Fortran MPI predefined datatype to C datatype.
+    if (l$count != MPI_DATATYPE_NULL && *v$prev == NC_COUNT_IGNORE) {
+        /* When bufcount == NC_COUNT_IGNORE, buftype must be a predefine MPI
+         * datatype. Convert Fortran MPI predefined datatype to C datatype.
          */
              if (l$count == MPI_CHARACTER)        l$count = MPI_CHAR;
         else if (l$count == MPI_INTEGER1)         l$count = MPI_SIGNED_CHAR;

--- a/src/binding/f77/pnetcdf.inc.in
+++ b/src/binding/f77/pnetcdf.inc.in
@@ -810,6 +810,10 @@
       integer NF_REQ_NULL
       PARAMETER (NF_REQ_NULL = -1)
 
+! Ignore bufcount argument in flexible APIs
+      integer NF_COUNT_IGNORE
+      PARAMETER (NF_COUNT_IGNORE = -1)
+
 ! indicate to flush all pending non-blocking requests
       integer NF_REQ_ALL
       PARAMETER (NF_REQ_ALL = -1)

--- a/src/binding/f90/nf90_constants.fh
+++ b/src/binding/f90/nf90_constants.fh
@@ -100,6 +100,9 @@
   ! NULL request for non-blocking I/O APIs
   INTEGER, PARAMETER, PUBLIC :: NF90_REQ_NULL = NF_REQ_NULL
 
+  ! Ignore bufcount argument in flexible APIs
+  INTEGER, PARAMETER, PUBLIC :: NF90_COUNT_IGNORE = NF_COUNT_IGNORE
+
   ! indicate to flush all pending non-blocking requests
   INTEGER, PARAMETER, PUBLIC :: NF90_REQ_ALL     = NF_REQ_ALL
   INTEGER, PARAMETER, PUBLIC :: NF90_GET_REQ_ALL = NF_GET_REQ_ALL

--- a/src/binding/f90/nfmpi_constants.fh.in
+++ b/src/binding/f90/nfmpi_constants.fh.in
@@ -347,6 +347,10 @@
       integer, parameter, public :: &
       NF_REQ_NULL = -1
 
+! Ignore bufcount argument in flexible APIs
+      integer, parameter, public :: &
+      NF_COUNT_IGNORE = -1
+
 ! indicate to flush all pending non-blocking requests
       integer, parameter, public :: &
       NF_REQ_ALL = -1, &

--- a/src/dispatchers/var_getput.m4
+++ b/src/dispatchers/var_getput.m4
@@ -337,9 +337,9 @@ APINAME($1,$2,$3,$4)(int ncid,
                                        IndexArgs($2));')
 
     ifelse(`$3',`',`
-    /* when bufcount == -1, buftype must be an MPI predefined datatype */
+    /* when bufcount == NC_COUNT_IGNORE, buftype must be an MPI predefined datatype */
     if (err == NC_NOERR &&
-        buftype != MPI_DATATYPE_NULL && bufcount == -1 &&
+        buftype != MPI_DATATYPE_NULL && bufcount == NC_COUNT_IGNORE &&
         buftype != MPI_CHAR          &&
         buftype != MPI_SIGNED_CHAR   && buftype != MPI_UNSIGNED_CHAR      &&
         buftype != MPI_SHORT         && buftype != MPI_UNSIGNED_SHORT     &&
@@ -482,8 +482,8 @@ NAPINAME($1,$2,$3)(int                ncid,
     }
 
     ifelse(`$2',`',`
-    /* when bufcount == -1, buftype must be an MPI predefined datatype */
-    if (buftype != MPI_DATATYPE_NULL && bufcount == -1 &&
+    /* when bufcount == NC_COUNT_IGNORE, buftype must be an MPI predefined datatype */
+    if (buftype != MPI_DATATYPE_NULL && bufcount == NC_COUNT_IGNORE &&
         buftype != MPI_CHAR          &&
         buftype != MPI_SIGNED_CHAR   && buftype != MPI_UNSIGNED_CHAR      &&
         buftype != MPI_SHORT         && buftype != MPI_UNSIGNED_SHORT     &&
@@ -605,8 +605,8 @@ MAPINAME($1,$2,$3,$4)(int                ncid,
             if (err != NC_NOERR) break;
         }')
         ifelse(`$3',`',`
-        /* when bufcounts[i] == -1, buftypes[i] must be an MPI predefined datatype */
-        if (buftypes[i] != MPI_DATATYPE_NULL && bufcounts[i] == -1 &&
+        /* when bufcounts[i] == NC_COUNT_IGNORE, buftypes[i] must be an MPI predefined datatype */
+        if (buftypes[i] != MPI_DATATYPE_NULL && bufcounts[i] == NC_COUNT_IGNORE &&
             buftypes[i] != MPI_CHAR          &&
             buftypes[i] != MPI_SIGNED_CHAR   && buftypes[i] != MPI_UNSIGNED_CHAR      &&
             buftypes[i] != MPI_SHORT         && buftypes[i] != MPI_UNSIGNED_SHORT     &&
@@ -735,8 +735,8 @@ IAPINAME($1,$2,$3)(int ncid,
     ifelse(`$3',`',`if (buftype != MPI_DATATYPE_NULL && bufcount == 0) return NC_NOERR;')
 
     ifelse(`$3',`',`
-    /* when bufcount == -1, buftype must be an MPI predefined datatype */
-    if (buftype != MPI_DATATYPE_NULL && bufcount == -1 &&
+    /* when bufcount == NC_COUNT_IGNORE, buftype must be an MPI predefined datatype */
+    if (buftype != MPI_DATATYPE_NULL && bufcount == NC_COUNT_IGNORE &&
         buftype != MPI_CHAR          &&
         buftype != MPI_SIGNED_CHAR   && buftype != MPI_UNSIGNED_CHAR      &&
         buftype != MPI_SHORT         && buftype != MPI_UNSIGNED_SHORT     &&
@@ -844,8 +844,8 @@ INAPINAME($1,$2)(int                ncid,
     ifelse(`$2',`',`if (buftype != MPI_DATATYPE_NULL && bufcount == 0) return NC_NOERR;')
 
     ifelse(`$2',`',`
-    /* when bufcount == -1, buftype must be an MPI predefined datatype */
-    if (buftype != MPI_DATATYPE_NULL && bufcount == -1 &&
+    /* when bufcount == NC_COUNT_IGNORE, buftype must be an MPI predefined datatype */
+    if (buftype != MPI_DATATYPE_NULL && bufcount == NC_COUNT_IGNORE &&
         buftype != MPI_CHAR          &&
         buftype != MPI_SIGNED_CHAR   && buftype != MPI_UNSIGNED_CHAR      &&
         buftype != MPI_SHORT         && buftype != MPI_UNSIGNED_SHORT     &&
@@ -927,9 +927,9 @@ ncmpi_$1_vard$2(int           ncid,
 
     err = sanity_check(pncp, varid, IO_TYPE($1), MPI_DATATYPE_NULL, IS_COLL($2));
 
-    /* when bufcount == -1, buftype must be an MPI predefined datatype */
+    /* when bufcount == NC_COUNT_IGNORE, buftype must be an MPI predefined datatype */
     if (err == NC_NOERR &&
-        buftype != MPI_DATATYPE_NULL && bufcount == -1 &&
+        buftype != MPI_DATATYPE_NULL && bufcount == NC_COUNT_IGNORE &&
         buftype != MPI_CHAR          &&
         buftype != MPI_SIGNED_CHAR   && buftype != MPI_UNSIGNED_CHAR      &&
         buftype != MPI_SHORT         && buftype != MPI_UNSIGNED_SHORT     &&

--- a/src/drivers/common/dtype_decode.c
+++ b/src/drivers/common/dtype_decode.c
@@ -481,9 +481,9 @@ int ncmpii_dtype_decode(MPI_Datatype  dtype,
 /*----< ncmpii_buftype_decode() >--------------------------------------------*/
 /* Obtain the following metadata about buftype:
  * etype:    element data type (MPI primitive type) in buftype
- * bufcount: If it is -1, then this is called from a high-level API and in
- *           this case buftype will be an MPI predefined data type.
- *           If bufcount is not -1, then this is called from a flexible API.
+ * bufcount: If it is NC_COUNT_IGNORE, then this is called from a high-level
+ *           API and in this case buftype must be an MPI predefined data type.
+ *           Otherwise, this is called from a flexible API.
  * nelems:   number of etypes in user buffer
  * xnbytes:  number of bytes (in external data representation) to read/write
  *           from/to the file
@@ -528,7 +528,7 @@ ncmpii_buftype_decode(int               ndims,
         *xnbytes  = *nelems * xsz;
         *isContig = 1;
     }
-    else if (bufcount == -1) {
+    else if (bufcount == NC_COUNT_IGNORE) {
         /* This is called from a high-level API, buftype must be a predefined
          * MPI datatype. This requirement has already been checked in
          * src/dispatchers/var_getput.m4

--- a/src/drivers/ncmpio/ncmpio_i_getput.m4
+++ b/src/drivers/ncmpio/ncmpio_i_getput.m4
@@ -172,7 +172,7 @@ ncmpio_igetput_varm(NC               *ncp,
         itype = xtype;
         isize = xsize;
     }
-    else if (bufcount == -1) {
+    else if (bufcount == NC_COUNT_IGNORE) {
         /* In this case, this subroutine is called from a high-level API and
          * buftype must be one of the MPI predefined datatype. We set itype to
          * buftype. itype is the MPI element type in internal representation.
@@ -583,17 +583,17 @@ define(`IGETPUT_API',dnl
  * count  NOT NULL (allocated in dispatcher when api is NC_VAR or NC_VAR1)
  * stride can be NULL only when api is NC_VAR, NC_VAR1, or NC_VARA
  * imap   can be NULL only when api is NC_VAR, NC_VAR1, NC_VARA, or NC_VARS
- * bufcount is >= 0 when called from a flexible API, is -1 when called from a
- *         high-level API and in this case buftype is an MPI primitive
- *         datatype.
- * buftype is an MPI primitive data type (corresponding to the internal data
- *         type of buf, e.g. short in ncmpi_put_short is mapped to MPI_SHORT)
- *         if called from a high-level APIs. When called from a flexible API
- *         it can be an MPI derived data type or MPI_DATATYPE_NULL. If it is
- *         MPI_DATATYPE_NULL, then it means the data type of buf in memory
- *         matches the variable external data type. In this case, bufcount is
- *         ignored.
- * reqMode indicates modes (NC_REQ_COLL/NC_REQ_INDEP/NC_REQ_WR etc.)
+ * bufcount If NC_COUNT_IGNORE, then this is called from a high-level API
+ *          and buftype must be an MPI primitive data type. Otherwise,
+ *          this is called from a flexible API.
+ * buftype  is an MPI primitive data type (corresponding to the internal data
+ *          type of buf, e.g. short in ncmpi_put_short is mapped to MPI_SHORT)
+ *          if called from a high-level APIs. When called from a flexible API
+ *          it can be an MPI derived data type or MPI_DATATYPE_NULL. If it is
+ *          MPI_DATATYPE_NULL, then it means the data type of buf in memory
+ *          matches the variable external data type. In this case, bufcount is
+ *          ignored.
+ * reqMode  indicates modes (NC_REQ_COLL/NC_REQ_INDEP/NC_REQ_WR etc.)
  */
 int
 ncmpio_i$1_var(void             *ncdp,

--- a/src/drivers/ncmpio/ncmpio_i_varn.m4
+++ b/src/drivers/ncmpio/ncmpio_i_varn.m4
@@ -108,11 +108,11 @@ igetput_varn(NC                *ncp,
     xtype = ncmpii_nc2mpitype(varp->xtype);
     MPI_Type_size(xtype, &xsize);
 
-    if (bufcount == -1) { /* buftype is an MPI primitive data type */
+    if (bufcount == NC_COUNT_IGNORE) {
         /* In this case, this subroutine is called from a high-level API.
-         * buftype is one of the MPI primitive data type. We set itype to
-         * buftype. itype is the MPI element type in internal representation.
-         * In addition, it means the user buf is contiguous.
+         * buftype is one of the MPI predefined primitive data type. We set
+         * itype to buftype. itype is the MPI element type in internal
+         * representation. In addition, it means the user buf is contiguous.
          */
         itype = buftype;
         MPI_Type_size(itype, &isize); /* buffer element size */

--- a/src/include/pnetcdf.h.in
+++ b/src/include/pnetcdf.h.in
@@ -575,6 +575,11 @@ by the desired type. */
 /* invalid nonblocking request ID and zero-length request */
 #define NC_REQ_NULL -1
 
+/* For flexible APIs, when argument bufcount is NC_COUNT_IGNORE and buftype is
+ * a predefine MPI datatype, the APIs operate as the high-level APIs.
+ */
+#define NC_COUNT_IGNORE -1
+
 /* indicate to flush all pending non-blocking requests */
 #define NC_REQ_ALL     -1
 #define NC_GET_REQ_ALL -2

--- a/test/testcases/flexible_api.f
+++ b/test/testcases/flexible_api.f
@@ -3,8 +3,8 @@
 !   See COPYRIGHT notice in top-level directory.
 !
 ! This program tests if PnetCDF handles Fortran predefine datatypes when
-! bufcount argument in the flexible APIs is -1 and buftype argument is a
-! predefined MPI datatype
+! bufcount argument in the flexible APIs is NF_COUNT_IGNORE and buftype
+! argument is a predefined MPI datatype
 !
        INTEGER FUNCTION XTRIM(STRING)
            CHARACTER*(*) STRING
@@ -211,8 +211,8 @@
           call check(err, 'In nfmpi_wait_all:')
 
           ! test blocking and nonblocking APIs when bufcount argument is
-          ! -1 and buftype argument is a predefined MPI datatype
-          bufcount = -1
+          ! NF_COUNT_IGNORE and buftype argument is a predefined MPI datatype
+          bufcount = NF_COUNT_IGNORE
 
           err = nfmpi_put_vara_all(ncid, varid, starts, counts, buf,
      +                             bufcount, MPI_INTEGER)
@@ -294,7 +294,7 @@
 
           if (rank .eq. 0) then
               msg = '*** TESTING F77 '//cmd(1:XTRIM(cmd))//
-     +              ' for bufcount=-1 & buftype predefined'
+     +              ' for bufcount=NF_COUNT_IGNORE & buftype predefined'
               call pass_fail(nerrs, msg)
           endif
 

--- a/test/testcases/flexible_var.c
+++ b/test/testcases/flexible_var.c
@@ -13,7 +13,8 @@
  *
  * The global 2D array is not partitioned.
  *
- * The local buffer on each process has ghost cells surrounded along both dimensions.
+ * The local buffer on each process has ghost cells surrounded along both
+ * dimensions.
  *
  * The compile and run commands are given below.
  *
@@ -269,9 +270,9 @@ int main(int argc, char** argv)
     CHECK_GET_BUF_GHOST(NY, NX, GHOST, buf_ghost)
 
     /*----------------------------------------------------------------------*/
-    /*---- test using bufcount == -1 with no ghost cells -------------------*/
+    /*---- test using bufcount == NC_COUNT_IGNORE with no ghost cells ------*/
     /*----------------------------------------------------------------------*/
-    bufcount = -1;
+    bufcount = NC_COUNT_IGNORE;
 
     /* initiate put buffer contents, no ghost cells */
     INIT_PUT_BUF(NY, NX, buf)
@@ -412,9 +413,9 @@ int main(int argc, char** argv)
     CHECK_GET_BUF_GHOST(NY, NX, GHOST, buf_ghost)
 
     /*----------------------------------------------------------------------*/
-    /*---- test using bufcount == -1 with no ghost cells -------------------*/
+    /*---- test using bufcount == NC_COUNT_IGNORE with no ghost cells ------*/
     /*----------------------------------------------------------------------*/
-    bufcount = -1;
+    bufcount = NC_COUNT_IGNORE;
 
     /* initiate put buffer contents, no ghost cells */
     INIT_PUT_BUF(NY, NX, buf)


### PR DESCRIPTION
* This constant is added to replace -1 used in PR #82
* In flexible APIs, when argument bufcount is NC_COUNT_IGNORE, buftype must be a predefine MPI datatype and the APIs operate as the high-level APIs.