### PR TITLE
Thread-safe feature requires MPICH 4.0.3

### DIFF
--- a/.github/workflows/ubuntu_mpich.yml
+++ b/.github/workflows/ubuntu_mpich.yml
@@ -16,90 +16,62 @@ on:
       - '**/*.1'
       - 'docs/*'
 
+env:
+   MPICH_VERSION: 4.0.3
+
 jobs:
     build:
       runs-on: ubuntu-latest
+      timeout-minutes: 60
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Set up dependencies
           run: |
             sudo apt-get update
-            sudo apt-get install m4
+            sudo apt-get install automake autoconf libtool libtool-bin m4
+            # install gfortran
+            version=12
+            sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+            sudo apt-get update
+            sudo apt-get install -y gcc-${version} gfortran-${version}
+            sudo update-alternatives \
+              --install /usr/bin/gcc gcc /usr/bin/gcc-${version} 100 \
+              --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${version} \
+              --slave /usr/bin/gcov gcov /usr/bin/gcov-${version}
+            echo "---- gcc/gfortran version ------------------------------"
+            which gcc
+            which gfortran
             gcc --version
-        - name: Build autoconf
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            VERSION=2.71
-            echo "Install autoconf ${VERSION} in ${GITHUB_WORKSPACE}/AUTOTOOLS"
-            rm -rf AUTOTOOLS
-            mkdir AUTOTOOLS
-            cd AUTOTOOLS
-            wget -q https://ftp.gnu.org/gnu/autoconf/autoconf-${VERSION}.tar.gz
-            gzip -dc autoconf-${VERSION}.tar.gz | tar -xf -
-            cd autoconf-${VERSION}
-            ./configure --prefix=${GITHUB_WORKSPACE}/AUTOTOOLS --silent
-            make -s -j 8 install
-            make -s distclean
-        - name: Build automake
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            VERSION=1.16.5
-            echo "Install automake ${VERSION} in ${GITHUB_WORKSPACE}/AUTOTOOLS"
-            cd AUTOTOOLS
-            wget -q https://ftp.gnu.org/gnu/automake/automake-${VERSION}.tar.gz
-            gzip -dc automake-${VERSION}.tar.gz | tar -xf -
-            cd automake-${VERSION}
-            ./configure --prefix=${GITHUB_WORKSPACE}/AUTOTOOLS --silent
-            make -s -j 8 install
-            make -s distclean
-        - name: Build libtool
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            VERSION=2.4.6
-            echo "Install libtool ${VERSION} in ${GITHUB_WORKSPACE}/AUTOTOOLS"
-            cd AUTOTOOLS
-            wget -q https://ftp.gnu.org/gnu/libtool/libtool-${VERSION}.tar.gz
-            gzip -dc libtool-${VERSION}.tar.gz | tar -xf -
-            cd libtool-${VERSION}
-            ./configure --prefix=${GITHUB_WORKSPACE}/AUTOTOOLS --silent
-            make -s -j 8 install
-            make -s distclean
+            gfortran --version
         - name: Build MPICH
           run: |
             cd ${GITHUB_WORKSPACE}
-            VERSION=4.0.2
-            echo "Install MPICH ${VERSION} in ${GITHUB_WORKSPACE}/MPICH"
-            rm -rf ${GITHUB_WORKSPACE}/MPICH
-            mkdir -p ${GITHUB_WORKSPACE}/MPICH
-            cd ${GITHUB_WORKSPACE}/MPICH
+            echo "Install MPICH ${MPICH_VERSION} in ${GITHUB_WORKSPACE}/MPICH"
+            rm -rf MPICH ; mkdir MPICH ; cd MPICH
             # git clone -q https://github.com/pmodels/mpich.git
             # cd mpich
             # git submodule update --init
             # ./autogen.sh
