### PR TITLE
Test a stronger file consistency is required by UnifyFS

### DIFF
--- a/test/F90/f90tst_parallel2.f90
+++ b/test/F90/f90tst_parallel2.f90
@@ -109,6 +109,11 @@ program f90tst_parallel
   ! With classic model netCDF-4 file, enddef must be called.
   call handle_err(nf90mpi_enddef(ncid))
 
+  ! UnifyFS requires a stronger file consistency
+  call handle_err(nf90mpi_sync(ncid))
+  call MPI_Barrier(MPI_COMM_WORLD, ierr)
+  call handle_err(nf90mpi_sync(ncid))
+
   ! Determine what part of the variable will be written for this
   ! processor. It's a checkerboard decomposition.
   count = (/ NX / 4, NY / 4 /)

--- a/test/F90/f90tst_parallel3.f90
+++ b/test/F90/f90tst_parallel3.f90
@@ -113,6 +113,11 @@ program f90tst_parallel3
   ! This will be the last collective operation.
   call check(nf90mpi_enddef(ncid))
 
+  ! UnifyFS requires a stronger file consistency
+  call check(nf90mpi_sync(ncid))
+  call MPI_Barrier(MPI_COMM_WORLD, ierr)
+  call check(nf90mpi_sync(ncid))
+
   ! Determine what part of the variable will be written/read for this
   ! processor. It's a checkerboard decomposition.
   count = (/ HALF_NX, HALF_NY /)

--- a/test/largefile/high_dim_var.c
+++ b/test/largefile/high_dim_var.c
@@ -78,6 +78,12 @@ int main(int argc, char** argv) {
     err = ncmpi_enddef(ncid); CHECK_ERR
     if (err != NC_NOERR) goto fn_exit;
 
+#ifdef STRONGER_CONSISTENCY
+    ncmpi_sync(ncid);
+    MPI_Barrier(MPI_COMM_WORLD);
+    ncmpi_sync(ncid);
+#endif
+
     nelms = (NRECS > DIMLEN) ? NRECS : DIMLEN;
     for (i=1; i<NDIMS; i++) nelms *= DIMLEN;
     buffer = (short*) malloc(nelms * sizeof(short));
@@ -95,6 +101,12 @@ int main(int argc, char** argv) {
             err = ncmpi_fill_var_rec(ncid, rvarid[i], j); CHECK_ERR
         }
     }
+
+#ifdef STRONGER_CONSISTENCY
+    ncmpi_sync(ncid);
+    MPI_Barrier(MPI_COMM_WORLD);
+    ncmpi_sync(ncid);
+#endif
 
     for (i=0; i<nelms; i++) buffer[i] = i % 32768;
 
@@ -114,6 +126,12 @@ int main(int argc, char** argv) {
         err = ncmpi_put_vars_short_all(ncid, rvarid[i], start, count, stride,
                                        buffer); CHECK_ERR
     }
+
+#ifdef STRONGER_CONSISTENCY
+    ncmpi_sync(ncid);
+    MPI_Barrier(MPI_COMM_WORLD);
+    ncmpi_sync(ncid);
+#endif
 
     /* all processes read and verify */
     if (rank > 0) for (i=0; i<NDIMS; i++) count[i]  = 2;

--- a/test/nonblocking/i_varn_indef.c
+++ b/test/nonblocking/i_varn_indef.c
@@ -339,11 +339,23 @@ int main(int argc, char** argv)
 
     err = ncmpi_enddef(ncid); CHECK_ERR
 
+#ifdef STRONGER_CONSISTENCY
+    ncmpi_sync(ncid);
+    MPI_Barrier(MPI_COMM_WORLD);
+    ncmpi_sync(ncid);
+#endif
+
     /* clear the file contents using a blocking API, before commit the
      * nonblocking requests posted in define mode */
     if (!bb_enabled) {
         nerrs += clear_file_contents(ncid, varid);
     }
