### PR TITLE
Require autoconf 2.71, automake 1.16.5, and libtool 2.4.6

### DIFF
--- a/.github/workflows/ubuntu_mpich.yml
+++ b/.github/workflows/ubuntu_mpich.yml
@@ -24,35 +24,80 @@ jobs:
         - name: Set up dependencies
           run: |
             sudo apt-get update
-            sudo apt-get install automake autoconf libtool libtool-bin m4
-            autoconf --version
-            automake --version
-            libtool --version
+            sudo apt-get install m4
             gcc --version
+        - name: Build autoconf
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            VERSION=2.71
+            echo "Install autoconf ${VERSION} in ${GITHUB_WORKSPACE}/AUTOTOOLS"
+            rm -rf AUTOTOOLS
+            mkdir AUTOTOOLS
+            cd AUTOTOOLS
+            wget -q https://ftp.gnu.org/gnu/autoconf/autoconf-${VERSION}.tar.gz
+            gzip -dc autoconf-${VERSION}.tar.gz | tar -xf -
+            cd autoconf-${VERSION}
+            ./configure --prefix=${GITHUB_WORKSPACE}/AUTOTOOLS --silent
+            make -s -j 8 install
+            make -s distclean
+        - name: Build automake
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            VERSION=1.16.5
+            echo "Install automake ${VERSION} in ${GITHUB_WORKSPACE}/AUTOTOOLS"
+            cd AUTOTOOLS
+            wget -q https://ftp.gnu.org/gnu/automake/automake-${VERSION}.tar.gz
+            gzip -dc automake-${VERSION}.tar.gz | tar -xf -
+            cd automake-${VERSION}
+            ./configure --prefix=${GITHUB_WORKSPACE}/AUTOTOOLS --silent
+            make -s -j 8 install
+            make -s distclean
+        - name: Build libtool
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            VERSION=2.4.6
+            echo "Install libtool ${VERSION} in ${GITHUB_WORKSPACE}/AUTOTOOLS"
+            cd AUTOTOOLS
+            wget -q https://ftp.gnu.org/gnu/libtool/libtool-${VERSION}.tar.gz
+            gzip -dc libtool-${VERSION}.tar.gz | tar -xf -
+            cd libtool-${VERSION}
+            ./configure --prefix=${GITHUB_WORKSPACE}/AUTOTOOLS --silent
+            make -s -j 8 install
+            make -s distclean
         - name: Build MPICH
           run: |
-            WORKDIR=$(pwd)
-            mkdir -p ${WORKDIR}/MPICH
-            cd ${WORKDIR}/MPICH
+            cd ${GITHUB_WORKSPACE}
+            VERSION=4.0.2
+            echo "Install MPICH ${VERSION} in ${GITHUB_WORKSPACE}/MPICH"
+            rm -rf ${GITHUB_WORKSPACE}/MPICH
+            mkdir -p ${GITHUB_WORKSPACE}/MPICH
+            cd ${GITHUB_WORKSPACE}/MPICH
             # git clone -q https://github.com/pmodels/mpich.git
             # cd mpich
             # git submodule update --init
             # ./autogen.sh
-            wget -q https://www.mpich.org/static/downloads/4.0.2/mpich-4.0.2.tar.gz
-            gzip -dc mpich-4.0.2.tar.gz | tar -xf -
-            cd mpich-4.0.2
-            ./configure --prefix=${WORKDIR}/MPICH \
+            wget -q https://www.mpich.org/static/downloads/${VERSION}/mpich-${VERSION}.tar.gz
+            gzip -dc mpich-${VERSION}.tar.gz | tar -xf -
+            cd mpich-${VERSION}
+            ./configure --prefix=${GITHUB_WORKSPACE}/MPICH \
                         --silent \
                         --enable-romio \
                         --with-file-system=ufs \
                         --with-device=ch3:sock \
                         --enable-fortran \
                         CC=gcc FC=gfortran
-            make -s -j8 install
-            cd ${WORKDIR}
+            make -s LIBTOOLFLAGS=--silent V=1 -j8 install
+            make -s distclean
         - name: Build PnetCDF
           run: |
