### PR TITLE
Add new hint nc_header_collective

### DIFF
--- a/benchmarks/C/parallel_run.sh
+++ b/benchmarks/C/parallel_run.sh
@@ -26,6 +26,9 @@ fi
 
 for i in ${check_PROGRAMS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
 
@@ -40,12 +43,13 @@ for i in ${check_PROGRAMS} ; do
 
         if test "x${ENABLE_BURST_BUFFER}" = x1 ; then
            # echo "test burst buffering feature"
-           export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
+           saved_PNETCDF_HINTS=${PNETCDF_HINTS}
+           export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
            ${MPIRUN} ./$i -q -l 10 ${TESTOUTDIR}/$i.bb.nc
            if test $? = 0 ; then
               echo "PASS:  C  parallel run on $1 processes --------------- $i"
            fi
-           unset PNETCDF_HINTS
+           export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
            # echo "--- validating file ${TESTOUTDIR}/$i.bb.nc"
            ${TESTSEQRUN} ${VALIDATOR} -q ${TESTOUTDIR}/$i.bb.nc

--- a/benchmarks/FLASH-IO/parallel_run.sh
+++ b/benchmarks/FLASH-IO/parallel_run.sh
@@ -26,6 +26,9 @@ fi
 
 for i in ${check_PROGRAMS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
 
@@ -47,12 +50,13 @@ for i in ${check_PROGRAMS} ; do
 
         if test "x${ENABLE_BURST_BUFFER}" = x1 ; then
            # echo "test burst buffering feature"
-           export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
+           saved_PNETCDF_HINTS=${PNETCDF_HINTS}
+           export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
            ${MPIRUN} ./$i -q ${TESTOUTDIR}/$i.bb.
            if test $? = 0 ; then
               echo "PASS: F90 parallel run on $1 processes --------------- $i"
            fi
-           unset PNETCDF_HINTS
+           export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
            # echo "--- validating file ${TESTOUTDIR}/$i.bb.ncmpi_chk_0000.nc"
            ${TESTSEQRUN} ${VALIDATOR} -q ${TESTOUTDIR}/$i.bb.ncmpi_chk_0000.nc

--- a/examples/C/get_info.c
+++ b/examples/C/get_info.c
@@ -15,7 +15,7 @@
  *
  *    Example standard output:
 
-    MPI File Info: nkeys = 18
+    MPI File Info: nkeys = 27
     MPI File Info: [ 0] key =            cb_buffer_size, value = 16777216
     MPI File Info: [ 1] key =             romio_cb_read, value = automatic
     MPI File Info: [ 2] key =            romio_cb_write, value = automatic
@@ -30,10 +30,19 @@
     MPI File Info: [11] key =        ind_wr_buffer_size, value = 524288
     MPI File Info: [12] key =             romio_ds_read, value = automatic
     MPI File Info: [13] key =            romio_ds_write, value = automatic
-    MPI File Info: [14] key =            cb_config_list, value = *:1
-    MPI File Info: [15] key =      nc_header_align_size, value = 512
-    MPI File Info: [16] key =         nc_var_align_size, value = 512
-    MPI File Info: [17] key = nc_header_read_chunk_size, value = 0
+    MPI File Info: [14] key =  romio_synchronized_flush, value = disabled
+    MPI File Info: [15] key =            cb_config_list, value = *:1
+    MPI File Info: [16] key =     romio_filesystem_type, value = UFS: Generic ROMIO driver for all UNIX-like file systems
+    MPI File Info: [17] key =     romio_aggregator_list, value = 0
+    MPI File Info: [18] key =      nc_header_align_size, value = 512
+    MPI File Info: [19] key =         nc_var_align_size, value = 4
+    MPI File Info: [20] key =      nc_record_align_size, value = 4
+    MPI File Info: [21] key = nc_header_read_chunk_size, value = 262144
+    MPI File Info: [22] key =          nc_in_place_swap, value = auto
+    MPI File Info: [23] key =              nc_ibuf_size, value = 16777216
+    MPI File Info: [24] key =         pnetcdf_subfiling, value = disable
+    MPI File Info: [25] key =           nc_num_subfiles, value = 0
+    MPI File Info: [26] key =      nc_header_collective, value = false
  */
 
 #include <stdio.h>

--- a/examples/C/parallel_run.sh
+++ b/examples/C/parallel_run.sh
@@ -29,6 +29,9 @@ fi
 
 for i in ${check_PROGRAMS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
 
@@ -59,7 +62,8 @@ for i in ${check_PROGRAMS} ; do
 
         if test "x${ENABLE_BURST_BUFFER}" = x1 ; then
            # echo "test burst buffering feature"
-           export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
+           saved_PNETCDF_HINTS=${PNETCDF_HINTS}
+           export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
            if test $i = get_vara ; then
               ${MPIRUN} ./$i -q ${TESTOUTDIR}/put_vara.bb.nc
            else
@@ -68,7 +72,7 @@ for i in ${check_PROGRAMS} ; do
            if test $? = 0 ; then
               echo "PASS:  C  parallel run on $1 processes --------------- $i"
            fi
-           unset PNETCDF_HINTS
+           export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
            if test $i != get_vara ; then
               # echo "--- validating file ${TESTOUTDIR}/$i.bb.nc"

--- a/examples/CXX/parallel_run.sh
+++ b/examples/CXX/parallel_run.sh
@@ -29,6 +29,9 @@ fi
 
 for i in ${check_PROGRAMS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
 
@@ -57,7 +60,8 @@ for i in ${check_PROGRAMS} ; do
 
         if test "x${ENABLE_BURST_BUFFER}" = x1 ; then
            # echo "test burst buffering feature"
-           export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
+           saved_PNETCDF_HINTS=${PNETCDF_HINTS}
+           export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
            if test $i = get_vara ; then
               ${MPIRUN} ./$i -q ${TESTOUTDIR}/put_vara.bb.nc
            else
@@ -66,7 +70,7 @@ for i in ${check_PROGRAMS} ; do
            if test $? = 0 ; then
               echo "PASS: CXX parallel run on $1 processes --------------- $i"
            fi
-           unset PNETCDF_HINTS
+           export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
            if test $i != get_vara ; then
               # echo "--- validating file ${TESTOUTDIR}/$i.bb.nc"

--- a/examples/F77/parallel_run.sh
+++ b/examples/F77/parallel_run.sh
@@ -29,6 +29,9 @@ fi
 
 for i in ${check_PROGRAMS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
 
@@ -57,7 +60,8 @@ for i in ${check_PROGRAMS} ; do
 
         if test "x${ENABLE_BURST_BUFFER}" = x1 ; then
            # echo "test burst buffering feature"
-           export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
+           saved_PNETCDF_HINTS=${PNETCDF_HINTS}
+           export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
            if test $i = get_vara ; then
               ${MPIRUN} ./$i -q ${TESTOUTDIR}/put_vara.bb.nc
            else
@@ -66,7 +70,7 @@ for i in ${check_PROGRAMS} ; do
            if test $? = 0 ; then
               echo "PASS: F77 parallel run on $1 processes --------------- $i"
            fi
-           unset PNETCDF_HINTS
+           export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
            if test $i != get_vara ; then
               # echo "--- validating file ${TESTOUTDIR}/$i.bb.nc"

--- a/examples/F90/parallel_run.sh
+++ b/examples/F90/parallel_run.sh
@@ -29,6 +29,9 @@ fi
 
 for i in ${check_PROGRAMS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
 
@@ -57,7 +60,8 @@ for i in ${check_PROGRAMS} ; do
 
         if test "x${ENABLE_BURST_BUFFER}" = x1 ; then
            # echo "test burst buffering feature"
-           export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
+           saved_PNETCDF_HINTS=${PNETCDF_HINTS}
+           export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
            if test $i = get_vara ; then
               ${MPIRUN} ./$i -q ${TESTOUTDIR}/put_vara.bb.nc
            else
@@ -66,7 +70,7 @@ for i in ${check_PROGRAMS} ; do
            if test $? = 0 ; then
               echo "PASS: F90 parallel run on $1 processes --------------- $i"
            fi
-           unset PNETCDF_HINTS
+           export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
            if test $i != get_vara ; then
               # echo "--- validating file ${TESTOUTDIR}/$i.bb.nc"

--- a/examples/adios/parallel_run.sh
+++ b/examples/adios/parallel_run.sh
@@ -25,6 +25,9 @@ fi
 
 for i in ${check_PROGRAMS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
         if test "$i" = read_metadata ; then

--- a/examples/burst_buffer/parallel_run.sh
+++ b/examples/burst_buffer/parallel_run.sh
@@ -30,6 +30,9 @@ fi
 for i in ${check_PROGRAMS} ; do
     # echo "---- exec=$i"
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
 

--- a/examples/tutorial/parallel_run.sh
+++ b/examples/tutorial/parallel_run.sh
@@ -29,6 +29,9 @@ fi
 
 for i in ${check_PROGRAMS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
 
@@ -80,7 +83,8 @@ for i in ${check_PROGRAMS} ; do
 
         if test "x${ENABLE_BURST_BUFFER}" = x1 ; then
            # echo "test burst buffering feature"
-           export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
+           saved_PNETCDF_HINTS=${PNETCDF_HINTS}
+           export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
            if test $i = "pnetcdf-read-from-master" ; then
               ${MPIRUN} ./$i ${TESTOUTDIR}/pnetcdf-write-from-master.bb.nc
            elif test $i = "pnetcdf-read-nfiles" ; then
@@ -103,7 +107,7 @@ for i in ${check_PROGRAMS} ; do
                  echo "PASS:  C  parallel run on $1 processes --------------- $i"
               fi
            fi
-           unset PNETCDF_HINTS
+           export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
            if test $i = "pnetcdf-write-nfiles" ; then
               ${TESTSEQRUN} ${VALIDATOR} -q ${TESTOUTDIR}/$i.bb.nc.0-4.nc

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -56,7 +56,8 @@ This is essentially a placeholder for the next release note ...
     read and write the file header. The default is "false", meaning the file
     header is only read/written by rank 0, using MPI independent read and write
     APIs. When set to "true", collective APIs will be used with all other
-    processes making zero-size requests.
+    processes making zero-size requests. See
+    [PR #104](https://github.com/Parallel-NetCDF/PnetCDF/pull/104).
 
 * New run-time environment variables
   + none
@@ -69,8 +70,9 @@ This is essentially a placeholder for the next release note ...
     file may still be a valid netCDF file.
     * When larger, this can happen if opening an existing file that contains no
       variable. Deleting a global attribute reduces the file header size. The
-      file is still a valid netCDF file. PR #99 detects this mismatch and
-      truncates the file size to the header size.
+      file is still a valid netCDF file.
+      [PR #99](https://github.com/Parallel-NetCDF/PnetCDF/pull/99) detects
+      this mismatch and truncates the file size to the header size.
     * When smaller, this can happen if the last variable is partially written.
       The expected file size is calculated based on the full sizes of all
       variables. The file is still a valid netCDF file.
@@ -105,7 +107,8 @@ This is essentially a placeholder for the next release note ...
 
 * Bug fixes
   + Fix ncmpi_inq_num_rec_vars and ncmpi_inq_num_fix_vars when opening an
-    existing file. See PR #103.
+    existing file. See
+    [PR #103](https://github.com/Parallel-NetCDF/PnetCDF/pull/103).
   + ncmpidiff -  when checking the dimensions defined in the second files
     whether they are defined in the first file. See 88cd9c1.
 
@@ -117,8 +120,10 @@ This is essentially a placeholder for the next release note ...
 
 * New test program
   + test/testcases/tst_symlink.c - test NC_CLOBBER on a symbolic link.
-  + test/testcases/tst_del_attr.c - test delete attributes. See PR #99.
-  + test/testcases/test_get_varn.c - test get_varn API. See PR #90.
+  + test/testcases/tst_del_attr.c - test delete attributes. See
+    [PR #99](https://github.com/Parallel-NetCDF/PnetCDF/pull/99).
+  + test/testcases/test_get_varn.c - test get_varn API. See
+    [PR #90](https://github.com/Parallel-NetCDF/PnetCDF/pull/90).
   + test/testcases/flexible_var.c - test flexible var API
   + test/testcases/flexible_api.f - test flexible API when bufcount == -1
 

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -52,7 +52,11 @@ This is essentially a placeholder for the next release note ...
   + none
 
 * New PnetCDF hint
-  + none
+  + nc_header_collective -- to instruct PnetCDF to call MPI collective APIs to
+    read and write the file header. The default is "false", meaning the file
+    header is only read/written by rank 0, using MPI independent read and write
+    APIs. When set to "true", collective APIs will be used with all other
+    processes making zero-size requests.
 
 * New run-time environment variables
   + none

--- a/src/drivers/ncmpio/ncmpio_NC.h
+++ b/src/drivers/ncmpio/ncmpio_NC.h
@@ -340,6 +340,7 @@ typedef struct NC_buf {
 #define NC_HSYNC  0x200000  /* synchronise whole header on change */
 #define NC_NDIRTY 0x400000  /* numrecs has changed */
 #define NC_HDIRTY 0x800000  /* header info has changed */
+#define NC_HCOLL  0x000001  /* write header collectively */
 struct NC {
     int           ncid;         /* file ID */
     int           flags;        /* various modes, i.e. define/data, fill,
@@ -444,6 +445,7 @@ typedef struct bufferinfo {
     int         size;     /* allocated size of the buffer */
     int         version;  /* 1, 2, and 5 for CDF-1, 2, and 5 respectively */
     int         safe_mode;/* 0: disabled, 1: enabled */
+    int         rw_mode;  /* 0: independent, 1: collective */
     char       *base;     /* beginning of read/write buffer */
     char       *pos;      /* current position in buffer */
     char       *end;      /* end position of buffer */

--- a/src/drivers/ncmpio/ncmpio_util.c
+++ b/src/drivers/ncmpio/ncmpio_util.c
@@ -162,6 +162,18 @@ void ncmpio_set_pnetcdf_hints(NC *ncp,
     MPI_Info_set(info_used, "pnetcdf_subfiling", "disable");
     MPI_Info_set(info_used, "nc_num_subfiles", "0");
 #endif
+
+    if (user_info != MPI_INFO_NULL) {
+        /* read/write file header using MPI collective APIs */
+        MPI_Info_get(user_info, "nc_header_collective", MPI_MAX_INFO_VAL-1, value,
+                     &flag);
+        if (flag) {
+            if (strcasecmp(value, "true") == 0)
+                fSet((ncp)->flags, NC_HCOLL);
+        }
+    }
+    if (!flag) strcpy(value, "false");
+    MPI_Info_set(info_used, "nc_header_collective", value);
 }
 
 /*----< ncmpio_first_offset() >-----------------------------------------------*/

--- a/test/C/parallel_run.sh
+++ b/test/C/parallel_run.sh
@@ -24,7 +24,10 @@ else
 fi
 
 for j in ${safe_modes} ; do
-    # export PNETCDF_SAFE_MODE=$j
+    if test "$j" = 1 ; then # test only in safe mode
+       export PNETCDF_HINTS="nc_header_collective=true"
+    fi
+    export PNETCDF_SAFE_MODE=$j
     # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
     ${MPIRUN} ./pres_temp_4D_wr ${TESTOUTDIR}/pres_temp_4D.nc
     ${MPIRUN} ./pres_temp_4D_rd ${TESTOUTDIR}/pres_temp_4D.nc
@@ -34,10 +37,11 @@ for j in ${safe_modes} ; do
 
     if test "x${ENABLE_BURST_BUFFER}" = x1 ; then
        # echo "test burst buffering feature"
-       export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
+       saved_PNETCDF_HINTS=${PNETCDF_HINTS}
+       export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
        ${MPIRUN} ./pres_temp_4D_wr ${TESTOUTDIR}/pres_temp_4D.bb.nc
        ${MPIRUN} ./pres_temp_4D_rd ${TESTOUTDIR}/pres_temp_4D.bb.nc
-       unset PNETCDF_HINTS
+       export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
        # echo "--- validating file ${TESTOUTDIR}/pres_temp_4D.bb.nc"
        ${TESTSEQRUN} ${VALIDATOR} -q   ${TESTOUTDIR}/pres_temp_4D.bb.nc

--- a/test/CXX/parallel_run.sh
+++ b/test/CXX/parallel_run.sh
@@ -26,6 +26,9 @@ fi
 
 for i in ${TESTPROGRAMS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
         ${MPIRUN} ./$i ${TESTOUTDIR}/$i.nc
@@ -36,9 +39,10 @@ for i in ${TESTPROGRAMS} ; do
 
         if test "x${ENABLE_BURST_BUFFER}" = x1 ; then
            # echo "test burst buffering feature"
-           export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
+           saved_PNETCDF_HINTS=${PNETCDF_HINTS}
+           export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
            ${MPIRUN} ./$i ${TESTOUTDIR}/$i.bb.nc
-           unset PNETCDF_HINTS
+           export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
            # echo "--- validating file ${TESTOUTDIR}/$i.bb.nc"
            ${TESTSEQRUN} ${VALIDATOR} -q ${TESTOUTDIR}/$i.bb.nc

--- a/test/F90/parallel_run.sh
+++ b/test/F90/parallel_run.sh
@@ -26,6 +26,9 @@ fi
 
 for i in ${PARALLEL_PROGS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
         ${MPIRUN} ./$i ${TESTOUTDIR}/$i.nc
@@ -36,9 +39,10 @@ for i in ${PARALLEL_PROGS} ; do
 
         if test "x${ENABLE_BURST_BUFFER}" = x1 ; then
            # echo "test burst buffering feature"
-           export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
+           saved_PNETCDF_HINTS=${PNETCDF_HINTS}
+           export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
            ${MPIRUN} ./$i ${TESTOUTDIR}/$i.bb.nc
-           unset PNETCDF_HINTS
+           export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
            # echo "--- validating file ${TESTOUTDIR}/$i.bb.nc"
            ${TESTSEQRUN} ${VALIDATOR} -q ${TESTOUTDIR}/$i.bb.nc

--- a/test/adios/parallel_run.sh
+++ b/test/adios/parallel_run.sh
@@ -23,6 +23,9 @@ fi
 
 for i in ${check_PROGRAMS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
         if test "$i" = open ; then

--- a/test/burst_buffer/parallel_run.sh
+++ b/test/burst_buffer/parallel_run.sh
@@ -26,21 +26,25 @@ fi
 
 for i in ${TESTPROGRAMS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
 
-        export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
+        saved_PNETCDF_HINTS=${PNETCDF_HINTS}
+        export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
         rm -f ${OUTDIR}/$i.nc
         ${MPIRUN} ./$i ${TESTOUTDIR}/$i.nc
-        unset PNETCDF_HINTS
+        export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
         # echo "--- validating file ${TESTOUTDIR}/$i.nc"
         ${TESTSEQRUN} ${VALIDATOR} -q ${TESTOUTDIR}/$i.nc
 
-        export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable;nc_burst_buf_shared_logs=enable"
+        export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable;nc_burst_buf_shared_logs=enable"
         rm -f ${OUTDIR}/$i.nc
         ${MPIRUN} ./$i ${TESTOUTDIR}/$i.nc
-        unset PNETCDF_HINTS
+        export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
         # echo "--- validating file ${TESTOUTDIR}/$i.nc"
         ${TESTSEQRUN} ${VALIDATOR} -q ${TESTOUTDIR}/$i.nc

--- a/test/cdf_format/parallel_run.sh
+++ b/test/cdf_format/parallel_run.sh
@@ -26,6 +26,9 @@ else
 fi
 
 for j in ${safe_modes} ; do
+    if test "$j" = 1 ; then # test only in safe mode
+       export PNETCDF_HINTS="nc_header_collective=true"
+    fi
     export PNETCDF_SAFE_MODE=$j
     # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
     ${MPIRUN} ./test_inq_format ${srcdir}
@@ -39,11 +42,12 @@ for j in ${safe_modes} ; do
 
     if test "x${ENABLE_BURST_BUFFER}" = x1 ; then
        # echo "test burst buffering feature"
-       export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
+       saved_PNETCDF_HINTS=${PNETCDF_HINTS}
+       export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
        ${MPIRUN} ./test_inq_format ${srcdir}
        ${MPIRUN} ./cdf_type ${TESTOUTDIR}/cdf_type.bb.nc
        ${MPIRUN} ./dim_cdf12 ${TESTOUTDIR}/dim_cdf12.bb.nc
-       unset PNETCDF_HINTS
+       export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
        # echo "--- validating file ${TESTOUTDIR}/cdf_type.bb.nc"
        ${TESTSEQRUN} ${VALIDATOR} -q ${TESTOUTDIR}/cdf_type.bb.nc

--- a/test/header/parallel_run.sh
+++ b/test/header/parallel_run.sh
@@ -26,6 +26,9 @@ fi
 
 for i in ${check_PROGRAMS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
         ${MPIRUN} ./$i ${TESTOUTDIR}/$i.nc
@@ -36,9 +39,10 @@ for i in ${check_PROGRAMS} ; do
 
         if test "x${ENABLE_BURST_BUFFER}" = x1 ; then
            # echo "test burst buffering feature"
-           export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
+           saved_PNETCDF_HINTS=${PNETCDF_HINTS}
+           export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
            ${MPIRUN} ./$i ${TESTOUTDIR}/$i.bb.nc
-           unset PNETCDF_HINTS
+           export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
            # echo "--- validating file ${TESTOUTDIR}/$i.bb.nc"
            ${TESTSEQRUN} ${VALIDATOR} -q ${TESTOUTDIR}/$i.bb.nc

--- a/test/nc4/parallel_run.sh
+++ b/test/nc4/parallel_run.sh
@@ -23,6 +23,9 @@ fi
 
 for i in ${check_PROGRAMS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
         ${MPIRUN} ./$i ${TESTOUTDIR}/$i.nc

--- a/test/nonblocking/parallel_run.sh
+++ b/test/nonblocking/parallel_run.sh
@@ -26,6 +26,9 @@ fi
 
 for i in ${check_PROGRAMS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
         ${MPIRUN} ./$i ${TESTOUTDIR}/$i.nc
@@ -38,9 +41,10 @@ for i in ${check_PROGRAMS} ; do
 
         if test "x${ENABLE_BURST_BUFFER}" = x1 ; then
            # echo "test burst buffering feature"
-           export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
+           saved_PNETCDF_HINTS=${PNETCDF_HINTS}
+           export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
            ${MPIRUN} ./$i ${TESTOUTDIR}/$i.bb.nc
-           unset PNETCDF_HINTS
+           export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
            if test "$i" = mcoll_perf ; then
               continue

--- a/test/subfile/parallel_run.sh
+++ b/test/subfile/parallel_run.sh
@@ -26,6 +26,9 @@ fi
 
 for i in ${check_PROGRAMS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
         ${MPIRUN} ./$i -f ${TESTOUTDIR}/$i.nc -s 2
@@ -43,9 +46,10 @@ for i in ${check_PROGRAMS} ; do
 
         if test "x${ENABLE_BURST_BUFFER}" = x1 ; then
            # echo "test burst buffering feature"
-           export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
+           saved_PNETCDF_HINTS=${PNETCDF_HINTS}
+           export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
            ${MPIRUN} ./$i -f ${TESTOUTDIR}/$i.bb.nc -s 2
-           unset PNETCDF_HINTS
+           export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
            # echo "--- validating file ${TESTOUTDIR}/$i.bb.nc"
            ${TESTSEQRUN} ${VALIDATOR} -q ${TESTOUTDIR}/$i.bb.nc

--- a/test/testcases/parallel_run.sh
+++ b/test/testcases/parallel_run.sh
@@ -29,6 +29,9 @@ fi
 
 for i in ${check_PROGRAMS} ; do
     for j in ${safe_modes} ; do
+        if test "$j" = 1 ; then # test only in safe mode
+           export PNETCDF_HINTS="nc_header_collective=true"
+        fi
         export PNETCDF_SAFE_MODE=$j
         # echo "set PNETCDF_SAFE_MODE ${PNETCDF_SAFE_MODE}"
 
@@ -63,9 +66,10 @@ for i in ${check_PROGRAMS} ; do
 
         if test "x${ENABLE_BURST_BUFFER}" = x1 ; then
            # echo "test burst buffering feature"
-           export PNETCDF_HINTS="nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
+           saved_PNETCDF_HINTS=${PNETCDF_HINTS}
+           export PNETCDF_HINTS="${PNETCDF_HINTS};nc_burst_buf=enable;nc_burst_buf_dirname=${TESTOUTDIR};nc_burst_buf_overwrite=enable"
            ${MPIRUN} ./$i ${TESTOUTDIR}/$i.bb.nc
-           unset PNETCDF_HINTS
+           export PNETCDF_HINTS=${saved_PNETCDF_HINTS}
 
            # put_all_kinds and iput_all_kinds output 3 files
            if test "$i" = put_all_kinds -o "$i" = iput_all_kinds ; then

--- a/test/testcases/tst_free_comm.c
+++ b/test/testcases/tst_free_comm.c
@@ -47,8 +47,8 @@ tst_fmt(char *fname, int cmode)
     err = ncmpi_create(comm, fname, cmode, info, &ncid); EXP_ERR(exp_err)
     if (err == NC_ENOTBUILT) goto fn_exit;
 
-    MPI_Comm_free(&comm);
-    MPI_Info_free(&info);
+    MPI_Comm_free(&comm); comm = MPI_COMM_NULL;
+    MPI_Info_free(&info); info = MPI_INFO_NULL;
 
     err = ncmpi_close(ncid); CHECK_ERR
 

--- a/test/testcases/tst_info.c
+++ b/test/testcases/tst_info.c
@@ -110,6 +110,7 @@ int main(int argc, char** argv) {
     MPI_Info_create(&info);
     MPI_Info_set(info, "nc_header_align_size", "1");   /* size in bytes */
     MPI_Info_set(info, "nc_var_align_size",    "197"); /* size in bytes */
+    MPI_Info_set(info, "nc_header_collective", "true");
 
     /* create another new file using a non-NULL MPI info --------------------*/
     err = ncmpi_create(MPI_COMM_WORLD, filename, NC_CLOBBER, info, &ncid2); CHECK_ERR
@@ -189,6 +190,19 @@ int main(int argc, char** argv) {
                    value);
             nerrs++;
         }
+    }
+
+    MPI_Info_get_valuelen(info_used, "nc_header_collective", &len, &flag);
+    if (flag) {
+        MPI_Info_get(info_used, "nc_header_collective", len+1, value, &flag);
+        if (strcasecmp("true", value)) {
+            printf("Error: nc_header_collective expect \"true\" but got \"%s\"\n",
+                   value);
+            nerrs++;
+        }
+    } else {
+        printf("Error: hint \"nc_header_collective\" is missing\n");
+        nerrs++;
     }
 
     MPI_Info_get_valuelen(info_used, "pnetcdf_subfiling", &len, &flag);


### PR DESCRIPTION
* Default is "false"
* When it is set to "true", MPI collective reads and writes will be
  used for accessing file header. In this case, all processes except
  rank 0 will make zero sized requests.