+
+#ifdef STRONGER_CONSISTENCY
+    ncmpi_sync(ncid);
+    MPI_Barrier(MPI_COMM_WORLD);
+    ncmpi_sync(ncid);
+#endif
 
     nerrs += check_num_pending_reqs(ncid, nreqs, __LINE__);
     err = ncmpi_wait_all(ncid, nreqs, reqs, sts);
@@ -393,11 +405,23 @@ int main(int argc, char** argv)
     }
     err = ncmpi_enddef(ncid); CHECK_ERR
 
+#ifdef STRONGER_CONSISTENCY
+    ncmpi_sync(ncid);
+    MPI_Barrier(MPI_COMM_WORLD);
+    ncmpi_sync(ncid);
+#endif
+
     /* clear the file contents using a blocking API, before commit the
      * nonblocking requests posted in define mode */
     if (!bb_enabled) {
         nerrs += clear_file_contents(ncid, varid);
     }
+
+#ifdef STRONGER_CONSISTENCY
+    ncmpi_sync(ncid);
+    MPI_Barrier(MPI_COMM_WORLD);
+    ncmpi_sync(ncid);
+#endif
 
     nerrs += check_num_pending_reqs(ncid, nreqs, __LINE__);
     err = ncmpi_wait_all(ncid, nreqs, reqs, sts);
@@ -457,11 +481,23 @@ int main(int argc, char** argv)
 
     err = ncmpi_enddef(ncid); CHECK_ERR
 
+#ifdef STRONGER_CONSISTENCY
+    ncmpi_sync(ncid);
+    MPI_Barrier(MPI_COMM_WORLD);
+    ncmpi_sync(ncid);
+#endif
+
     /* clear the file contents using a blocking API, before commit the
      * nonblocking requests posted in define mode */
     if (!bb_enabled) {
         nerrs += clear_file_contents(ncid, varid);
     }
+
+#ifdef STRONGER_CONSISTENCY
+    ncmpi_sync(ncid);
+    MPI_Barrier(MPI_COMM_WORLD);
+    ncmpi_sync(ncid);
+#endif
 
     nerrs += check_num_pending_reqs(ncid, nreqs*2, __LINE__);
     err = ncmpi_wait_all(ncid, nreqs, reqs, sts);
@@ -555,11 +591,23 @@ int main(int argc, char** argv)
 
     err = ncmpi_enddef(ncid); CHECK_ERR
 
+#ifdef STRONGER_CONSISTENCY
+    ncmpi_sync(ncid);
+    MPI_Barrier(MPI_COMM_WORLD);
+    ncmpi_sync(ncid);
+#endif
+
     /* clear the file contents using a blocking API, before commit the
      * nonblocking requests posted in define mode */
     if (!bb_enabled) {
         nerrs += clear_file_contents(ncid, varid);
     }
+
+#ifdef STRONGER_CONSISTENCY
+    ncmpi_sync(ncid);
+    MPI_Barrier(MPI_COMM_WORLD);
+    ncmpi_sync(ncid);
+#endif
 
     nerrs += check_num_pending_reqs(ncid, nreqs*3, __LINE__);
 

--- a/test/nonblocking/mcoll_perf.c
+++ b/test/nonblocking/mcoll_perf.c
@@ -512,6 +512,12 @@ int main(int argc, char **argv)
         err = ncmpi_enddef(ncid);
         CHECK_ERR
 
+#ifdef STRONGER_CONSISTENCY
+        ncmpi_sync(ncid);
+        MPI_Barrier(MPI_COMM_WORLD);
+        ncmpi_sync(ncid);
+#endif
+
         if (k == 0) {
             if (rank == 0 && verbose)
                 printf("*** Testing to write 2 non-record variables and 2 record variables by using ncmpi_put_vara_all() ...");
@@ -522,6 +528,12 @@ int main(int argc, char **argv)
                     CHECK_ERR
                 }
             }
