### PR TITLE
Add configure variables SEQ_CFLAGS, SEQ_LDFLAGS, and SEQ_LIBS

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -203,6 +203,14 @@ Some influential environment variables:
   TESTMPIRUN  MPI run command for "make ptest", [default: mpiexec -n NP]
   TESTOUTDIR  Output file directory for "make check" and "make ptest",
               [default: ./]
+  SEQ_CC      C compiler for building sequential utility programs,
+              [default: gcc]
+  SEQ_CFLAGS  C compile flags for building sequential utility programs,
+              [default: none]
+  SEQ_LDFLAGS Linker flags for building sequential utility programs,
+              [default: none]
+  SEQ_LIBS    Libraries for building sequential utility programs,
+              [default: none]
 
 Use these variables to override the choices made by `configure' or to help
 it to find libraries and programs with nonstandard names/locations.

--- a/configure.ac
+++ b/configure.ac
@@ -2503,7 +2503,7 @@ AC_SUBST([FSTYPE_PREFIX])
 # Note on Theta @ALCF, CPATH is set for Intel Compiler and when gcc is used to
 # compile the above utility programs, errors can occur. See doc/README.CRAY for
 # more information. Below we use the same C compiler as MPICC.
-AC_ARG_VAR(SEQ_CC, [C compiler to build sequential utility programs, @<:@default: gcc@:>@])
+AC_ARG_VAR(SEQ_CC, [C compiler for building sequential utility programs, @<:@default: gcc@:>@])
 if test "x$SEQ_CC" = x ; then
    # if test "x$ac_cv_mpicc_base" = xGCC ; then
    #    AC_PATH_PROG([SEQ_CC], [gcc], [$MPICC])
@@ -2528,6 +2528,13 @@ fi
 AC_MSG_CHECKING([C compiler for serial utility programs])
 AC_MSG_RESULT([$SEQ_CC])
 AC_SUBST(SEQ_CC)
+
+AC_ARG_VAR(SEQ_CFLAGS, [C compile flags for building sequential utility programs, @<:@default: none@:>@])
+AC_SUBST(SEQ_CFLAGS)
+AC_ARG_VAR(SEQ_LDFLAGS, [Linker flags for building sequential utility programs, @<:@default: none@:>@])
+AC_SUBST(SEQ_LIBS)
+AC_ARG_VAR(SEQ_LIBS, [Libraries for building sequential utility programs, @<:@default: none@:>@])
+AC_SUBST(SEQ_LIBS)
 
 dnl Configuration Date
 dnl Note that command 'date' is not portable across Unix platforms
@@ -2731,38 +2738,54 @@ fi
 
 echo "\
 
-   Compilers: MPICC    = ${MPICC}"
+   Compilers: MPICC       = ${MPICC}"
 if test "${has_mpicxx}" = yes ; then
    echo "\
-              MPICXX   = ${MPICXX}"
+              MPICXX      = ${MPICXX}"
 fi
 if test "${has_fortran}" = yes ; then
    echo "\
-              MPIF77   = ${MPIF77}
-              MPIF90   = ${MPIF90}"
+              MPIF77      = ${MPIF77}
+              MPIF90      = ${MPIF90}"
 fi
 if test "x${CPPFLAGS}" != x ; then
    echo "\
-              CPPFLAGS = ${CPPFLAGS}"
+              CPPFLAGS    = ${CPPFLAGS}"
 fi
 echo "\
-              CFLAGS   = ${CFLAGS}"
+              CFLAGS      = ${CFLAGS}"
 if test "${has_mpicxx}" = yes ; then
    echo "\
-              CXXFLAGS = ${CXXFLAGS}"
+              CXXFLAGS    = ${CXXFLAGS}"
 fi
 if test "${has_fortran}" = yes ; then
    echo "\
-              FFLAGS   = ${FFLAGS}
-              FCFLAGS  = ${FCFLAGS}"
+              FFLAGS      = ${FFLAGS}
+              FCFLAGS     = ${FCFLAGS}"
 fi
 if test "x${LDFLAGS}" != x ; then
    echo "\
-              LDFLAGS  = ${LDFLAGS}"
+              LDFLAGS     = ${LDFLAGS}"
 fi
 if test "x${LIBS}" != x ; then
    echo "\
-              LIBS     = ${LIBS}"
+              LIBS        = ${LIBS}"
+fi
+if test "x${SEQ_CC}" != x ; then
+   echo "\
+              SEQ_CC      = ${SEQ_CC}"
+fi
+if test "x${SEQ_CFLAGS}" != x ; then
+   echo "\
+              SEQ_CFLAGS  = ${SEQ_CFLAGS}"
+fi
+if test "x${SEQ_LDFLAGS}" != x ; then
+   echo "\
+              SEQ_LDFLAGS = ${SEQ_LDFLAGS}"
+fi
+if test "x${SEQ_LIBS}" != x ; then
+   echo "\
+              SEQ_LIBS    = ${SEQ_LIBS}"
 fi
 if test "x${enable_netcdf4}" = xyes; then
    echo "\

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -29,6 +29,11 @@ This is essentially a placeholder for the next release note ...
     `${prefix}/pnetcdf_examples` along with run script files. An example is
     `${prefix}/pnetcdf_examples/C/run_c_examples.sh`. The default of this
     option is `disabled`.
+  + Add three new environment variables `SEQ_CFLAGS`, `SEQ_LDFLAGS` and
+    `SEQ_LIBS` for setting the compile, link, and library flags, respectively
+    to be used to build the sequential utility programs, i.e. `cdfdiff`,
+    `ncoffsets`, `ncvalidator`, and `pnetcdf_version`.
+    See [PR #122](https://github.com/Parallel-NetCDF/PnetCDF/pull/122)
 
 * Configure updates:
   + Upgrade config.guess config.sub to 2024-01-01.

--- a/src/utils/ncmpidiff/Makefile.am
+++ b/src/utils/ncmpidiff/Makefile.am
@@ -18,7 +18,7 @@ ncmpidiff_LDADD += @NETCDF4_LDFLAGS@ @ADIOS_LDFLAGS@ @NETCDF4_LIBS@ @ADIOS_LIBS@
 cdfdiff_SOURCES = cdfdiff.c
 
 cdfdiff$(EXEEXT): cdfdiff.c Makefile
-	$(SEQ_CC) -I$(top_srcdir)/src/utils/ncvalidator -o $@ $<
+	$(SEQ_CC) $(SEQ_CFLAGS) -I$(top_srcdir)/src/utils/ncvalidator -o $@ $< $(SEQ_LDFLAGS) $(SEQ_LIBS)
 
 $(top_builddir)/src/libs/libpnetcdf.la:
 	set -e; cd $(top_builddir)/src/libs && $(MAKE) $(MFLAGS)

--- a/src/utils/ncoffsets/Makefile.am
+++ b/src/utils/ncoffsets/Makefile.am
@@ -10,7 +10,7 @@ bin_PROGRAMS = ncoffsets
 EXTRA_DIST = ncoffsets.c
 
 ncoffsets$(EXEEXT): ncoffsets.c
-	$(SEQ_CC) -o $@ $<
+	$(SEQ_CC) $(SEQ_CFLAGS) -o $@ $< $(SEQ_LDFLAGS) $(SEQ_LIBS)
 
 dist_man_MANS = ncoffsets.1
 

--- a/src/utils/ncvalidator/Makefile.am
+++ b/src/utils/ncvalidator/Makefile.am
@@ -76,7 +76,7 @@ EVARSIZE_FILES = bad_large_fixed_var.nc2 \
 TST_HDF5_FILES = pad_superblock.h5
 
 ncvalidator$(EXEEXT): ncvalidator.c Makefile
-	$(SEQ_CC) -o $@ $<
+	$(SEQ_CC) $(SEQ_CFLAGS) -o $@ $< $(SEQ_LDFLAGS) $(SEQ_LIBS)
 
 # autimake 1.11.3 has not yet implemented AM_TESTS_ENVIRONMENT
 # For newer versions, we can use AM_TESTS_ENVIRONMENT instead

--- a/src/utils/pnetcdf_version/Makefile.am
+++ b/src/utils/pnetcdf_version/Makefile.am
@@ -22,7 +22,7 @@ XDEFS += -DMPIF90="\"$(MPIF90)\"" -DFCFLAGS="\"$(FCFLAGS)\""
 endif
 
 pnetcdf_version$(EXEEXT): pnetcdf_version.c
-	$(SEQ_CC) $(XDEFS) -o $@ $<
+	$(SEQ_CC) $(SEQ_CFLAGS) $(XDEFS) -o $@ $< $(SEQ_LDFLAGS) $(SEQ_LIBS)
 
 dist_man_MANS = pnetcdf_version.1
 


### PR DESCRIPTION
`SEQ_CFLAGS`, `SEQ_LDFLAGS`, and `SEQ_LIBS` will be used for setting the compile, link, and library flags, respectively to be used to build the sequential utility programs, i.e. `cdfdiff`, `ncoffsets`, `ncvalidator`, and `pnetcdf_version`.