### PR TITLE
NC_SHARE: call sync after fill operations

### DIFF
--- a/src/drivers/ncmpio/ncmpio_fill.c
+++ b/src/drivers/ncmpio/ncmpio_fill.c
@@ -240,6 +240,11 @@ fill_var_rec(NC         *ncp,
         }
     }
 
+    if (NC_doFsync(ncp)) { /* NC_SHARE is set */
+        TRACE_IO(MPI_File_sync)(fh);
+        TRACE_COMM(MPI_Barrier)(ncp->comm);
+    }
+
     return NC_NOERR;
 }
 
@@ -590,6 +595,11 @@ fillerup_aggregate(NC *ncp, NC *old_ncp)
     if (mpireturn != MPI_SUCCESS)
         if (status == NC_NOERR)
             status = ncmpii_error_mpi2nc(mpireturn, "MPI_File_set_view");
+
+    if (NC_doFsync(ncp)) { /* NC_SHARE is set */
+        TRACE_IO(MPI_File_sync)(fh);
+        TRACE_COMM(MPI_Barrier)(ncp->comm);
+    }
 
     return status;
 }


### PR DESCRIPTION
While running PnetCDF tests on a file system that requires stricter adherence to the MPI-I/O consistency semantics (UnifyFS), I found that several test cases involving fill operations were not calling ``MPI_File_sync`` after the writes associated with the fill calls.  This led to data inconsistency when other ranks later wrote different data to the same region of the file.  This was true even after modifying the test to create the file with ``NC_SHARE`` set.

One example shows up when running ``test/testcases/flexible.c`` with 4 ranks on 1 node due to the fill calls here:

https://github.com/Parallel-NetCDF/PnetCDF/blob/e47596438326bfa7b9ed0b3857800d3a0d09ff1a/test/testcases/flexible.c#L91-L97

Adding ``NC_SHARE`` to the ``ncmpi_create`` call does not help:

https://github.com/Parallel-NetCDF/PnetCDF/blob/e47596438326bfa7b9ed0b3857800d3a0d09ff1a/test/testcases/flexible.c#L79

To get this test to pass, I had to add a call to ``ncmpi_sync`` after the fill calls.

The intent with this PR is to call ``MPI_File_sync/MPI_Barrier`` after writing data during a fill call if the ``NC_SHARE`` mode bit was set when creating the file.

I wanted to open the PR for discussion.

Are you open to a change like this?

If so, are there other locations where ``MPI_File_sync`` should be called during fills?