-            WORKDIR=$(pwd)
+            cd ${GITHUB_WORKSPACE}
+            export PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/bin:${GITHUB_WORKSPACE}/MPICH/bin:${PATH}"
+            which autoconf
+            autoconf --version
+            which automake
+            automake --version
+            which libtool
+            libtool --version
             autoreconf -i
             ./configure --enable-option-checking=fatal \
                         --enable-profiling \
@@ -62,33 +107,31 @@ jobs:
                         --enable-shared \
                         --enable-thread-safe \
                         --with-pthread \
-                        --with-mpi=${WORKDIR}/MPICH
+                        --with-mpi=${GITHUB_WORKSPACE}/MPICH
             make -j 8 tests
         - name: Print config.log
           if: ${{ failure() }}
           run: |
-            WORKDIR=$(pwd)
-            cat ${WORKDIR}/config.log
+            cat ${GITHUB_WORKSPACE}/config.log
         - name: make check
           run: |
             make check
         - name: Print log files
           if: ${{ failure() }}
           run: |
-            WORKDIR=$(pwd)
-            cat ${WORKDIR}/src/utils/ncvalidator/*.log
-            cat ${WORKDIR}/test/*/*.log
+            cat ${GITHUB_WORKSPACE}/src/utils/ncvalidator/*.log
+            cat ${GITHUB_WORKSPACE}/test/*/*.log
         - name: make ptests
           run: |
-            WORKDIR=$(pwd)
+            cd ${GITHUB_WORKSPACE}
             make ptests
         - name: make distcheck
           run: |
-            WORKDIR=$(pwd)
-            make distcheck DISTCHECK_CONFIGURE_FLAGS="--silent --with-mpi=${WORKDIR}/MPICH"
+            cd ${GITHUB_WORKSPACE}
+            make distcheck DISTCHECK_CONFIGURE_FLAGS="--silent --with-mpi=${GITHUB_WORKSPACE}/MPICH"
         - name: Cleanup
           if: ${{ always() }}
           run: |
             make -s distclean
-            rm -rf ${WORKDIR}/MPICH
+            rm -rf ${GITHUB_WORKSPACE}/MPICH
 

--- a/.github/workflows/ubuntu_openmpi.yml
+++ b/.github/workflows/ubuntu_openmpi.yml
@@ -24,20 +24,62 @@ jobs:
         - name: Set up dependencies
           run: |
             sudo apt-get update
-            sudo apt-get install automake autoconf libtool libtool-bin m4
+            sudo apt-get install m4
             # mpi
             sudo apt-get install openmpi-bin
             # zlib
             sudo apt-get install zlib1g-dev
-            autoconf --version
-            automake --version
-            libtool --version
             gcc --version
+        - name: Build autoconf
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            VERSION=2.71
+            echo "Install autoconf ${VERSION} in ${GITHUB_WORKSPACE}/AUTOTOOLS"
+            rm -rf AUTOTOOLS
+            mkdir AUTOTOOLS
+            cd AUTOTOOLS
+            wget -q https://ftp.gnu.org/gnu/autoconf/autoconf-${VERSION}.tar.gz
+            gzip -dc autoconf-${VERSION}.tar.gz | tar -xf -
+            cd autoconf-${VERSION}
+            ./configure --prefix=${GITHUB_WORKSPACE}/AUTOTOOLS --silent
+            make -s -j 8 install
+            make -s distclean
+        - name: Build automake
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            VERSION=1.16.5
+            echo "Install automake ${VERSION} in ${GITHUB_WORKSPACE}/AUTOTOOLS"
+            cd AUTOTOOLS
+            wget -q https://ftp.gnu.org/gnu/automake/automake-${VERSION}.tar.gz
+            gzip -dc automake-${VERSION}.tar.gz | tar -xf -
+            cd automake-${VERSION}
+            ./configure --prefix=${GITHUB_WORKSPACE}/AUTOTOOLS --silent
+            make -s -j 8 install
+            make -s distclean
+        - name: Build libtool
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            VERSION=2.4.6
+            echo "Install libtool ${VERSION} in ${GITHUB_WORKSPACE}/AUTOTOOLS"
+            cd AUTOTOOLS
+            wget -q https://ftp.gnu.org/gnu/libtool/libtool-${VERSION}.tar.gz
+            gzip -dc libtool-${VERSION}.tar.gz | tar -xf -
+            cd libtool-${VERSION}
+            ./configure --prefix=${GITHUB_WORKSPACE}/AUTOTOOLS --silent
+            make -s -j 8 install
+            make -s distclean
         - name: Build PnetCDF
           run: |
