### PR TITLE
change checking for size of dim/attr/header limit

### DIFF
--- a/src/dispatchers/dimension.c
+++ b/src/dispatchers/dimension.c
@@ -10,7 +10,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <limits.h> /* INT_MAX */
 #include <assert.h>
 
 #include <pnetcdf.h>
@@ -58,8 +57,8 @@ ncmpi_def_dim(int         ncid,    /* IN:  file ID */
     /* MPI_Offset is usually a signed value, but serial netcdf uses size_t.
      * In 1999 ISO C standard, size_t is an unsigned integer type of at least
      * 16 bit. */
-    if (pncp->format == NC_FORMAT_CDF2) { /* CDF-2 format, max is INT_MAX */
-        if (size > INT_MAX || (size < 0))
+    if (pncp->format == NC_FORMAT_CDF2) { /* CDF-2 format, max is NC_MAX_INT */
+        if (size > NC_MAX_INT || (size < 0))
             err = NC_EDIMSIZE;
     } else if (pncp->format == NC_FORMAT_CDF5) { /* CDF-5 format */
         if (size < 0)
@@ -68,7 +67,7 @@ ncmpi_def_dim(int         ncid,    /* IN:  file ID */
                pncp->format == NC_FORMAT_NETCDF4_CLASSIC) { /* NetCDF-4 format */
         if (size < 0)
             err = NC_EDIMSIZE;
-    } else { /* CDF-1 format, max is INT_MAX */
+    } else { /* CDF-1 format, max is NC_MAX_INT */
         if (size > NC_MAX_INT || (size < 0))
             err = NC_EDIMSIZE;
     }

--- a/src/dispatchers/dimension.c
+++ b/src/dispatchers/dimension.c
@@ -10,6 +10,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h> /* INT_MAX */
 #include <assert.h>
 
 #include <pnetcdf.h>
@@ -57,9 +58,8 @@ ncmpi_def_dim(int         ncid,    /* IN:  file ID */
     /* MPI_Offset is usually a signed value, but serial netcdf uses size_t.
      * In 1999 ISO C standard, size_t is an unsigned integer type of at least
      * 16 bit. */
-    if (pncp->format == NC_FORMAT_CDF2) { /* CDF-2 format, max is 2^32-4 */
-        if (size > NC_MAX_UINT - 3 || (size < 0))
-            /* "-3" handles rounded-up size */
+    if (pncp->format == NC_FORMAT_CDF2) { /* CDF-2 format, max is INT_MAX */
+        if (size > INT_MAX || (size < 0))
             err = NC_EDIMSIZE;
     } else if (pncp->format == NC_FORMAT_CDF5) { /* CDF-5 format */
         if (size < 0)
@@ -68,9 +68,8 @@ ncmpi_def_dim(int         ncid,    /* IN:  file ID */
                pncp->format == NC_FORMAT_NETCDF4_CLASSIC) { /* NetCDF-4 format */
         if (size < 0)
             err = NC_EDIMSIZE;
-    } else { /* CDF-1 format, max is 2^31-4 */
-        if (size > NC_MAX_INT - 3 || (size < 0))
-            /* "-3" handles rounded-up size */
+    } else { /* CDF-1 format, max is INT_MAX */
+        if (size > NC_MAX_INT || (size < 0))
             err = NC_EDIMSIZE;
     }
     if (err != NC_NOERR) {

--- a/src/drivers/ncmpio/ncmpio_header_put.c
+++ b/src/drivers/ncmpio/ncmpio_header_put.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #endif
 #include <stdio.h>
+#include <limits.h> /* INT_MAX */
 
 #include <mpi.h>
 
@@ -80,7 +81,8 @@ hdr_put_NC_dim(bufferinfo   *pbp,
     /* copy dim_length */
     if (pbp->version < 5) {
         /* TODO: Isn't checking dimension size already done in def_dim()? */
-        if (dimp->size != (uint)dimp->size) DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
+        if (dimp->size > INT_MAX)
+            DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
         err = ncmpix_put_uint32((void**)(&pbp->pos), (uint)dimp->size);
     }
     else
@@ -174,7 +176,8 @@ hdr_put_NC_attrV(bufferinfo    *pbp,
     sz = attrp->nelems * xsz;
     padding = attrp->xsz - sz;
 
-    if (sz != (size_t) sz) DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
+    if (sz > INT_MAX)
+        DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
     memcpy(pbp->pos, attrp->xvalue, (size_t)sz);
     pbp->pos = (void *)((char *)pbp->pos + sz);
 
@@ -212,7 +215,7 @@ hdr_put_NC_attr(bufferinfo    *pbp,
 
     /* copy nelems */
     if (pbp->version < 5) {
-        if (attrp->nelems != (uint)attrp->nelems)
+        if (attrp->nelems  > INT_MAX)
             DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
         status = ncmpix_put_uint32((void**)(&pbp->pos), (uint)attrp->nelems);
     }
@@ -365,7 +368,8 @@ hdr_put_NC_var(bufferinfo   *pbp,
      * in CDF-2 and CDF-5, it is a 64-bit integer
      */
     if (pbp->version == 1) {
-        if (varp->begin != (uint)varp->begin) DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
+        if (varp->begin  > INT_MAX)
+            DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
         status = ncmpix_put_uint32((void**)(&pbp->pos), (uint)varp->begin);
     }
     else
@@ -473,7 +477,8 @@ ncmpio_hdr_put_NC(NC *ncp, void *buf)
     /* copy numrecs, number of records */
     nrecs = ncp->numrecs;
     if (ncp->format < 5) {
-        if (nrecs != (uint)nrecs) DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
+        if (nrecs  > INT_MAX)
+            DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
         status = ncmpix_put_uint32((void**)(&putbuf.pos), (uint)nrecs);
     }
     else {
@@ -535,7 +540,7 @@ int ncmpio_write_header(NC *ncp)
         /* copy header object to write buffer */
         status = ncmpio_hdr_put_NC(ncp, buf);
 
-        if (ncp->xsz != (int)ncp->xsz) {
+        if (ncp->xsz  > INT_MAX) {
             NCI_Free(buf);
             DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
         }

--- a/src/drivers/ncmpio/ncmpio_header_put.c
+++ b/src/drivers/ncmpio/ncmpio_header_put.c
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 #endif
 #include <stdio.h>
-#include <limits.h> /* INT_MAX */
 
 #include <mpi.h>
 
@@ -81,7 +80,7 @@ hdr_put_NC_dim(bufferinfo   *pbp,
     /* copy dim_length */
     if (pbp->version < 5) {
         /* TODO: Isn't checking dimension size already done in def_dim()? */
-        if (dimp->size > INT_MAX)
+        if (dimp->size > NC_MAX_INT)
             DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
         err = ncmpix_put_uint32((void**)(&pbp->pos), (uint)dimp->size);
     }
@@ -176,7 +175,7 @@ hdr_put_NC_attrV(bufferinfo    *pbp,
     sz = attrp->nelems * xsz;
     padding = attrp->xsz - sz;
 
-    if (sz > INT_MAX)
+    if (sz > NC_MAX_INT)
         DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
     memcpy(pbp->pos, attrp->xvalue, (size_t)sz);
     pbp->pos = (void *)((char *)pbp->pos + sz);
@@ -215,7 +214,7 @@ hdr_put_NC_attr(bufferinfo    *pbp,
 
     /* copy nelems */
     if (pbp->version < 5) {
-        if (attrp->nelems  > INT_MAX)
+        if (attrp->nelems  > NC_MAX_INT)
             DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
         status = ncmpix_put_uint32((void**)(&pbp->pos), (uint)attrp->nelems);
     }
@@ -368,7 +367,7 @@ hdr_put_NC_var(bufferinfo   *pbp,
      * in CDF-2 and CDF-5, it is a 64-bit integer
      */
     if (pbp->version == 1) {
-        if (varp->begin  > INT_MAX)
+        if (varp->begin  > NC_MAX_INT)
             DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
         status = ncmpix_put_uint32((void**)(&pbp->pos), (uint)varp->begin);
     }
@@ -477,7 +476,7 @@ ncmpio_hdr_put_NC(NC *ncp, void *buf)
     /* copy numrecs, number of records */
     nrecs = ncp->numrecs;
     if (ncp->format < 5) {
-        if (nrecs  > INT_MAX)
+        if (nrecs  > NC_MAX_INT)
             DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
         status = ncmpix_put_uint32((void**)(&putbuf.pos), (uint)nrecs);
     }
@@ -540,7 +539,7 @@ int ncmpio_write_header(NC *ncp)
         /* copy header object to write buffer */
         status = ncmpio_hdr_put_NC(ncp, buf);
 
-        if (ncp->xsz  > INT_MAX) {
+        if (ncp->xsz  > NC_MAX_INT) {
             NCI_Free(buf);
             DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
         }

--- a/test/testcases/tst_dimsizes.c
+++ b/test/testcases/tst_dimsizes.c
@@ -25,14 +25,24 @@
 
 #include <testutils.h>
 
-#define DIMMAXCLASSIC (NC_MAX_INT - 3)
-#define DIMMAX64OFFSET (NC_MAX_UINT - 3)
+#define DIMMAXCLASSIC NC_MAX_INT
+#define DIMMAX64OFFSET NC_MAX_INT
 #define DIMMAX64DATA NC_MAX_INT64
 
 /*
- * NC_CLASSIC => NC_INT_MAX - 3
- * NC_64BIT_OFFSET => NC_UINT_MAX - 3
- * NC_64BIT_DATA => NC_INT64_MAX
+ * NetCDF file format specification:
+ *   netcdf_file  = header data
+ *   header       = magic numrecs dim_list gatt_list var_list
+ *   dim_list     = ABSENT | NC_DIMENSION nelems [dim ...]
+ *   dim          = name dim_length
+ *   dim_length   = NON_NEG
+ *   NON_NEG      = <non-negative INT>
+ *   INT          = <32-bit signed integer, Bigendian, two's complement>
+ *
+ * Therefore, the max dimension size are:
+ * NC_CLASSIC       Max dimension size is  NC_INT_MAX
+ * NC_64BIT_OFFSET  Max dimension size is  NC_INT_MAX
+ * NC_64BIT_DATA    Max dimension size is  NC_INT64_MAX
  * Note that for NC_64BIT_DATA, the max dimension size is different from netCDF
  * library. This is because PnetCDF uses MPI_Offset for dimension size and
  * MPI_Offset is a signed long long.
@@ -72,7 +82,7 @@ main(int argc, char **argv)
     err = ncmpi_def_dim(ncid, "testdim", dimsize, &dimid); CHECK_ERR
     dimsize = -1;
     err = ncmpi_def_dim(ncid, "testdim1", dimsize, &dimid); EXP_ERR(NC_EDIMSIZE)
-    dimsize = DIMMAXCLASSIC+1;
+    dimsize = (MPI_Offset)DIMMAXCLASSIC+1;
     err = ncmpi_def_dim(ncid, "testdim1", dimsize, &dimid); EXP_ERR(NC_EDIMSIZE)
     err = ncmpi_close(ncid); CHECK_ERR
 
@@ -92,7 +102,7 @@ main(int argc, char **argv)
     err = ncmpi_def_dim(ncid, "testdim", dimsize, &dimid); CHECK_ERR
     dimsize = -1;
     err = ncmpi_def_dim(ncid, "testdim1", dimsize, &dimid); EXP_ERR(NC_EDIMSIZE)
-    dimsize = DIMMAX64OFFSET+1;
+    dimsize = (MPI_Offset)DIMMAX64OFFSET+1;
     err = ncmpi_def_dim(ncid, "testdim1", dimsize, &dimid); EXP_ERR(NC_EDIMSIZE)
     err = ncmpi_close(ncid); CHECK_ERR
 


### PR DESCRIPTION
The maximal header extent for CDF 1 and 2 should be `NC_MAX_INT `, i,e,
the maximum value of a signed 4-byte integer, `2^31-1`. Same for the
dimension size. This is because NetCDF file format defines them as
non-negative **signed** integers, `OFFSET` and `NON_NEG` respectively.

NetCDF file format specification:
```
netcdf_file  = header data
header       = magic numrecs dim_list gatt_list var_list
dim_list     = ABSENT | NC_DIMENSION nelems [dim ...]
dim          = name dim_length
var          = name nelems [dimid ...] vatt_list nc_type vsize begin
vsize        = NON_NEG
dim_length   = NON_NEG 
NON_NEG      = <non-negative INT>
begin        = OFFSET
OFFSET       = <non-negative INT> | <non-negative INT64>
INT          = <32-bit signed integer, Bigendian, two's complement>
```

* `begin` is the file extent, i.e. starting file offset of the data section.
* `dim_length` is the dimension size.

Note for variable size, the maximal is
  2^31-3  for CDF-1 
  2^32-3  for CDF-2 
  2^63-3  for CDF-5 
Variable size is calculated internally in PnetCDF. Therefore, the
variable size is limited to the space available in bytes. `-3` is 
due to the 4-byte upward alignment.
Although `vsize` is defined and stored in the file header, it is marked as a redundant item and is not used in PnetCDF.