-            wget -q https://www.mpich.org/static/downloads/${VERSION}/mpich-${VERSION}.tar.gz
-            gzip -dc mpich-${VERSION}.tar.gz | tar -xf -
-            cd mpich-${VERSION}
+            wget -q https://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz
+            gzip -dc mpich-${MPICH_VERSION}.tar.gz | tar -xf -
+            cd mpich-${MPICH_VERSION}
             ./configure --prefix=${GITHUB_WORKSPACE}/MPICH \
                         --silent \
                         --enable-romio \
                         --with-file-system=ufs \
                         --with-device=ch3:sock \
                         --enable-fortran \
-                        CC=gcc FC=gfortran
-            make -s LIBTOOLFLAGS=--silent V=1 -j8 install
-            make -s distclean
+                        CC=gcc FC=gfortran \
+                        FFLAGS=-fallow-argument-mismatch \
+                        FCFLAGS=-fallow-argument-mismatch
+            make -s LIBTOOLFLAGS=--silent V=1 -j 4 install > qout 2>&1
+            make -s -j 4 distclean >> qout 2>&1
         - name: Build PnetCDF
           run: |
             cd ${GITHUB_WORKSPACE}
-            export PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/bin:${GITHUB_WORKSPACE}/MPICH/bin:${PATH}"
-            which autoconf
-            autoconf --version
-            which automake
-            automake --version
-            which libtool
-            libtool --version
             autoreconf -i
-            ./configure --enable-option-checking=fatal \
+            ./configure --prefix=${GITHUB_WORKSPACE}/PnetCDF \
+                        --enable-option-checking=fatal \
                         --enable-profiling \
                         pnc_ac_debug=yes \
                         --enable-burst_buffering \
@@ -110,17 +82,25 @@ jobs:
                         --with-mpi=${GITHUB_WORKSPACE}/MPICH
             make -j 8 tests
         - name: Print config.log
-          if: ${{ failure() }}
+          if: ${{ always() }}
           run: |
             cat ${GITHUB_WORKSPACE}/config.log
         - name: make check
           run: |
+            cd ${GITHUB_WORKSPACE}
             make check
-        - name: Print log files
-          if: ${{ failure() }}
+        - name: Print test log files
+          if: ${{ always() }}
           run: |
-            cat ${GITHUB_WORKSPACE}/src/utils/ncvalidator/*.log
-            cat ${GITHUB_WORKSPACE}/test/*/*.log
+            cd ${GITHUB_WORKSPACE}
+            fname=`find src test examples benchmarks -type f -name "*.log"`
+            for f in $fname ; do \
+               bname=`basename $f` ; \
+               if test "x$bname" != xconfig.log ; then \
+                  echo "-------- dump $f ----------------------------" ; \
+                  cat $f ; \
+               fi ; \
+            done
         - name: make ptests
           run: |
             cd ${GITHUB_WORKSPACE}
@@ -128,10 +108,11 @@ jobs:
         - name: make distcheck
           run: |
             cd ${GITHUB_WORKSPACE}
-            make distcheck DISTCHECK_CONFIGURE_FLAGS="--silent --with-mpi=${GITHUB_WORKSPACE}/MPICH"
+            make -j 8 distcheck DISTCHECK_CONFIGURE_FLAGS="--silent --with-mpi=${GITHUB_WORKSPACE}/MPICH"
         - name: Cleanup
           if: ${{ always() }}
           run: |
+            cd ${GITHUB_WORKSPACE}
             make -s distclean
             rm -rf ${GITHUB_WORKSPACE}/MPICH
 

--- a/.github/workflows/ubuntu_openmpi.yml
+++ b/.github/workflows/ubuntu_openmpi.yml
@@ -19,65 +19,22 @@ on:
 jobs:
     build:
       runs-on: ubuntu-latest
+      timeout-minutes: 60
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Set up dependencies
           run: |
             sudo apt-get update
-            sudo apt-get install m4
-            # mpi
-            sudo apt-get install openmpi-bin
+            sudo apt-get install automake autoconf libtool libtool-bin m4
             # zlib
             sudo apt-get install zlib1g-dev
