### PR TITLE
truncate file size after ncmpi_del_att

### DIFF
--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -61,6 +61,17 @@ This is essentially a placeholder for the next release note ...
   + none
 
 * Updated utility program
+  + ncvalidator - When the file size is larger and smaller than expected, the
+    file may still be a valid netCDF file.
+    * When larger, this can happen if opening an existing file that contains no
+      variable. Deleting a global attribute reduces the file header size. The
+      file is still a valid netCDF file. PR #99 detects this mismatch and
+      truncates the file size to the header size.
+    * When smaller, this can happen if the last variable is partially written.
+      The expected file size is calculated based on the full sizes of all
+      variables. The file is still a valid netCDF file.
+    * In the former case, PR #99 changes ncvalidator to report a warning,
+      rather than an error.
   + ncvalidator - Add printing of the dimension size of a variable when its
     size is larger than the limitation allowed by the file format. See commit
     5584d44.
@@ -99,6 +110,7 @@ This is essentially a placeholder for the next release note ...
   + none
 
 * New test program
+  + test/testcases/tst_del_attr.c - test delete attributes. See PR #99.
   + test/testcases/test_get_varn.c - test get_varn API. See PR #90.
   + test/testcases/flexible_var.c - test flexible var API
   + test/testcases/flexible_api.f - test flexible API when bufcount == -1

--- a/src/utils/ncvalidator/ncvalidator.c
+++ b/src/utils/ncvalidator/ncvalidator.c
@@ -6,10 +6,10 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/types.h>  /* open() */
-#include <sys/stat.h>   /* open() */
+#include <sys/types.h>  /* open(), fstat() */
+#include <sys/stat.h>   /* open(), fstat() */
 #include <fcntl.h>      /* open() */
-#include <unistd.h>     /* read(), getopt() */
+#include <unistd.h>     /* read(), getopt(), fstat() */
 #include <string.h>     /* strcpy(), strncpy() */
 #include <inttypes.h>   /* check for Endianness, uint32_t*/
 #include <assert.h>
@@ -2637,7 +2637,7 @@ int main(int argc, char **argv)
     /* class file format: CDF-1, 2 or 5 */
     fmt = ncp->format;
 