+#ifdef STRONGER_CONSISTENCY
+            ncmpi_sync(ncid);
+            MPI_Barrier(MPI_COMM_WORLD);
+            ncmpi_sync(ncid);
+#endif
+
             for (i=0; i<nvars; i++){
                 err = ncmpi_put_vara_all(ncid, varid[i], starts[i], counts[i], buf[i], bufcounts[i], MPI_INT);
                 CHECK_ERR

--- a/test/testcases/flexible.c
+++ b/test/testcases/flexible.c
@@ -88,6 +88,12 @@ int main(int argc, char **argv) {
     err = ncmpi_set_fill(ncid, NC_FILL, NULL); CHECK_ERR /* enable fill mode */
     err = ncmpi_enddef(ncid); CHECK_ERR
 
+#ifdef STRONGER_CONSISTENCY
+    ncmpi_sync(ncid);
+    MPI_Barrier(MPI_COMM_WORLD);
+    ncmpi_sync(ncid);
+#endif
+
     /* fill 2 records with default fill values */
     err = ncmpi_fill_var_rec(ncid, varid1, 0); CHECK_ERR
     err = ncmpi_fill_var_rec(ncid, varid1, 1); CHECK_ERR
@@ -95,6 +101,12 @@ int main(int argc, char **argv) {
     err = ncmpi_fill_var_rec(ncid, varid2, 1); CHECK_ERR
     err = ncmpi_fill_var_rec(ncid, varid3, 0); CHECK_ERR
     err = ncmpi_fill_var_rec(ncid, varid3, 1); CHECK_ERR
+
+#ifdef STRONGER_CONSISTENCY
+    ncmpi_sync(ncid);
+    MPI_Barrier(MPI_COMM_WORLD);
+    ncmpi_sync(ncid);
+#endif
 
     /* initialize the contents of the array */
     for (j=0; j<NY; j++) for (i=0; i<NX; i++) buf[j][i] = j+10;

--- a/test/testcases/ivarn.c
+++ b/test/testcases/ivarn.c
@@ -208,6 +208,12 @@ int main(int argc, char** argv)
     }
     err = ncmpi_enddef(ncid); CHECK_ERR
 
+#ifdef STRONGER_CONSISTENCY
+    ncmpi_sync(ncid);
+    MPI_Barrier(MPI_COMM_WORLD);
+    ncmpi_sync(ncid);
+#endif
+
     if (nprocs < 4) { /* need 4 processes to fill the variables */
         err = ncmpi_fill_var_rec(ncid, vari0001, 0); CHECK_ERR
         err = ncmpi_fill_var_rec(ncid, varr0001, 0); CHECK_ERR
@@ -216,6 +222,12 @@ int main(int argc, char** argv)
         err = ncmpi_fill_var_rec(ncid, varr0002, 0); CHECK_ERR
         err = ncmpi_fill_var_rec(ncid, vard0002, 0); CHECK_ERR
     }
+
+#ifdef STRONGER_CONSISTENCY
+    ncmpi_sync(ncid);
+    MPI_Barrier(MPI_COMM_WORLD);
+    ncmpi_sync(ncid);
+#endif
 
     starts    = (MPI_Offset**) malloc(2 *    sizeof(MPI_Offset*));
     counts    = (MPI_Offset**) malloc(2 *    sizeof(MPI_Offset*));

--- a/test/testcases/mix_collectives.c
+++ b/test/testcases/mix_collectives.c
@@ -69,6 +69,12 @@ int main(int argc, char **argv)
     err = ncmpi_set_fill(ncid, NC_FILL, NULL); CHECK_ERR
     err = ncmpi_enddef(ncid); CHECK_ERR
 
+#ifdef STRONGER_CONSISTENCY
+    ncmpi_sync(ncid);
+    MPI_Barrier(MPI_COMM_WORLD);
+    ncmpi_sync(ncid);
+#endif
+
     for (j=0; j<6; j++) for (i=0; i<4; i++) buf[j][i] = j*4+i + rank*100;
 
     /* now, each of 4 processes makes a call to different kinds of put APIs */

--- a/test/testcases/test_vardf.F
+++ b/test/testcases/test_vardf.F
@@ -308,6 +308,12 @@
           err = nfmpi_enddef(ncid)
           call check(err, 'In nfmpi_enddef: ')
 
+#ifdef STRONGER_CONSISTENCY
+          err = nfmpi_sync(ncid)
+          call MPI_Barrier(MPI_COMM_WORLD, ierr)
+          err = nfmpi_sync(ncid)
+#endif
+
           ! now we are in data mode
 
           ! fill 2 records with default fill values
@@ -323,6 +329,12 @@
           recno = 2
           err = nfmpi_fill_var_rec(ncid, varid2, recno)
           call check(err, 'In nfmpi_fill_var_rec: varid2, 2 ')
+
+#ifdef STRONGER_CONSISTENCY
+          err = nfmpi_sync(ncid)
+          call MPI_Barrier(MPI_COMM_WORLD, ierr)
+          err = nfmpi_sync(ncid)
+#endif
 
           ! create a file type for the record variable */
           err = nfmpi_inq_recsize(ncid, recsize)

--- a/test/testcases/test_vardf90.f90
+++ b/test/testcases/test_vardf90.f90
@@ -290,6 +290,11 @@
           err = nf90mpi_enddef(ncid)
           call check(err, 'In nf90mpi_enddef: ')
 
+          ! UnifyFS requires a stronger file consistency
+          err = nf90mpi_sync(ncid)
+          call MPI_Barrier(MPI_COMM_WORLD, err)
+          err = nf90mpi_sync(ncid)
+
           ! now we are in data mode
 
           ! fill 2 records with default fill values
@@ -305,6 +310,11 @@
           recno = 2
           err = nf90mpi_fill_var_rec(ncid, varid2, recno)
           call check(err, 'In nf90mpi_fill_var_rec: varid2, 2 ')
+
+          ! UnifyFS requires a stronger file consistency
+          err = nf90mpi_sync(ncid)
+          call MPI_Barrier(MPI_COMM_WORLD, err)
+          err = nf90mpi_sync(ncid)
 
           ! create a file type for the record variable */
           err = nf90mpi_inq_recsize(ncid, recsize)

--- a/test/testcases/tst_def_var_fill.c
+++ b/test/testcases/tst_def_var_fill.c
@@ -61,6 +61,12 @@ tst_fmt(char *filename, int cmode)
 
     err = ncmpi_enddef(ncid); CHECK_ERR
 
+#ifdef STRONGER_CONSISTENCY
+    err = ncmpi_sync(ncid); CHECK_ERR
+    MPI_Barrier(MPI_COMM_WORLD);
+    err = ncmpi_sync(ncid); CHECK_ERR
+#endif
+
     /* initialize I/O buffer */
     for (i=0; i<NY*NX; i++) buf[i] = rank+5;
 

--- a/test/testcases/varn_real.f90
+++ b/test/testcases/varn_real.f90
@@ -113,6 +113,11 @@
           err = nf90mpi_enddef(ncid)
           call check(err, 'In nf90mpi_enddef: ')
 
+          ! UnifyFS requires a stronger file consistency
+          err = nf90mpi_sync(ncid)
+          call MPI_Barrier(MPI_COMM_WORLD, err)
+          err = nf90mpi_sync(ncid)
+
           ! pick arbitrary numbers of requests for 4 processes
           num_reqs = 0
           if (rank .EQ.  0) then
@@ -230,6 +235,11 @@
           call check(err, 'In nf90mpi_put_varn_all: ')
 
           if (nprocs .GT. 4) call MPI_Barrier(MPI_COMM_WORLD, err)
+
+          ! UnifyFS requires a stronger file consistency
+          err = nf90mpi_sync(ncid)
+          call MPI_Barrier(MPI_COMM_WORLD, err)
+          err = nf90mpi_sync(ncid)
 
           ! read a scalar back and check the content
           oneReal = -1.0  ! a scalar


### PR DESCRIPTION
When running tests on UnifyFS file system, a stronger file consistency is required.
See #107 and #119 

This is done by adding the following code fragment.
```
    ncmpi_sync(ncid);
    MPI_Barrier(MPI_COMM_WORLD);
    ncmpi_sync(ncid);
```