-            WORKDIR=$(pwd)
-            mkdir -p /dev/shm/pnetcdf_output
+            cd ${GITHUB_WORKSPACE}
+            export PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/bin:${GITHUB_WORKSPACE}/MPICH/bin:${PATH}"
+            which autoconf
+            autoconf --version
+            which automake
+            automake --version
+            which libtool
+            libtool --version
             autoreconf -i
+            mkdir -p /dev/shm/pnetcdf_output
             ./configure --enable-option-checking=fatal \
                         --enable-profiling \
                         pnc_ac_debug=yes \
@@ -52,8 +94,7 @@ jobs:
         - name: Print config.log
           if: ${{ failure() }}
           run: |
-            WORKDIR=$(pwd)
-            cat ${WORKDIR}/config.log
+            cat ${GITHUB_WORKSPACE}/config.log
         - name: make check
           run: |
             make check
@@ -66,8 +107,7 @@ jobs:
         - name: Print log files
           if: ${{ always() }}
           run: |
-            WORKDIR=$(pwd)
-            cat ${WORKDIR}/test/*/*.log
+            cat ${GITHUB_WORKSPACE}/test/*/*.log
         - name: Cleanup
           if: ${{ always() }}
           run: |

--- a/configure.ac
+++ b/configure.ac
@@ -12,8 +12,9 @@ dnl When using svn, we use SVN keyword Revision to copy the unique revision
 dnl number as a stamp into configure script.
 dnl AC_REVISION([$Revision$])dnl
 
-dnl autoconf v2.69 was released in 2012-04-24
-AC_PREREQ([2.69])
+dnl autoconf v2.70 and later is required. See https://github.com/Parallel-NetCDF/PnetCDF/issues/94
+dnl autoconf v2.71 was released in 2021-01-28
+AC_PREREQ([2.71])
 AC_INIT([PnetCDF],[1.12.3],[parallel-netcdf@mcs.anl.gov],[pnetcdf],[https://parallel-netcdf.github.io])
 
 dnl config.h.in will be created by autoreconf (autoheader)
@@ -40,8 +41,9 @@ dnl Note getting command line should be done before calling AM_INIT_AUTOMAKE
 dnl as AM_INIT_AUTOMAKE modifies command line $*
 CONFIGURE_ARGS_CLEAN=`echo $* | tr '"' ' '`
 
+dnl automake version 1.16.5 was released in 2021-10-03
 dnl AM_INIT_AUTOMAKE([subdir-objects])
-AM_INIT_AUTOMAKE([1.13])
+AM_INIT_AUTOMAKE([1.16.5])
 dnl enable silent rules by default
 AM_SILENT_RULES([yes])
 
@@ -430,7 +432,7 @@ dnl AC_PROG_RANLIB
 
 dnl libtool v2.4.6 was released in 2015-02-15
 dnl Travis CI only has v2.4.2
-LT_PREREQ([2.4.2])
+LT_PREREQ([2.4.6])
 dnl LT_INIT([dlopen disable-shared])
 dnl LT_INIT([dlopen])
 LT_INIT([disable-shared])

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -66,6 +66,13 @@ This is essentially a placeholder for the next release note ...
     5584d44.
 
 * Other updates:
+  + Upgrade autotool version requirement to autoconf 2.71, automake 1.16.5, and
+    libtool 2.4.6.
+    See [PR #95](https://github.com/Parallel-NetCDF/PnetCDF/pull/95)
+    Thanks to Blaise Bourdin for pointing out in
+    [Issue #94](https://github.com/Parallel-NetCDF/PnetCDF/issues/94)
+    that configure failed when using Intel OneAPI 2022.2.0 compilers. The fix
+    is to use autoconf 2.70 and newer.
   + In all prior versions, the file name was checked whether it contains
     character ':'. The prefix name ending with ':' is considered by ROMIO as
     the file system type name. The prefix name, if found, is then stripped, so


### PR DESCRIPTION
autoconf 2.70 and newer is required to fix #94
otherwise, configure fails with intel OneAPI