### PR TITLE
suppress warning messages when using NAG Fortran compiler

### DIFF
--- a/benchmarks/FLASH-IO/Makefile.am
+++ b/benchmarks/FLASH-IO/Makefile.am
@@ -29,6 +29,18 @@ AM_FCFLAGS += $(FC_DEFINE)N_DIM=3
 AM_FCFLAGS += $(FC_DEFINE)MAXBLOCKS=100
 AM_FCFLAGS += $(FC_DEFINE)IONMAX=13
 
+# suppress warning messages when using NAG Fortran compiler
+if NAGFORT
+  # suppresses warning messages about unused external procedures
+  AM_FCFLAGS += -w=uep
+
+  # suppresses warning messages about variables set but never referenced;
+  AM_FCFLAGS += -w=unreffed
+
+  # suppresses warning messages about unused PARAMETERs;
+  AM_FCFLAGS += -w=uparam
+endif
+
 check_PROGRAMS = flash_benchmark_io
 
 noinst_PROGRAMS = $(check_PROGRAMS)

--- a/configure.ac
+++ b/configure.ac
@@ -1023,6 +1023,7 @@ if test "x${has_fortran}" = xyes && test "x${ax_cv_fc_compiler_vendor}" = xnag ;
    ACX_F77_MISMATCH([AS_VAR_APPEND([FFLAGS], [" $acx_cv_f77_mismatch_flag"])])
    ACX_FC_MISMATCH([AS_VAR_APPEND([FCFLAGS], [" $acx_cv_fc_mismatch_flag"])])
 fi
+AM_CONDITIONAL(NAGFORT, [test x$ax_cv_fc_compiler_vendor = xnag])
 
 if test "x$enable_shared" = xyes ; then
    dnl Call LT_OUTPUT to produce file ./libtool which is used later in

--- a/examples/F77/Makefile.am
+++ b/examples/F77/Makefile.am
@@ -13,6 +13,23 @@ AM_FFLAGS = -I$(top_builddir)/src/binding/f77 $(FFIXEDFORMFLAG)
 LDADD  = ${top_builddir}/src/libs/libpnetcdf.la utils.o
 LDADD += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@
 
+# suppress warning messages when using NAG Fortran compiler
+if NAGFORT
+  # suppresses warning messages about unused external procedures
+  AM_FFLAGS += -w=uep
+
+  # suppresses extension warnings for obsolete but common extensions to Fortran
+  # 77 - these are TAB format, byte-length specifiers, Hollerith constants
+  # and D lines;
+  AM_FFLAGS += -w=x77
+
+  # suppresses warning messages about variables set but never referenced;
+  AM_FFLAGS += -w=unreffed
+
+  # suppresses warning messages about unused PARAMETERs;
+  AM_FFLAGS += -w=uparam
+endif
+
 if SIZEOF_MPI_AINT_IS_4
    AM_FFLAGS += $(FC_DEFINE)SIZEOF_MPI_AINT_IS_4
 endif

--- a/examples/F90/Makefile.am
+++ b/examples/F90/Makefile.am
@@ -14,6 +14,18 @@ AM_FCFLAGS = ${FC_MODINC}$(top_builddir)/src/binding/f90 $(FFREEFORMFLAG)
 LDADD  = ${top_builddir}/src/libs/libpnetcdf.la utils.o
 LDADD += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@
 
+# suppress warning messages when using NAG Fortran compiler
+if NAGFORT
+  # suppresses warning messages about unused external procedures
+  AM_FCFLAGS += -w=uep
+
+  # suppresses warning messages about variables set but never referenced;
+  AM_FCFLAGS += -w=unreffed
+
+  # suppresses warning messages about unused PARAMETERs;
+  AM_FCFLAGS += -w=uparam
+endif
+
 check_PROGRAMS = nonblocking_write \
                  column_wise \
                  block_cyclic \