-    /* check data size */
+    /* check file size */
     if (-1 == fstat(fd, &ncfilestat)) {
         if (verbose) printf("Error at line %d fstat (%s)\n",__LINE__,strerror(errno));
         status = NC_EFILE;
@@ -2647,10 +2647,10 @@ int main(int argc, char **argv)
         long long expect_fsize;
         expect_fsize = ncp->begin_rec + ncp->recsize * ncp->numrecs;
         if (expect_fsize < ncfilestat.st_size) {
-            if (verbose) printf("Error: file size (%lld) is larger than expected (%lld)!\n",(long long)ncfilestat.st_size, expect_fsize);
-            if (verbose) printf("\tbegin_rec=%lld recsize=%lld numrecs=%lld ncfilestat.st_size=%lld\n",ncp->begin_rec, ncp->recsize, ncp->numrecs, (long long) ncfilestat.st_size);
-            status = NC_EFILE;
-            goto prog_exit;
+            if (verbose) {
+                printf("Warning: file size (%lld) is larger than expected (%lld)!\n",(long long)ncfilestat.st_size, expect_fsize);
+                printf("\tbegin_rec=%lld recsize=%lld numrecs=%lld ncfilestat.st_size=%lld\n",ncp->begin_rec, ncp->recsize, ncp->numrecs, (long long) ncfilestat.st_size);
+            }
         }
         else if (expect_fsize > ncfilestat.st_size) {
             /* if file header are valid and the only error is the file size
@@ -2674,10 +2674,10 @@ int main(int argc, char **argv)
             expect_fsize = MAX(expect_fsize, var_end);
         }
         if (expect_fsize < ncfilestat.st_size) {
-            if (verbose) printf("Error:\n");
-            if (verbose) printf("\tfile size (%lld) is larger than expected (%lld)!\n",(long long)ncfilestat.st_size, expect_fsize);
-            status = NC_EFILE;
-            goto prog_exit;
+            if (verbose) {
+                printf("Warning:\n");
+                printf("\tfile size (%lld) is larger than expected (%lld)!\n",(long long)ncfilestat.st_size, expect_fsize);
+            }
         }
         else if (expect_fsize > ncfilestat.st_size) {
             /* if file header are valid and the only error is the file size

--- a/test/testcases/Makefile.am
+++ b/test/testcases/Makefile.am
@@ -74,7 +74,8 @@ TESTPROGRAMS = ncmpi_vars_null_stride \
                error_precedence \
                tst_free_comm \
                flexible_var \
-	       test_get_varn
+	       test_get_varn \
+	       tst_del_attr
 
 M4_SRCS      = put_all_kinds.m4 \
                erange_fill.m4 \

--- a/test/testcases/tst_del_attr.c
+++ b/test/testcases/tst_del_attr.c
@@ -1,0 +1,157 @@
+/*
+ *  Copyright (C) 2015, Northwestern University and Argonne National Laboratory
+ *  See COPYRIGHT notice in top-level directory.
+ *
+ *  $Id$
+ */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * This program tests conflicted in-memory data types against external data
+ * types and see if the correct error codes were returned.
+ *
+ * The compile and run commands are given below.
+ *
+ *    % mpicc -g -o check_type check_type.c -lpnetcdf
+ *
+ *    % mpiexec -l -n 1 check_type testfile.nc
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h> /* strcasecmp() */
+#include <libgen.h> /* basename() */
+#include <pnetcdf.h>
+
+#include <testutils.h>
+
+#define ATTR_EXP_ERR(expect_err,name) { \
+    if (err != expect_err) { \
+        printf("Error at line %d in %s: attr=%s err=%s\n", \
+               __LINE__,__FILE__,name,ncmpi_strerrno(err)); \
+        nerrs++; \
+    }  \
+}
+
+static int
+tst_fmt(char *filename, int cmode)
+{
+    char *attr_name[12] = {"attr_NC_NAT",
+                           "attr_NC_BYTE",
+                           "attr_NC_CHAR",
+                           "attr_NC_SHORT",
+                           "attr_NC_INT",
+                           "attr_NC_FLOAT",
+                           "attr_NC_DOUBLE",
+                           "attr_NC_UBYTE",
+                           "attr_NC_USHORT",
+                           "attr_NC_UINT",
+                           "attr_NC_INT64",
+                           "attr_NC_UINT64"};
+    char buf[1024];
+    int i, j, err, nerrs=0, ncid, max_type;
+
+    if (cmode == 0 || cmode == NC_64BIT_OFFSET || cmode & NC_CLASSIC_MODEL)
+        max_type = NC_DOUBLE;
+    else
+        max_type = NC_UINT64;
+
+    for (i=0; i<1024; i++) buf[i]=0;
+
+    for (i=NC_BYTE; i<=max_type; i++) {
+        /* create a new file (or truncate it to 0 length) */
+        cmode |= NC_CLOBBER;
+        err = ncmpi_create(MPI_COMM_WORLD, filename, cmode, MPI_INFO_NULL, &ncid); CHECK_ERR
+
+        if (i == NC_CHAR) {
+            for (j=0; j<3; j++) buf[j]='a'+j;
+            err = ncmpi_put_att_text(ncid, NC_GLOBAL, attr_name[i], 3, buf); CHECK_ERR
+        }
+        else
+            err = ncmpi_put_att(ncid, NC_GLOBAL, attr_name[i], i, 3, buf); CHECK_ERR
+        ATTR_EXP_ERR(NC_NOERR, attr_name[i])
+
+        err = ncmpi_close(ncid); CHECK_ERR
+
+        /* reopen the file */
+        err = ncmpi_open(MPI_COMM_WORLD, filename, NC_WRITE, MPI_INFO_NULL, &ncid); CHECK_ERR
+        err = ncmpi_redef(ncid); CHECK_ERR
+
+        err = ncmpi_del_att(ncid, NC_GLOBAL, attr_name[i]); CHECK_ERR
+        ATTR_EXP_ERR(NC_NOERR, attr_name[i])
+
+        err = ncmpi_close(ncid); CHECK_ERR
+
+        /* This deletion of attribute will make the file size larger than
+         * expected, i.e. larger than if no attribute is ever created. It is
+         * not a fatal error. The file is still a valid NetCDF file. We should
+         * expect running ncvalidator to print a warning message, such as
+         * "file size (80) is larger than expected (48)!"
+         */
+    }
+    return nerrs;
+}
+
+int main(int argc, char* argv[])
+{
+    char filename[256], *hint_value;
+    int err, nerrs=0, rank, bb_enabled=0;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if (argc > 2) {
+        if (!rank) printf("Usage: %s [filename]\n",argv[0]);
+        MPI_Finalize();
+        return 1;
+    }
+    if (argc == 2) snprintf(filename, 256, "%s", argv[1]);
+    else           strcpy(filename, "testfile.nc");
+    MPI_Bcast(filename, 256, MPI_CHAR, 0, MPI_COMM_WORLD);
+
+    if (rank == 0) {
+        char *cmd_str = (char*)malloc(strlen(argv[0]) + 256);
+        sprintf(cmd_str, "*** TESTING C   %s for testing delete attr ", basename(argv[0]));
+        printf("%-66s ------ ", cmd_str); fflush(stdout);
+        free(cmd_str);
+    }
+
+    /* check whether burst buffering is enabled */
+    if (inq_env_hint("nc_burst_buf", &hint_value)) {
+        if (strcasecmp(hint_value, "enable") == 0) bb_enabled = 1;
+        free(hint_value);
+    }
+
+    nerrs += tst_fmt(filename, 0);
+    nerrs += tst_fmt(filename, NC_64BIT_OFFSET);
+    if (!bb_enabled) {
+#ifdef ENABLE_NETCDF4
+        nerrs += tst_fmt(filename, NC_NETCDF4);
+        nerrs += tst_fmt(filename, NC_NETCDF4 | NC_CLASSIC_MODEL);
+#endif
+    }
+    nerrs += tst_fmt(filename, NC_64BIT_DATA);
+
+    /* check if PnetCDF freed all internal malloc */
+    MPI_Offset malloc_size, sum_size;
+    err = ncmpi_inq_malloc_size(&malloc_size);
+    if (err == NC_NOERR) {
+        MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
+        if (rank == 0 && sum_size > 0)
+            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+                   sum_size);
+        if (malloc_size > 0) ncmpi_inq_malloc_list();
+    }
+
+    MPI_Allreduce(MPI_IN_PLACE, &nerrs, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    if (rank == 0) {
+        if (nerrs) printf(FAIL_STR,nerrs);
+        else       printf(PASS_STR);
+    }
+
+    MPI_Finalize();
+
+    return (nerrs > 0);
+}
+


### PR DESCRIPTION
When a file contains no variables and an existing attribute is deleted,
the file size can be larger than the header size. This PR truncates the
file size to the header size.

In addition, ncvalidator should treats such an unmatched file size as a
warning, rather than an error, because the file is still a valid netCDF file.