-            gcc --version
-        - name: Build autoconf
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            VERSION=2.71
-            echo "Install autoconf ${VERSION} in ${GITHUB_WORKSPACE}/AUTOTOOLS"
-            rm -rf AUTOTOOLS
-            mkdir AUTOTOOLS
-            cd AUTOTOOLS
-            wget -q https://ftp.gnu.org/gnu/autoconf/autoconf-${VERSION}.tar.gz
-            gzip -dc autoconf-${VERSION}.tar.gz | tar -xf -
-            cd autoconf-${VERSION}
-            ./configure --prefix=${GITHUB_WORKSPACE}/AUTOTOOLS --silent
-            make -s -j 8 install
-            make -s distclean
-        - name: Build automake
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            VERSION=1.16.5
-            echo "Install automake ${VERSION} in ${GITHUB_WORKSPACE}/AUTOTOOLS"
-            cd AUTOTOOLS
-            wget -q https://ftp.gnu.org/gnu/automake/automake-${VERSION}.tar.gz
-            gzip -dc automake-${VERSION}.tar.gz | tar -xf -
-            cd automake-${VERSION}
-            ./configure --prefix=${GITHUB_WORKSPACE}/AUTOTOOLS --silent
-            make -s -j 8 install
-            make -s distclean
-        - name: Build libtool
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            VERSION=2.4.6
-            echo "Install libtool ${VERSION} in ${GITHUB_WORKSPACE}/AUTOTOOLS"
-            cd AUTOTOOLS
-            wget -q https://ftp.gnu.org/gnu/libtool/libtool-${VERSION}.tar.gz
-            gzip -dc libtool-${VERSION}.tar.gz | tar -xf -
-            cd libtool-${VERSION}
-            ./configure --prefix=${GITHUB_WORKSPACE}/AUTOTOOLS --silent
-            make -s -j 8 install
-            make -s distclean
+            # mpi
+            sudo apt-get install openmpi-bin openmpi-common libopenmpi-dev libgtk2.0-dev
+            echo "---- location of OpenMPI C compiler ----"
+            which mpicc
         - name: Build PnetCDF
           run: |
             cd ${GITHUB_WORKSPACE}
-            export PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/bin:${GITHUB_WORKSPACE}/MPICH/bin:${PATH}"
-            which autoconf
-            autoconf --version
-            which automake
-            automake --version
-            which libtool
-            libtool --version
             autoreconf -i
             mkdir -p /dev/shm/pnetcdf_output
             ./configure --enable-option-checking=fatal \
@@ -92,25 +49,37 @@ jobs:
                         TESTOUTDIR=/dev/shm/pnetcdf_output
             make -j 8 tests
         - name: Print config.log
-          if: ${{ failure() }}
+          if: ${{ always() }}
           run: |
             cat ${GITHUB_WORKSPACE}/config.log
         - name: make check
           run: |
+            cd ${GITHUB_WORKSPACE}
             make check
+        - name: Print test log files
+          if: ${{ always() }}
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            fname=`find src test examples benchmarks -type f -name "*.log"`
+            for f in $fname ; do \
+               bname=`basename $f` ; \
+               if test "x$bname" != xconfig.log ; then \
+                  echo "-------- dump $f ----------------------------" ; \
+                  cat $f ; \
+               fi ; \
+            done
         - name: make ptests
           run: |
+            cd ${GITHUB_WORKSPACE}
             make ptests
         - name: make distcheck
           run: |
