### PR TITLE
doc: fix formatting in consistency readme

### DIFF
--- a/doc/README.consistency.md
+++ b/doc/README.consistency.md
@@ -15,6 +15,7 @@ MPI_File_sync() after each MPI I/O calls.
   * For PnetCDF collective APIs, an MPI_Barrier() will also be called right
     after MPI_File_sync().
   * For independent APIs, there is no need for calling MPI_Barrier().
+
 Users are warned that the I/O performance when using NC_SHARE flag could become
 significantly slower than not using it.
 


### PR DESCRIPTION
The markdown rendering merges a sentence meant to stand on its own to the last item of a list.  This adds a blank line to separate the two sentences.