--- a/examples/tutorial/Makefile.am
+++ b/examples/tutorial/Makefile.am
@@ -16,6 +16,22 @@ AM_FCFLAGS = $(FC_MODINC)$(top_builddir)/src/binding/f90 $(FFREEFORMFLAG)
 LDADD  = ${top_builddir}/src/libs/libpnetcdf.la
 LDADD += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@
 
+# suppress warning messages when using NAG Fortran compiler
+if NAGFORT
+  # suppresses warning messages about unused external procedures
+  AM_FFLAGS += -w=uep
+  AM_FCFLAGS += -w=uep
+
+  # suppresses extension warnings for obsolete but common extensions to Fortran
+  # 77 - these are TAB format, byte-length specifiers, Hollerith constants
+  # and D lines;
+  AM_FFLAGS += -w=x77
+
+  # suppresses warning messages about variables set but never referenced;
+  AM_FFLAGS += -w=unreffed
+  AM_FCFLAGS += -w=unreffed
+endif
+
 check_PROGRAMS = pnetcdf-write-from-master \
                  pnetcdf-read-from-master \
                  pnetcdf-write-nfiles \

--- a/test/F90/Makefile.am
+++ b/test/F90/Makefile.am
@@ -16,6 +16,18 @@ AM_FCFLAGS = $(FC_MODINC)$(top_builddir)/src/binding/f90 \
 LDADD  = $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
 LDADD += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@
 
+# suppress warning messages when using NAG Fortran compiler
+if NAGFORT
+  # suppresses warning messages about unused external procedures
+  AM_FCFLAGS += -w=uep
+
+  # suppresses warning messages about variables set but never referenced;
+  AM_FCFLAGS += -w=unreffed
+
+  # suppresses warning messages about unused PARAMETERs;
+  AM_FCFLAGS += -w=uparam
+endif
+
 TESTPROGRAMS = tst_f90 \
                f90tst_vars \
                tst_types2 \

--- a/test/fandc/Makefile.am
+++ b/test/fandc/Makefile.am
@@ -19,6 +19,26 @@ AM_FCFLAGS  = $(FC_MODINC)$(top_builddir)/src/binding/f90 \
 LDADD  = $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
 LDADD += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@ -lm
 
+# suppress warning messages when using NAG Fortran compiler
+if NAGFORT
+  # suppresses warning messages about unused external procedures
+  AM_FFLAGS += -w=uep
+  AM_FCFLAGS += -w=uep
+
+  # suppresses extension warnings for obsolete but common extensions to Fortran
+  # 77 - these are TAB format, byte-length specifiers, Hollerith constants
+  # and D lines;
+  AM_FFLAGS += -w=x77
+
+  # suppresses warning messages about variables set but never referenced;
+  AM_FFLAGS += -w=unreffed
+  AM_FCFLAGS += -w=unreffed
+
+  # suppresses warning messages about unused PARAMETERs;
+  AM_FFLAGS += -w=uparam
+  AM_FCFLAGS += -w=uparam
+endif
+
 if DECL_MPI_OFFSET
    # Do not add to AM_CPPFLAGS, as it will also be used by Fortran programs
    # AM_CPPFLAGS += -DHAVE_DECL_MPI_OFFSET

--- a/test/nf90_test/Makefile.am
+++ b/test/nf90_test/Makefile.am
@@ -22,6 +22,18 @@ AM_CFLAGS   =
 LDADD  = $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
 LDADD += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@
 
+# suppress warning messages when using NAG Fortran compiler
+if NAGFORT
+  # suppresses warning messages about unused external procedures
+  AM_FCFLAGS += -w=uep
+
+  # suppresses warning messages about variables set but never referenced;
+  AM_FCFLAGS += -w=unreffed
+
+  # suppresses warning messages about unused PARAMETERs;
+  AM_FCFLAGS += -w=uparam
+endif
+
 if RELAX_COORD_BOUND
    AM_CFLAGS  += -DRELAX_COORD_BOUND
    AM_FCFLAGS += $(FC_DEFINE)RELAX_COORD_BOUND