-            make distcheck DISTCHECK_CONFIGURE_FLAGS="--silent TESTOUTDIR=/dev/shm/pnetcdf_output"
-        - name: Print log files
-          if: ${{ always() }}
-          run: |
-            cat ${GITHUB_WORKSPACE}/test/*/*.log
+            cd ${GITHUB_WORKSPACE}
+            make -j 8 distcheck DISTCHECK_CONFIGURE_FLAGS="--silent TESTOUTDIR=/dev/shm/pnetcdf_output"
         - name: Cleanup
           if: ${{ always() }}
           run: |
+            cd ${GITHUB_WORKSPACE}
             make -s distclean
             rm -rf /dev/shm/pnetcdf_output
 

--- a/configure.ac
+++ b/configure.ac
@@ -1664,6 +1664,18 @@ AC_ARG_ENABLE([thread-safe],
 )
 ENABLE_THREAD_SAFE=0
 if test "x${thread_safe}" = xyes ; then
+   if test "x${ax_cv_mpi_compiler_vendor}" = xMPICH ; then
+      AX_COMPARE_VERSION([${ax_cv_mpi_compiler_version}],[ge],[4.0.3])
+      if test "$ax_compare_version" = "false" ; then
+         AC_MSG_ERROR([
+         -----------------------------------------------------------------------
+           Thread-safety feature, --enable-thread-safe, requires MPICH version
+           4.0.3 and later. The version of provided MPICH is $ax_cv_mpi_compiler_version.
+           See bug fix in https://github.com/pmodels/mpich/pull/5954
+           Abort.
+         -----------------------------------------------------------------------])
+      fi
+   fi
    AC_DEFINE(ENABLE_THREAD_SAFE)
    ENABLE_THREAD_SAFE=1
 fi

--- a/m4/ax_compare_version.m4
+++ b/m4/ax_compare_version.m4
@@ -1,0 +1,177 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_compare_version.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_COMPARE_VERSION(VERSION_A, OP, VERSION_B, [ACTION-IF-TRUE], [ACTION-IF-FALSE])
+#
+# DESCRIPTION
+#
+#   This macro compares two version strings. Due to the various number of
+#   minor-version numbers that can exist, and the fact that string
+#   comparisons are not compatible with numeric comparisons, this is not
+#   necessarily trivial to do in a autoconf script. This macro makes doing
+#   these comparisons easy.
+#
+#   The six basic comparisons are available, as well as checking equality
+#   limited to a certain number of minor-version levels.
+#
+#   The operator OP determines what type of comparison to do, and can be one
+#   of:
+#
+#    eq  - equal (test A == B)
+#    ne  - not equal (test A != B)
+#    le  - less than or equal (test A <= B)
+#    ge  - greater than or equal (test A >= B)
+#    lt  - less than (test A < B)
+#    gt  - greater than (test A > B)
+#
+#   Additionally, the eq and ne operator can have a number after it to limit
+#   the test to that number of minor versions.
+#
+#    eq0 - equal up to the length of the shorter version
+#    ne0 - not equal up to the length of the shorter version
+#    eqN - equal up to N sub-version levels
+#    neN - not equal up to N sub-version levels
+#
+#   When the condition is true, shell commands ACTION-IF-TRUE are run,
+#   otherwise shell commands ACTION-IF-FALSE are run. The environment
+#   variable 'ax_compare_version' is always set to either 'true' or 'false'
+#   as well.
+#
+#   Examples:
+#
+#     AX_COMPARE_VERSION([3.15.7],[lt],[3.15.8])
+#     AX_COMPARE_VERSION([3.15],[lt],[3.15.8])
+#
+#   would both be true.
+#
+#     AX_COMPARE_VERSION([3.15.7],[eq],[3.15.8])
+#     AX_COMPARE_VERSION([3.15],[gt],[3.15.8])
+#
+#   would both be false.
+#
+#     AX_COMPARE_VERSION([3.15.7],[eq2],[3.15.8])
+#
+#   would be true because it is only comparing two minor versions.
+#
+#     AX_COMPARE_VERSION([3.15.7],[eq0],[3.15])
+#
+#   would be true because it is only comparing the lesser number of minor
+#   versions of the two values.
+#
+#   Note: The characters that separate the version numbers do not matter. An
+#   empty string is the same as version 0. OP is evaluated by autoconf, not
+#   configure, so must be a string, not a variable.
+#
+#   The author would like to acknowledge Guido Draheim whose advice about
+#   the m4_case and m4_ifvaln functions make this macro only include the
+#   portions necessary to perform the specific comparison specified by the
+#   OP argument in the final configure script.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Tim Toolan <toolan@ele.uri.edu>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 13
+
+dnl #########################################################################
+AC_DEFUN([AX_COMPARE_VERSION], [
+  AC_REQUIRE([AC_PROG_AWK])
+
+  # Used to indicate true or false condition
+  ax_compare_version=false
+
+  # Convert the two version strings to be compared into a format that
+  # allows a simple string comparison.  The end result is that a version
+  # string of the form 1.12.5-r617 will be converted to the form
+  # 0001001200050617.  In other words, each number is zero padded to four
+  # digits, and non digits are removed.
+  AS_VAR_PUSHDEF([A],[ax_compare_version_A])
+  A=`echo "$1" | sed -e 's/\([[0-9]]*\)/Z\1Z/g' \
+                     -e 's/Z\([[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([[0-9]][[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([[0-9]][[0-9]][[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/[[^0-9]]//g'`
+
+  AS_VAR_PUSHDEF([B],[ax_compare_version_B])
+  B=`echo "$3" | sed -e 's/\([[0-9]]*\)/Z\1Z/g' \
+                     -e 's/Z\([[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([[0-9]][[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([[0-9]][[0-9]][[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/[[^0-9]]//g'`
+
+  dnl # In the case of le, ge, lt, and gt, the strings are sorted as necessary
+  dnl # then the first line is used to determine if the condition is true.
+  dnl # The sed right after the echo is to remove any indented white space.
+  m4_case(m4_tolower($2),
+  [lt],[
+    ax_compare_version=`echo "x$A
+x$B" | sed 's/^ *//' | sort -r | sed "s/x${A}/false/;s/x${B}/true/;1q"`
+  ],
+  [gt],[
+    ax_compare_version=`echo "x$A
+x$B" | sed 's/^ *//' | sort | sed "s/x${A}/false/;s/x${B}/true/;1q"`
+  ],
+  [le],[
+    ax_compare_version=`echo "x$A
+x$B" | sed 's/^ *//' | sort | sed "s/x${A}/true/;s/x${B}/false/;1q"`
+  ],
+  [ge],[
+    ax_compare_version=`echo "x$A
+x$B" | sed 's/^ *//' | sort -r | sed "s/x${A}/true/;s/x${B}/false/;1q"`
+  ],[
+    dnl Split the operator from the subversion count if present.
+    m4_bmatch(m4_substr($2,2),
+    [0],[
+      # A count of zero means use the length of the shorter version.
+      # Determine the number of characters in A and B.
+      ax_compare_version_len_A=`echo "$A" | $AWK '{print(length)}'`
+      ax_compare_version_len_B=`echo "$B" | $AWK '{print(length)}'`
+
+      # Set A to no more than B's length and B to no more than A's length.
+      A=`echo "$A" | sed "s/\(.\{$ax_compare_version_len_B\}\).*/\1/"`
+      B=`echo "$B" | sed "s/\(.\{$ax_compare_version_len_A\}\).*/\1/"`
+    ],
+    [[0-9]+],[
+      # A count greater than zero means use only that many subversions
+      A=`echo "$A" | sed "s/\(\([[0-9]]\{4\}\)\{m4_substr($2,2)\}\).*/\1/"`
+      B=`echo "$B" | sed "s/\(\([[0-9]]\{4\}\)\{m4_substr($2,2)\}\).*/\1/"`
+    ],
+    [.+],[
+      AC_WARNING(
+        [invalid OP numeric parameter: $2])
+    ],[])
+
+    # Pad zeros at end of numbers to make same length.
+    ax_compare_version_tmp_A="$A`echo $B | sed 's/./0/g'`"
+    B="$B`echo $A | sed 's/./0/g'`"
+    A="$ax_compare_version_tmp_A"
+
+    # Check for equality or inequality as necessary.
+    m4_case(m4_tolower(m4_substr($2,0,2)),
+    [eq],[
+      test "x$A" = "x$B" && ax_compare_version=true
+    ],
+    [ne],[
+      test "x$A" != "x$B" && ax_compare_version=true
+    ],[
+      AC_WARNING([invalid OP parameter: $2])
+    ])
+  ])
+
+  AS_VAR_POPDEF([A])dnl
+  AS_VAR_POPDEF([B])dnl
+
+  dnl # Execute ACTION-IF-TRUE / ACTION-IF-FALSE.
+  if test "$ax_compare_version" = "true" ; then
+    m4_ifvaln([$4],[$4],[:])dnl
+    m4_ifvaln([$5],[else $5])dnl
+  fi
+]) dnl AX_COMPARE_VERSION

