### PR TITLE
Stop using file striping size to automatically set header extent size

### DIFF
--- a/src/drivers/ncmpio/ncmpio_NC.h
+++ b/src/drivers/ncmpio/ncmpio_NC.h
@@ -360,7 +360,6 @@ struct NC {
     int           chunk;       /* chunk size for reading header */
     MPI_Offset    h_align;     /* file alignment for header size */
     MPI_Offset    v_align;     /* alignment of the beginning of fixed-size variables */
-    MPI_Offset    fx_v_align;  /* file alignment for each fixed-size variable */
     MPI_Offset    r_align;     /* file alignment for record variable section */
     MPI_Offset    h_minfree;   /* pad at the end of the header section */
     MPI_Offset    v_minfree;   /* pad at the end of the data section for fixed-size variables */

--- a/src/drivers/ncmpio/ncmpio_file_misc.c
+++ b/src/drivers/ncmpio/ncmpio_file_misc.c
@@ -352,7 +352,7 @@ ncmpio_inq_misc(void       *ncdp,
         sprintf(value, "%lld", ncp->h_align);
         MPI_Info_set(*info_used, "nc_header_align_size", value);
 
-        sprintf(value, "%lld", ncp->fx_v_align);
+        sprintf(value, "%lld", ncp->v_align);
         MPI_Info_set(*info_used, "nc_var_align_size", value);
 
         sprintf(value, "%lld", ncp->r_align);

--- a/src/drivers/ncmpio/ncmpio_subfile.c
+++ b/src/drivers/ncmpio/ncmpio_subfile.c
@@ -261,9 +261,9 @@ int ncmpio_subfile_partition(NC *ncp)
     /* NOTE: the following "for loop" should be before NC_begins() */
 
     /* adjust the hints to be used by PnetCDF; use the same value in master */
-    ncp->ncp_sf->h_align    = ncp->h_align;
-    ncp->ncp_sf->fx_v_align = ncp->fx_v_align;
-    ncp->ncp_sf->r_align    = ncp->r_align;
+    ncp->ncp_sf->h_align = ncp->h_align;
+    ncp->ncp_sf->v_align = ncp->v_align;
+    ncp->ncp_sf->r_align = ncp->r_align;
 
     for(i=0; i<ncp->vars.ndefined; i++) { /* traverse all variables */
         NC_var **vpp = ncp->vars.value;

--- a/src/drivers/ncmpio/ncmpio_util.c
+++ b/src/drivers/ncmpio/ncmpio_util.c
@@ -62,9 +62,9 @@ void ncmpio_set_pnetcdf_hints(NC *ncp,
         MPI_Info_get(user_info, "nc_var_align_size", MPI_MAX_INFO_VAL-1, value, &flag);
         if (flag) {
             errno = 0;  /* errno must set to zero before calling strtoll */
-            ncp->fx_v_align = strtoll(value, NULL, 10);
-            if (errno != 0) ncp->fx_v_align = 0;
-            else if (ncp->fx_v_align < 0) ncp->fx_v_align = 0;
+            ncp->v_align = strtoll(value, NULL, 10);
+            if (errno != 0) ncp->v_align = 0;
+            else if (ncp->v_align < 0) ncp->v_align = 0;
         }
     }
     if (!flag) sprintf(value, "%d", FILE_ALIGNMENT_DEFAULT);


### PR DESCRIPTION
Automatically set the size of file header extent using the file striping
size obtained from MPI-IO hint striping_unit may yield an unexpectedly
large file header extent and cause movement of data sections if new
metadata is added when the program re-enter the define mode. With this
commit, file striping size will no longer be used to set the file header
alignment size. However, users can still set nc_header_align_size in
PNETCDF_HINTS environment variable or v_align in ncmpi__enddef() to
customize the size of header extent.