--- a/test/nf_test/Makefile.am
+++ b/test/nf_test/Makefile.am
@@ -20,6 +20,23 @@ AM_FFLAGS = $(FFIXEDFORMFLAG)
 LDADD  = $(top_builddir)/src/libs/libpnetcdf.la ../common/libtestutils.la
 LDADD += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@
 
+# suppress warning messages when using NAG Fortran compiler
+if NAGFORT
+  # suppresses warning messages about unused external procedures
+  AM_FFLAGS += -w=uep
+
+  # suppresses extension warnings for obsolete but common extensions to Fortran
+  # 77 - these are TAB format, byte-length specifiers, Hollerith constants
+  # and D lines;
+  AM_FFLAGS += -w=x77
+
+  # suppresses warning messages about variables set but never referenced;
+  AM_FFLAGS += -w=unreffed
+
+  # suppresses warning messages about unused PARAMETERs;
+  AM_FFLAGS += -w=uparam
+endif
+
 M4FLAGS += -I${top_srcdir}/m4
 
 if HAVE_F77_GNU_INT

--- a/test/nonblocking/Makefile.am
+++ b/test/nonblocking/Makefile.am
@@ -22,6 +22,26 @@ AM_FFLAGS   = -I$(top_builddir)/src/binding/f77 $(FFIXEDFORMFLAG)
 LDADD  = ${top_builddir}/src/libs/libpnetcdf.la ../common/libtestutils.la
 LDADD += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@ -lm
 
+# suppress warning messages when using NAG Fortran compiler
+if NAGFORT
+  # suppresses warning messages about unused external procedures
+  AM_FFLAGS += -w=uep
+  AM_FCFLAGS += -w=uep
+
+  # suppresses extension warnings for obsolete but common extensions to Fortran
+  # 77 - these are TAB format, byte-length specifiers, Hollerith constants
+  # and D lines;
+  AM_FFLAGS += -w=x77
+
+  # suppresses warning messages about variables set but never referenced;
+  AM_FFLAGS += -w=unreffed
+  AM_FCFLAGS += -w=unreffed
+
+  # suppresses warning messages about unused PARAMETERs;
+  AM_FFLAGS += -w=uparam
+  AM_FCFLAGS += -w=uparam
+endif
+
 if DECL_MPI_OFFSET
    # Do not add to AM_CPPFLAGS, as it will also be used by Fortran programs
    # AM_CPPFLAGS += -DHAVE_DECL_MPI_OFFSET

--- a/test/testcases/Makefile.am
+++ b/test/testcases/Makefile.am
@@ -34,6 +34,26 @@ if DECL_MPI_OFFSET
    AM_FCFLAGS += $(FC_DEFINE)HAVE_DECL_MPI_OFFSET
 endif
 
+# suppress warning messages when using NAG Fortran compiler
+if NAGFORT
+  # suppresses warning messages about unused external procedures
+  AM_FFLAGS += -w=uep
+  AM_FCFLAGS += -w=uep
+
+  # suppresses extension warnings for obsolete but common extensions to Fortran
+  # 77 - these are TAB format, byte-length specifiers, Hollerith constants
+  # and D lines;
+  AM_FFLAGS += -w=x77
+
+  # suppresses warning messages about variables set but never referenced;
+  AM_FFLAGS += -w=unreffed
+  AM_FCFLAGS += -w=unreffed
+
+  # suppresses warning messages about unused PARAMETERs;
+  AM_FFLAGS += -w=uparam
+  AM_FCFLAGS += -w=uparam
+endif
+
 TESTPROGRAMS = ncmpi_vars_null_stride \
                vectors \
                collective_error \


### PR DESCRIPTION
`-w=uep` to suppresses warning messages about unused external procedures 
`-w=x77` to suppresses extension warnings for Fortr 77 
`-w=unreffed` to suppresses warning messages about variables set but never referenced; 
`-w=uparam` to  suppresses warning messages about unused PARAMETERs;