--- a/m4/check_mpi.m4
+++ b/m4/check_mpi.m4
@@ -260,20 +260,28 @@ AC_DEFUN([CHECK_MPI_VERSION],[
    # `echo $version_str | ${GREP} MVAPICH2_VERSION`. Instead, we can use
    # version=`${GREP} MPICH_VERSION <<< "$version_str" | cut -d' ' -d'"' -f2`
 
+   ax_cv_mpi_compiler_vendor=
+   ax_cv_mpi_compiler_version=
    # Note MVAPICH2's mpi.h also defines MPICH_VERSION, so this check must be
    # done before MPICH.
    if test -f saved_conftest.i ; then
       if test "x$ac_cv_have_decl_MVAPICH2_VERSION" = xyes ; then
          mvapich2_version=`${GREP} MVAPICH2_VERSION saved_conftest.i | cut -d' ' -d'"' -f2`
          AC_MSG_RESULT(MVAPICH2 $mvapich2_version)
+         ax_cv_mpi_compiler_vendor=MVAPICH2
+         ax_cv_mpi_compiler_version=$mvapich2_version
          unset mvapich2_version
       elif test "x$ac_cv_have_decl_MPICH_VERSION" = xyes ; then
          mpich_version=`${GREP} MPICH_VERSION saved_conftest.i | cut -d' ' -d'"' -f2`
          AC_MSG_RESULT(MPICH $mpich_version)
+         ax_cv_mpi_compiler_vendor=MPICH
+         ax_cv_mpi_compiler_version=$mpich_version
          unset mpich_version
       elif test "x$ac_cv_have_decl_MPICH2_VERSION" = xyes ; then
          mpich2_version=`${GREP} MPICH2_VERSION saved_conftest.i | cut -d' ' -d'"' -f2`
          AC_MSG_RESULT(MPICH2 $mpich2_version)
+         ax_cv_mpi_compiler_vendor=MPICH2
+         ax_cv_mpi_compiler_version=$mpich2_version
          unset mpich2_version
       elif test "x$ac_cv_have_decl_OMPI_MAJOR_VERSION" = xyes ; then
          # AC_COMPUTE_INT([OMPI_MAJOR], [OMPI_MAJOR_VERSION], [[#include <mpi.h>]])
@@ -284,6 +292,8 @@ AC_DEFUN([CHECK_MPI_VERSION],[
          OMPI_RELEASE=`${GREP} OMPI_RELEASE_VERSION saved_conftest.i | cut -d' ' -f3`
          ompi_version="${OMPI_MAJOR}.${OMPI_MINOR}.${OMPI_RELEASE}"
          AC_MSG_RESULT(OpenMPI $ompi_version)
+         ax_cv_mpi_compiler_vendor=OpenMPI
+         ax_cv_mpi_compiler_version=$ompi_version
          unset OMPI_MAJOR
          unset OMPI_MINOR
          unset OMPI_RELEASE


### PR DESCRIPTION
An error message below may occur, which indicates ROMIO tries to free yylval, a global variable, multiple times.
  Attempt to free null pointer in file adio/common/cb_config_list.c, line 323
  application called MPI_Abort(MPI_COMM_WORLD, 1) - process 0

See bug fix in https://github.com/pmodels/mpich/pull/5954