### PR TITLE
Silence Intel compiler warning: implicit const int float conversion

### DIFF
--- a/test/nc_test/test_get.m4
+++ b/test/nc_test/test_get.m4
@@ -89,9 +89,9 @@ define(`NCT_ITYPE', ``NCT_'Upcase($1)')dnl
 dnl
 
 define(`CheckText', `ifelse(`$1',`text', , `== (NCT_ITYPE($1) == NCT_TEXT)')')dnl
-define(`CheckRange',`ifelse(`$1',`text', `1', `($2 >= $1_min && $2 <= $1_max)')')dnl
+define(`CheckRange',`ifelse(`$1',`text', `1', `($2 >= (double)$1_min && $2 <= (double)$1_max)')')dnl
 define(`IfCheckTextChar', `ifelse(`$1',`text', `if ($2 != NC_CHAR)')')dnl
-define(`CheckNumRange',`ifelse(`$1',`text', `1',`inRange3(cdf_format, $2,$3,NCT_ITYPE($1)) && ($2 >= $1_min && $2 <= $1_max)')')dnl
+define(`CheckNumRange',`ifelse(`$1',`text', `1',`inRange3(cdf_format, $2,$3,NCT_ITYPE($1)) && ($2 >= (double)$1_min && $2 <= (double)$1_max)')')dnl
 
 dnl TEST_NC_GET_VAR1(TYPE)
 dnl

--- a/test/nc_test/test_iget.m4
+++ b/test/nc_test/test_iget.m4
@@ -54,11 +54,11 @@ define(`NCT_ITYPE', ``NCT_'Upcase($1)')dnl
 dnl
 
 define(`CheckText', `ifelse(`$1',`text', , `== (NCT_ITYPE($1) == NCT_TEXT)')')dnl
-define(`CheckRange',`ifelse(`$1',`text', `1', `($2 >= $1_min && $2 <= $1_max)')')dnl
+define(`CheckRange',`ifelse(`$1',`text', `1', `($2 >= (double)$1_min && $2 <= (double)$1_max)')')dnl
 define(`IfCheckTextChar', `ifelse(`$1',`text', `if ($2 != NC_CHAR)')')dnl
 define(`CheckNumRange',
        `ifelse(`$1',`text', `1',
-               `inRange3(cdf_format, $2,$3,NCT_ITYPE($1)) && ($2 >= $1_min && $2 <= $1_max)')')dnl
+               `inRange3(cdf_format, $2,$3,NCT_ITYPE($1)) && ($2 >= (double)$1_min && $2 <= (double)$1_max)')')dnl
 
 #include "tests.h"
 

--- a/test/nc_test/test_iput.m4
+++ b/test/nc_test/test_iput.m4
@@ -67,7 +67,7 @@ define(`CheckText', `ifelse(`$1',`text', , `== (NCT_ITYPE($1) == NCT_TEXT)')')dn
 define(`IfCheckTextChar', `ifelse(`$1',`text', `if ($2 != NC_CHAR)')')dnl
 define(`CheckNumRange',
        `ifelse(`$1',`text', `1',
-               `inRange3(cdf_format, $2,$3,NCT_ITYPE($1)) && ($2 >= $1_min && $2 <= $1_max)')')dnl
+               `inRange3(cdf_format, $2,$3,NCT_ITYPE($1)) && ($2 >= (double)$1_min && $2 <= (double)$1_max)')')dnl
 define(`CheckRange3',
        `ifelse(`$1',`text', `1',
                `inRange3(cdf_format, $2,$3,NCT_ITYPE($1))')')dnl
@@ -83,17 +83,17 @@ hash2nc(const nc_type var_type, int var_rank, MPI_Offset *index)
 
     switch (var_type) {
         /* no type conversion will happen for NC_CHAR, use in-memory limits */
-        case NC_CHAR:   min = CHAR_MIN;     max = CHAR_MAX;     break;
-        case NC_BYTE:   min = X_BYTE_MIN;   max = X_BYTE_MAX;   break;
-        case NC_SHORT:  min = X_SHORT_MIN;  max = X_SHORT_MAX;  break;
-        case NC_INT:    min = X_INT_MIN;    max = X_INT_MAX;    break;
-        case NC_FLOAT:  min = X_FLOAT_MIN;  max = X_FLOAT_MAX;  break;
-        case NC_DOUBLE: min = X_DOUBLE_MIN; max = X_DOUBLE_MAX; break;
-        case NC_UBYTE:  min = 0;            max = X_UCHAR_MAX;  break;
-        case NC_USHORT: min = 0;            max = X_USHORT_MAX; break;
-        case NC_UINT:   min = 0;            max = X_UINT_MAX;   break;
-        case NC_INT64:  min = X_INT64_MIN;  max = X_INT64_MAX;  break;
-        case NC_UINT64: min = 0;            max = X_UINT64_MAX; break;
+        case NC_CHAR:   min = CHAR_MIN;     max = (double)CHAR_MAX;     break;
+        case NC_BYTE:   min = X_BYTE_MIN;   max = (double)X_BYTE_MAX;   break;
+        case NC_SHORT:  min = X_SHORT_MIN;  max = (double)X_SHORT_MAX;  break;
+        case NC_INT:    min = X_INT_MIN;    max = (double)X_INT_MAX;    break;
+        case NC_FLOAT:  min = X_FLOAT_MIN;  max = (double)X_FLOAT_MAX;  break;
+        case NC_DOUBLE: min = X_DOUBLE_MIN; max = (double)X_DOUBLE_MAX; break;
+        case NC_UBYTE:  min = 0;            max = (double)X_UCHAR_MAX;  break;
+        case NC_USHORT: min = 0;            max = (double)X_USHORT_MAX; break;
+        case NC_UINT:   min = 0;            max = (double)X_UINT_MAX;   break;
+        case NC_INT64:  min = X_INT64_MIN;  max = (double)X_INT64_MAX;  break;
+        case NC_UINT64: min = 0;            max = (double)X_UINT64_MAX; break;
         default:
             return NC_EBADTYPE;
     }

--- a/test/nc_test/test_put.m4
+++ b/test/nc_test/test_put.m4
@@ -120,9 +120,9 @@ define(`CheckText', `ifelse(`$1',`text', , `== (NCT_ITYPE($1) == NCT_TEXT)')')dn
 define(`IfCheckTextChar', `ifelse(`$1',`text', `if ($2 != NC_CHAR)')')dnl
 define(`CheckNumRange',
        `ifelse(`$1',`text', `1',
-               `inRange3(cdf_format, (double)$2,$3,NCT_ITYPE($1)) && ($2 >= $1_min && $2 <= $1_max)')')dnl
+               `inRange3(cdf_format, (double)$2,$3,NCT_ITYPE($1)) && ($2 >= (double)$1_min && $2 <= (double)$1_max)')')dnl
 define(`CheckRange',
-       `ifelse(`$1',`text', `0', `($2 >= $1_min && $2 <= $1_max)')')dnl
+       `ifelse(`$1',`text', `0', `($2 >= (double)$1_min && $2 <= (double)$1_max)')')dnl
 define(`CheckRange3',
        `ifelse(`$1',`text', `1',
                `inRange3(cdf_format, (double)$2,$3,NCT_ITYPE($1))')')dnl
@@ -145,8 +145,8 @@ hash_$1(const int       cdf_format,
 
     value = hash4(cdf_format, type, rank, index, itype);
     ifelse(`$1',`text',`return (text)value;',`
-    if (value > $1_max) return $1_max;
-    else if (value < $1_min) return $1_min;
+    if (value > (double)$1_max) return $1_max;
+    else if (value < (double)$1_min) return $1_min;
     else return ($1)value;')
 }
 ')dnl

--- a/test/nc_test/util.c
+++ b/test/nc_test/util.c
@@ -34,8 +34,8 @@ inRange(const double value, const nc_type xtype)
         case NC_UBYTE:  return value >= 0            && value <= X_UCHAR_MAX;
         case NC_USHORT: return value >= 0            && value <= X_USHORT_MAX;
         case NC_UINT:   return value >= 0            && value <= X_UINT_MAX;
-        case NC_INT64:  return value >= X_INT64_MIN  && value <= X_INT64_MAX;
-        case NC_UINT64: return value >= 0            && value <= X_UINT64_MAX;
+        case NC_INT64:  return value >= (double)X_INT64_MIN  && value <= (double)X_INT64_MAX;
+        case NC_UINT64: return value >= 0            && value <= (double)X_UINT64_MAX;
         default:
             assert(0);
             return(0);
@@ -94,8 +94,12 @@ inRange_float(const double value, const nc_type xtype)
         case NC_UBYTE:  min = 0;            max = X_UCHAR_MAX;  break;
         case NC_USHORT: min = 0;            max = X_USHORT_MAX; break;
         case NC_UINT:   min = 0;            max = X_UINT_MAX;   break;
-        case NC_INT64:  min = X_INT64_MIN;  max = X_INT64_MAX;  break;
-        case NC_UINT64: min = 0;            max = X_UINT64_MAX; break;
+        case NC_INT64:  min = (double)X_INT64_MIN;
+                        max = (double)X_INT64_MAX;
+                        break;
+        case NC_UINT64: min = 0;
+                        max = (double)X_UINT64_MAX;
+                        break;
         default: assert(0);
     }
     if (!( value >= min && value <= max)) {
@@ -384,7 +388,7 @@ int dbl2nc ( const double d, const nc_type xtype, void *p)
             break;
         case NC_INT:
             r = floor(0.5+d);
-            if ( r < long_min  ||  r > long_max )  return 2;
+            if ( r < (double)long_min  ||  r > (double)long_max )  return 2;
 #if INT_MAX >= X_INT_MAX
             *((int   *) p) = (int)r;
 #else
@@ -409,12 +413,12 @@ int dbl2nc ( const double d, const nc_type xtype, void *p)
             break;
         case NC_INT64:
             r = floor(0.5+d);
-            if ( r < int64_min  ||  r > int64_max )  return 2;
+            if ( r < (double)int64_min  ||  r > (double)int64_max )  return 2;
             *((long long *) p) = (long long)r;
             break;
         case NC_UINT64:
             r = floor(0.5+d);
-            if ( r < 0.0  ||  r > uint64_max )  return 2;
+            if ( r < 0.0  ||  r > (double)uint64_max )  return 2;
             *((unsigned long long *) p) = (unsigned long long)r;
             break;
         default:

--- a/test/nf90_test/fortlib.c
+++ b/test/nf90_test/fortlib.c
@@ -128,7 +128,7 @@ FORTRAN_API void FORT_CALL nc_ignorefpe_(int *doit)
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL min_schar_(void) {
-	return SCHAR_MIN;
+	return (double)SCHAR_MIN;
 }
 
 #ifdef F77_NAME_UPPER
@@ -140,7 +140,7 @@ FORTRAN_API double FORT_CALL min_schar_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL min_short_(void) {
-	return SHRT_MIN;
+	return (double)SHRT_MIN;
 }
 
 #ifdef F77_NAME_UPPER
@@ -152,7 +152,7 @@ FORTRAN_API double FORT_CALL min_short_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL min_int_(void) {
-	return INT_MIN;
+	return (double)INT_MIN;
 }
 
 #ifdef F77_NAME_UPPER
@@ -164,7 +164,7 @@ FORTRAN_API double FORT_CALL min_int_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL min_int64_(void) {
-	return INT64_MIN;
+	return (double)INT64_MIN;
 }
 
 #ifdef F77_NAME_UPPER
@@ -176,7 +176,7 @@ FORTRAN_API double FORT_CALL min_int64_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL max_schar_(void) {
-	return SCHAR_MAX;
+	return (double)SCHAR_MAX;
 }
 
 #ifdef F77_NAME_UPPER
@@ -188,7 +188,7 @@ FORTRAN_API double FORT_CALL max_schar_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL max_short_(void) {
-	return SHRT_MAX;
+	return (double)SHRT_MAX;
 }
 
 #ifdef F77_NAME_UPPER
@@ -200,7 +200,7 @@ FORTRAN_API double FORT_CALL max_short_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL max_int_(void) {
-	return INT_MAX;
+	return (double)INT_MAX;
 }
 
 #ifdef F77_NAME_UPPER
@@ -212,7 +212,7 @@ FORTRAN_API double FORT_CALL max_int_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL max_int64_(void) {
-	return INT64_MAX;
+	return (double)INT64_MAX;
 }
 
 #ifdef F77_NAME_UPPER
@@ -224,7 +224,7 @@ FORTRAN_API double FORT_CALL max_int64_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL max_float_(void) {
-	return FLT_MAX;
+	return (double)FLT_MAX;
 }
 
 #ifdef F77_NAME_UPPER
@@ -236,7 +236,7 @@ FORTRAN_API double FORT_CALL max_float_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL max_double_(void) {
-	return DBL_MAX;
+	return (double)DBL_MAX;
 }
 
 #if 0 /* this is implemented in library src now */

--- a/test/nf_test/fortlib.c
+++ b/test/nf_test/fortlib.c
@@ -128,7 +128,7 @@ FORTRAN_API void FORT_CALL nc_ignorefpe_(int *doit)
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL min_schar_(void) {
-	return SCHAR_MIN;
+	return (double)SCHAR_MIN;
 }
 
 #ifdef F77_NAME_UPPER
@@ -140,7 +140,7 @@ FORTRAN_API double FORT_CALL min_schar_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL min_short_(void) {
-	return SHRT_MIN;
+	return (double)SHRT_MIN;
 }
 
 #ifdef F77_NAME_UPPER
@@ -152,7 +152,7 @@ FORTRAN_API double FORT_CALL min_short_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL min_int_(void) {
-	return INT_MIN;
+	return (double)INT_MIN;
 }
 
 #ifdef F77_NAME_UPPER
@@ -176,7 +176,7 @@ FORTRAN_API double FORT_CALL min_int64_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL max_schar_(void) {
-	return SCHAR_MAX;
+	return (double)SCHAR_MAX;
 }
 
 #ifdef F77_NAME_UPPER
@@ -188,7 +188,7 @@ FORTRAN_API double FORT_CALL max_schar_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL max_short_(void) {
-	return SHRT_MAX;
+	return (double)SHRT_MAX;
 }
 
 #ifdef F77_NAME_UPPER
@@ -200,7 +200,7 @@ FORTRAN_API double FORT_CALL max_short_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL max_int_(void) {
-	return INT_MAX;
+	return (double)INT_MAX;
 }
 
 #ifdef F77_NAME_UPPER
@@ -212,7 +212,7 @@ FORTRAN_API double FORT_CALL max_int_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL max_int64_(void) {
-	return INT64_MAX;
+	return (double)INT64_MAX;
 }
 
 #ifdef F77_NAME_UPPER
@@ -224,7 +224,7 @@ FORTRAN_API double FORT_CALL max_int64_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL max_float_(void) {
-	return FLT_MAX;
+	return (double)FLT_MAX;
 }
 
 #ifdef F77_NAME_UPPER
@@ -236,7 +236,7 @@ FORTRAN_API double FORT_CALL max_float_(void) {
 /* Else leave name alone */
 #endif
 FORTRAN_API double FORT_CALL max_double_(void) {
-	return DBL_MAX;
+	return (double)DBL_MAX;
 }
 
 #if 0 /* this is implemented in library src now */


### PR DESCRIPTION
implicit conversion from 'long' to 'double'
implicit conversion from 'long long' to 'double'
implicit conversion from 'unsigned long long' to 'double'