### PR TITLE
Allow different hash table size for dim/var/attr

### DIFF
--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -95,6 +95,18 @@ This is essentially a placeholder for the next release note ...
   + none
 
 * New PnetCDF hint
+  + `nc_hash_size_dim:   Set hash table size for dimension names. Default: 256
+  + `nc_hash_size_var:   Set hash table size for variable names. Default: 256
+  + `nc_hash_size_gattr: Set hash table size for global attribute names.
+    Default: 64
+  + `nc_hash_size_vattr: Set hash table size for variable attribute names.
+    Default: 8
+  + The above 4 new hints allow users to set different hash table sizes for
+    different objects.  For instance, when the number of variables to be
+    defined is large and the number of attributes per variable is small,
+    increasing `nc_hash_size_var` can speed up the definition time, and
+    reducing `nc_hash_size_vattr` can reduce the memory footprint. See
+    [PR #132](https://github.com/Parallel-NetCDF/PnetCDF/pull/132).
   + `nc_header_collective` -- to instruct PnetCDF to call MPI collective APIs to
     read and write the file header. The default is "false", meaning the file
     header is only read/written by rank 0, using MPI independent read and write
@@ -179,6 +191,12 @@ This is essentially a placeholder for the next release note ...
   + none
 
 * New test program
+  + test/largefile/tst_hash_large_ndims.c - test hashing performance when
+    the number of dimensions is large.
+  + test/largefile/tst_hash_large_nvars.c - test hashing performance when
+    the number of variables is large.
+  + test/largefile/tst_hash_large_ngattr.c - test hashing performance when
+    the number of global attributes is large.
   + test/largefile/large_header.c - test file header size larger than 2 GiB.
   + test/largefile/large_reqs.c - test a single read/write request of size
     larger than 2 GiB.

--- a/src/drivers/ncmpio/ncmpio_create.c
+++ b/src/drivers/ncmpio/ncmpio_create.c
@@ -268,7 +268,7 @@ ncmpio_create(MPI_Comm     comm,
     ncp->ncid = ncid;
 
     /* chunk size for reading header, set to default before check hints */
-    ncp->chunk = NC_DEFAULT_CHUNKSIZE;
+    ncp->chunk = PNC_DEFAULT_CHUNKSIZE;
 
     /* calculate the true header size (not-yet aligned)
      * No need to do this now.
@@ -279,7 +279,7 @@ ncmpio_create(MPI_Comm     comm,
     ncp->dims.unlimited_id = -1;
 
     /* buffer to pack noncontiguous user buffers when calling wait() */
-    ncp->ibuf_size = NC_DEFAULT_IBUF_SIZE;
+    ncp->ibuf_size = PNC_DEFAULT_IBUF_SIZE;
 
     /* Extract PnetCDF specific I/O hints from user_info and set default hint
      * values into info_used. Note some MPI libraries, such as MPICH 3.3.1 and

--- a/src/drivers/ncmpio/ncmpio_file_misc.c
+++ b/src/drivers/ncmpio/ncmpio_file_misc.c
@@ -45,9 +45,16 @@ dup_NC(const NC *ref)
     /* copy most of the NC members over */
     *ncp = *ref;
 
+#ifndef SEARCH_NAME_LINEARLY
+    /* set hash tables to NULL, indicating space not-yet allocated */
+    ncp->dims.nameT = NULL;
+    ncp->vars.nameT = NULL;
+    ncp->attrs.nameT = NULL;
+#endif
+
     if (ncmpio_dup_NC_dimarray(&ncp->dims,   &ref->dims)  != NC_NOERR ||
         ncmpio_dup_NC_attrarray(&ncp->attrs, &ref->attrs) != NC_NOERR ||
-        ncmpio_dup_NC_vararray(&ncp->vars,   &ref->vars)  != NC_NOERR) {
+        ncmpio_dup_NC_vararray(&ncp->vars,   &ref->vars, ref->hash_size_attr) != NC_NOERR) {
         ncmpio_free_NC(ncp);
         return NULL;
     }

--- a/src/drivers/ncmpio/ncmpio_header_get.c
+++ b/src/drivers/ncmpio/ncmpio_header_get.c
@@ -753,7 +753,7 @@ hdr_get_NC_dimarray(bufferinfo *gbp, NC_dimarray *ncap)
         DEBUG_RETURN_ERROR(NC_ENOTNC)
     }
 
-    alloc_size = _RNDUP(ncap->ndefined, NC_ARRAY_GROWBY);
+    alloc_size = _RNDUP(ncap->ndefined, PNC_ARRAY_GROWBY);
     ncap->value = (NC_dim**) NCI_Calloc(alloc_size, sizeof(NC_dim*));
     if (ncap->value == NULL) DEBUG_RETURN_ERROR(NC_ENOMEM)
 
@@ -998,7 +998,7 @@ hdr_get_NC_attrarray(bufferinfo *gbp, NC_attrarray *ncap)
         DEBUG_RETURN_ERROR(NC_ENOTNC)
     }
 
-    alloc_size = _RNDUP(ncap->ndefined, NC_ARRAY_GROWBY);
+    alloc_size = _RNDUP(ncap->ndefined, PNC_ARRAY_GROWBY);
     ncap->value = (NC_attr**) NCI_Calloc(alloc_size, sizeof(NC_attr*));
     if (ncap->value == NULL) DEBUG_RETURN_ERROR(NC_ENOMEM)
 
@@ -1244,7 +1244,7 @@ hdr_get_NC_vararray(bufferinfo  *gbp,
         DEBUG_RETURN_ERROR(NC_ENOTNC)
     }
 
-    alloc_size = _RNDUP(ncap->ndefined, NC_ARRAY_GROWBY);
+    alloc_size = _RNDUP(ncap->ndefined, PNC_ARRAY_GROWBY);
     ncap->value = (NC_var**) NCI_Calloc(alloc_size, sizeof(NC_var*));
     if (ncap->value == NULL) DEBUG_RETURN_ERROR(NC_ENOMEM)
 

--- a/src/drivers/ncmpio/ncmpio_open.c
+++ b/src/drivers/ncmpio/ncmpio_open.c
@@ -40,7 +40,7 @@ ncmpio_open(MPI_Comm     comm,
             void       **ncpp)
 {
     char *env_str;
-    int mpiomode, err, status=NC_NOERR, mpireturn;
+    int i, mpiomode, err, status=NC_NOERR, mpireturn;
     MPI_File fh;
     MPI_Info info_used;
     NC *ncp=NULL;
@@ -99,10 +99,10 @@ ncmpio_open(MPI_Comm     comm,
     ncp->ncid = ncid;
 
     /* chunk size for reading header (set default before check hints) */
-    ncp->chunk = NC_DEFAULT_CHUNKSIZE;
+    ncp->chunk = PNC_DEFAULT_CHUNKSIZE;
 
     /* buffer to pack noncontiguous user buffers when calling wait() */
-    ncp->ibuf_size = NC_DEFAULT_IBUF_SIZE;
+    ncp->ibuf_size = PNC_DEFAULT_IBUF_SIZE;
 
     /* Extract PnetCDF specific I/O hints from user_info and set default hint
      * values into info_used. Note some MPI libraries, such as MPICH 3.3.1 and
@@ -182,9 +182,11 @@ ncmpio_open(MPI_Comm     comm,
 
 #ifndef SEARCH_NAME_LINEARLY
     /* initialize and populate name lookup tables ---------------------------*/
-    ncmpio_hash_table_populate_NC_dim(&ncp->dims);
-    ncmpio_hash_table_populate_NC_var(&ncp->vars);
+    ncmpio_hash_table_populate_NC_dim(&ncp->dims, ncp->dims.hash_size);
+    ncmpio_hash_table_populate_NC_var(&ncp->vars, ncp->vars.hash_size);
     ncmpio_hash_table_populate_NC_attr(ncp);
+    for (i=0; i<ncp->vars.ndefined; i++)
+        ncp->vars.value[i]->attrs.hash_size = ncp->hash_size_attr;
 #endif
 
     *ncpp = (void*)ncp;

--- a/src/drivers/ncmpio/ncmpio_util.c
+++ b/src/drivers/ncmpio/ncmpio_util.c
@@ -190,6 +190,70 @@ void ncmpio_set_pnetcdf_hints(NC *ncp,
     }
     if (!flag) strcpy(value, "false");
     MPI_Info_set(info_used, "nc_header_collective", value);
+
+    ncp->dims.hash_size = PNC_HSIZE_DIM;
+    if (user_info != MPI_INFO_NULL) {
+        /* Hash table size for dimensions */
+        MPI_Info_get(user_info, "nc_hash_size_dim", MPI_MAX_INFO_VAL-1,
+                     value, &flag);
+        if (flag) {
+            errno = 0;  /* errno must set to zero before calling atoi */
+            ncp->dims.hash_size = atoi(value);
+            if (errno != 0 || ncp->dims.hash_size < 0)
+                ncp->dims.hash_size = PNC_HSIZE_DIM;
+            sprintf(value, "%d", ncp->dims.hash_size);
+        }
+    }
+    if (!flag) sprintf(value, "%d", PNC_HSIZE_DIM);
+    MPI_Info_set(info_used, "nc_hash_size_dim", value);
+
+    ncp->vars.hash_size = PNC_HSIZE_VAR;
+    if (user_info != MPI_INFO_NULL) {
+        /* Hash table size for variables */
+        MPI_Info_get(user_info, "nc_hash_size_var", MPI_MAX_INFO_VAL-1,
+                     value, &flag);
+        if (flag) {
+            errno = 0;  /* errno must set to zero before calling atoi */
+            ncp->vars.hash_size = atoi(value);
+            if (errno != 0 || ncp->vars.hash_size < 0)
+                ncp->vars.hash_size = PNC_HSIZE_VAR;
+            sprintf(value, "%d", ncp->vars.hash_size);
+        }
+    }
+    if (!flag) sprintf(value, "%d", PNC_HSIZE_VAR);
+    MPI_Info_set(info_used, "nc_hash_size_var", value);
+
+    ncp->attrs.hash_size = PNC_HSIZE_GATTR;
+    if (user_info != MPI_INFO_NULL) {
+        /* Hash table size for global attributes */
+        MPI_Info_get(user_info, "nc_hash_size_gattr", MPI_MAX_INFO_VAL-1,
+                     value, &flag);
+        if (flag) {
+            errno = 0;  /* errno must set to zero before calling atoi */
+            ncp->attrs.hash_size = atoi(value);
+            if (errno != 0 || ncp->attrs.hash_size < 0)
+                ncp->attrs.hash_size = PNC_HSIZE_GATTR;
+            sprintf(value, "%d", ncp->attrs.hash_size);
+        }
+    }
+    if (!flag) sprintf(value, "%d", PNC_HSIZE_GATTR);
+    MPI_Info_set(info_used, "nc_hash_size_gattr", value);
+
+    ncp->hash_size_attr = PNC_HSIZE_VATTR;
+    if (user_info != MPI_INFO_NULL) {
+        /* Hash table size for non-global attributes */
+        MPI_Info_get(user_info, "nc_hash_size_vattr", MPI_MAX_INFO_VAL-1,
+                     value, &flag);
+        if (flag) {
+            errno = 0;  /* errno must set to zero before calling atoi */
+            ncp->hash_size_attr = atoi(value);
+            if (errno != 0 || ncp->hash_size_attr < 0)
+                ncp->hash_size_attr = PNC_HSIZE_VATTR;
+            sprintf(value, "%d", ncp->hash_size_attr);
+        }
+    }
+    if (!flag) sprintf(value, "%d", PNC_HSIZE_VATTR);
+    MPI_Info_set(info_used, "nc_hash_size_vattr", value);
 }
 
 /*----< ncmpio_first_offset() >-----------------------------------------------*/

--- a/src/drivers/ncmpio/ncmpio_util.c
+++ b/src/drivers/ncmpio/ncmpio_util.c
@@ -106,7 +106,7 @@ void ncmpio_set_pnetcdf_hints(NC *ncp,
             sprintf(value, "%d", ncp->chunk);
         }
     }
-    if (!flag) sprintf(value, "%d", NC_DEFAULT_CHUNKSIZE);
+    if (!flag) sprintf(value, "%d", PNC_DEFAULT_CHUNKSIZE);
     MPI_Info_set(info_used, "nc_header_read_chunk_size", value);
 
     if (user_info != MPI_INFO_NULL) {
@@ -144,7 +144,7 @@ void ncmpio_set_pnetcdf_hints(NC *ncp,
             sprintf(value, "%lld", ncp->ibuf_size);
         }
     }
-    if (!flag) sprintf(value, "%d", NC_DEFAULT_IBUF_SIZE);
+    if (!flag) sprintf(value, "%d", PNC_DEFAULT_IBUF_SIZE);
     MPI_Info_set(info_used, "nc_ibuf_size", value);
 
 #ifdef ENABLE_SUBFILING

--- a/test/largefile/Makefile.am
+++ b/test/largefile/Makefile.am
@@ -29,6 +29,9 @@ TESTPROGRAMS = large_files \
                large_dims_vars_attrs \
                high_dim_var \
                tst_cdf5_begin \
+               tst_hash_large_ndims \
+               tst_hash_large_nvars \
+               tst_hash_large_ngattrs \
                large_coalesce \
                large_header \
                large_reqs

--- a/test/largefile/large_dims_vars_attrs.c
+++ b/test/largefile/large_dims_vars_attrs.c
@@ -25,7 +25,7 @@
 #include <pnetcdf.h>
 #include <testutils.h>
 
-#define LARGE_NUM 10240
+#define LARGE_NUM 102400
 
 int main(int argc, char** argv)
 {
@@ -100,8 +100,11 @@ int main(int argc, char** argv)
     err = ncmpi_close(ncid);
     CHECK_ERR
 
-    err = ncmpi_open(MPI_COMM_WORLD, filename, NC_NOWRITE, MPI_INFO_NULL,
+    err = ncmpi_open(MPI_COMM_WORLD, filename, NC_WRITE, MPI_INFO_NULL,
                      &ncid); CHECK_ERR
+
+    err = ncmpi_redef(ncid); CHECK_ERR
+    err = ncmpi_enddef(ncid); CHECK_ERR
 
     for (i=0; i<LARGE_NUM; i++) {
         MPI_Offset len;
@@ -139,6 +142,10 @@ int main(int argc, char** argv)
             ncmpi_inq_malloc_list();
         }
     }
+
+    err = ncmpi_inq_malloc_max_size(&malloc_size);
+    printf("%d: PnetCDF internal memory footprint high water mark %.2f MB\n",
+           rank, (float)malloc_size/1048576);
 
     MPI_Allreduce(MPI_IN_PLACE, &nerrs, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
     if (rank == 0) {

--- a/test/largefile/tst_hash_large_ndims.c
+++ b/test/largefile/tst_hash_large_ndims.c
@@ -1,0 +1,157 @@
+/*********************************************************************
+ *
+ *  Copyright (C) 2024, Northwestern University and Argonne National Laboratory
+ *  See COPYRIGHT notice in top-level directory.
+ *
+ *********************************************************************/
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * This program is to test hash function performance using a large number of
+ * dimensions e.g. > 100K
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h> /* strcpy() */
+#include <libgen.h> /* basename() */
+#include <mpi.h>
+#include <pnetcdf.h>
+#include <testutils.h>
+
+#define NDIMS 400000
+
+int main(int argc, char** argv)
+{
+    char filename[256];
+    int i, rank, nprocs, err, nerrs=0, ncid, cmode, dimid, verbose=1;
+    double timing[2], max_timing[2];
+    MPI_Offset malloc_size[2], sum_size, max_size[2];
+    MPI_Info info;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+
+    /* get command-line arguments */
+    if (argc > 2) {
+        if (!rank) printf("Usage: %s [filename]\n",argv[0]);
+        MPI_Finalize();
+        return 1;
+    }
+    if (argc == 2) snprintf(filename, 256, "%s", argv[1]);
+    else           strcpy(filename, "testfile.nc");
+    MPI_Bcast(filename, 256, MPI_CHAR, 0, MPI_COMM_WORLD);
+
+    if (rank == 0) {
+        char *cmd_str = (char*)malloc(strlen(argv[0]) + 256);
+        sprintf(cmd_str, "*** TESTING C   %s for hasing large ndims ",
+                basename(argv[0]));
+        printf("%-66s ------ ", cmd_str); fflush(stdout);
+        free(cmd_str);
+    }
+
+    if (verbose && rank == 0) printf("\nNDIMS = %d\n", NDIMS);
+
+    MPI_Info_create(&info);
+    MPI_Info_set(info, "nc_hash_size_dim", "2048");
+
+    /* create a new file for writing ----------------------------------------*/
+    cmode = NC_CLOBBER | NC_64BIT_DATA;
+    err = ncmpi_create(MPI_COMM_WORLD, filename, cmode, info, &ncid);
+    CHECK_ERR
+
+    MPI_Info_free(&info);
+
+    err = ncmpi_inq_malloc_size(&malloc_size[0]); CHECK_ERR
+    err = ncmpi_inq_malloc_max_size(&malloc_size[1]); CHECK_ERR
+    MPI_Reduce(&malloc_size, &max_size, 2, MPI_OFFSET, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (verbose && rank == 0) {
+        printf("After ncmpi_create,  PnetCDF memory footprint high watermark %6.1f MB\n",
+               (float)max_size[1]/1048576);
+        printf("After ncmpi_create,  PnetCDF memory footprint                %6.1f MB\n",
+               (float)max_size[0]/1048576);
+    }
+    fflush(stdout);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    timing[0] = MPI_Wtime();
+    for (i=0; i<NDIMS; i++) {
+        char name[64];
+        sprintf(name, "d%d.x%d", (i*1747)%8642+100000, (i*8313)%97531+100000);
+        err = ncmpi_def_dim(ncid, name, nprocs, &dimid);
+        CHECK_ERR
+    }
+    timing[0] = MPI_Wtime() - timing[0];
+
+    err = ncmpi_inq_malloc_size(&malloc_size[0]); CHECK_ERR
+    err = ncmpi_inq_malloc_max_size(&malloc_size[1]); CHECK_ERR
+    MPI_Reduce(&malloc_size, &max_size, 2, MPI_OFFSET, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (verbose && rank == 0) {
+        printf("After ncmpi_def_dim, PnetCDF memory footprint high watermark %6.1f MB\n",
+               (float)max_size[1]/1048576);
+        printf("After ncmpi_def_dim, PnetCDF memory footprint                %6.1f MB\n",
+               (float)max_size[0]/1048576);
+    }
+    fflush(stdout);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    timing[1] = MPI_Wtime();
+    err = ncmpi_enddef(ncid);
+    CHECK_ERR
+    timing[1] = MPI_Wtime() - timing[1];
+
+    err = ncmpi_inq_malloc_size(&malloc_size[0]); CHECK_ERR
+    err = ncmpi_inq_malloc_max_size(&malloc_size[1]); CHECK_ERR
+    MPI_Reduce(&malloc_size, &max_size, 2, MPI_OFFSET, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (verbose && rank == 0) {
+        MPI_Offset header_size, header_extent;
+        ncmpi_inq_header_extent(ncid, &header_extent);
+        ncmpi_inq_header_size(ncid, &header_size);
+        printf("After ncmpi_enddef,  PnetCDF memory footprint high watermark %6.1f MB\n",
+               (float)max_size[1]/1048576);
+        printf("After ncmpi_enddef,  PnetCDF memory footprint                %6.1f MB\n",
+               (float)max_size[0]/1048576);
+        printf("NetCDF file header size %lld extent %lld\n",header_size,header_extent);
+    }
+    fflush(stdout);
+
+    err = ncmpi_close(ncid);
+    CHECK_ERR
+
+    err = ncmpi_inq_malloc_size(&malloc_size[0]); CHECK_ERR
+    err = ncmpi_inq_malloc_max_size(&malloc_size[1]); CHECK_ERR
+    MPI_Reduce(&malloc_size, &max_size, 2, MPI_OFFSET, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (verbose && rank == 0) {
+        printf("After ncmpi_close,   PnetCDF memory footprint high watermark %6.1f MB\n",
+               (float)max_size[1]/1048576);
+        printf("After ncmpi_close,   PnetCDF memory footprint                %4lld B\n",
+               max_size[0]);
+    }
+
+    /* check if PnetCDF freed all internal malloc */
+    if (err == NC_NOERR) {
+        MPI_Reduce(&malloc_size[0], &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
+        if (rank == 0 && sum_size > 0) {
+            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+                   sum_size);
+            ncmpi_inq_malloc_list();
+        }
+    }
+
+    MPI_Reduce(&timing, &max_timing, 2, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (verbose && rank == 0)
+        printf("Time ncmpi_def_dim = %.4f ncmpi_enddef = %.4f\n", max_timing[0],max_timing[1]);
+
+    MPI_Allreduce(MPI_IN_PLACE, &nerrs, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    if (rank == 0) {
+        if (nerrs) printf(FAIL_STR,nerrs);
+        else       printf(PASS_STR);
+    }
+
+    MPI_Finalize();
+    return (nerrs > 0);
+}
+

--- a/test/largefile/tst_hash_large_ngattrs.c
+++ b/test/largefile/tst_hash_large_ngattrs.c
@@ -1,0 +1,157 @@
+/*********************************************************************
+ *
+ *  Copyright (C) 2024, Northwestern University and Argonne National Laboratory
+ *  See COPYRIGHT notice in top-level directory.
+ *
+ *********************************************************************/
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * This program is to test hash function performance using a large number of
+ * global attributes e.g. > 100K
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h> /* strcpy() */
+#include <libgen.h> /* basename() */
+#include <mpi.h>
+#include <pnetcdf.h>
+#include <testutils.h>
+
+#define NATTRS 400000
+
+int main(int argc, char** argv)
+{
+    char filename[256];
+    int i, rank, nprocs, err, nerrs=0, ncid, cmode, verbose=1;
+    double timing[2], max_timing[2];
+    MPI_Offset malloc_size[2], sum_size, max_size[2];
+    MPI_Info info;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+
+    /* get command-line arguments */
+    if (argc > 2) {
+        if (!rank) printf("Usage: %s [filename]\n",argv[0]);
+        MPI_Finalize();
+        return 1;
+    }
+    if (argc == 2) snprintf(filename, 256, "%s", argv[1]);
+    else           strcpy(filename, "testfile.nc");
+    MPI_Bcast(filename, 256, MPI_CHAR, 0, MPI_COMM_WORLD);
+
+    if (rank == 0) {
+        char *cmd_str = (char*)malloc(strlen(argv[0]) + 256);
+        sprintf(cmd_str, "*** TESTING C   %s for hashing of large gattr ",
+                basename(argv[0]));
+        printf("%-66s ------ ", cmd_str); fflush(stdout);
+        free(cmd_str);
+    }
+
+    if (verbose && rank == 0) printf("\nNATTRS = %d\n", NATTRS);
+
+    MPI_Info_create(&info);
+    MPI_Info_set(info, "nc_hash_size_gattr", "2048");
+
+    /* create a new file for writing ----------------------------------------*/
+    cmode = NC_CLOBBER | NC_64BIT_DATA;
+    err = ncmpi_create(MPI_COMM_WORLD, filename, cmode, info, &ncid);
+    CHECK_ERR
+
+    MPI_Info_free(&info);
+
+    err = ncmpi_inq_malloc_size(&malloc_size[0]); CHECK_ERR
+    err = ncmpi_inq_malloc_max_size(&malloc_size[1]); CHECK_ERR
+    MPI_Reduce(&malloc_size, &max_size, 2, MPI_OFFSET, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (verbose && rank == 0) {
+        printf("After ncmpi_create,  PnetCDF memory footprint high watermark %6.1f MB\n",
+               (float)max_size[1]/1048576);
+        printf("After ncmpi_create,  PnetCDF memory footprint                %6.1f MB\n",
+               (float)max_size[0]/1048576);
+    }
+    fflush(stdout);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    timing[0] = MPI_Wtime();
+    for (i=0; i<NATTRS; i++) {
+        char name[64];
+        sprintf(name, "attr_%d.x%d", (i*1747)%8642+100000, (i*8313)%97531+100000);
+        err = ncmpi_put_att(ncid, NC_GLOBAL, name, NC_INT, 1, &i);
+        CHECK_ERR
+    }
+    timing[0] = MPI_Wtime() - timing[0];
+
+    err = ncmpi_inq_malloc_size(&malloc_size[0]); CHECK_ERR
+    err = ncmpi_inq_malloc_max_size(&malloc_size[1]); CHECK_ERR
+    MPI_Reduce(&malloc_size, &max_size, 2, MPI_OFFSET, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (verbose && rank == 0) {
+        printf("After ncmpi_put_att, PnetCDF memory footprint high watermark %6.1f MB\n",
+               (float)max_size[1]/1048576);
+        printf("After ncmpi_put_att, PnetCDF memory footprint                %6.1f MB\n",
+               (float)max_size[0]/1048576);
+    }
+    fflush(stdout);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    timing[1] = MPI_Wtime();
+    err = ncmpi_enddef(ncid);
+    CHECK_ERR
+    timing[1] = MPI_Wtime() - timing[1];
+
+    err = ncmpi_inq_malloc_size(&malloc_size[0]); CHECK_ERR
+    err = ncmpi_inq_malloc_max_size(&malloc_size[1]); CHECK_ERR
+    MPI_Reduce(&malloc_size, &max_size, 2, MPI_OFFSET, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (verbose && rank == 0) {
+        MPI_Offset header_size, header_extent;
+        ncmpi_inq_header_extent(ncid, &header_extent);
+        ncmpi_inq_header_size(ncid, &header_size);
+        printf("After ncmpi_enddef,  PnetCDF memory footprint high watermark %6.1f MB\n",
+               (float)max_size[1]/1048576);
+        printf("After ncmpi_enddef,  PnetCDF memory footprint                %6.1f MB\n",
+               (float)max_size[0]/1048576);
+        printf("NetCDF file header size %lld extent %lld\n",header_size,header_extent);
+    }
+    fflush(stdout);
+
+    err = ncmpi_close(ncid);
+    CHECK_ERR
+
+    err = ncmpi_inq_malloc_size(&malloc_size[0]); CHECK_ERR
+    err = ncmpi_inq_malloc_max_size(&malloc_size[1]); CHECK_ERR
+    MPI_Reduce(&malloc_size, &max_size, 2, MPI_OFFSET, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (verbose && rank == 0) {
+        printf("After ncmpi_close,   PnetCDF memory footprint high watermark %6.1f MB\n",
+               (float)max_size[1]/1048576);
+        printf("After ncmpi_close,   PnetCDF memory footprint                %4lld B\n",
+               max_size[0]);
+    }
+
+    /* check if PnetCDF freed all internal malloc */
+    if (err == NC_NOERR) {
+        MPI_Reduce(&malloc_size[0], &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
+        if (rank == 0 && sum_size > 0) {
+            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+                   sum_size);
+            ncmpi_inq_malloc_list();
+        }
+    }
+
+    MPI_Reduce(&timing, &max_timing, 2, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (verbose && rank == 0)
+        printf("Time ncmpi_put_att = %.4f ncmpi_enddef = %.4f\n", max_timing[0],max_timing[1]);
+
+    MPI_Allreduce(MPI_IN_PLACE, &nerrs, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    if (rank == 0) {
+        if (nerrs) printf(FAIL_STR,nerrs);
+        else       printf(PASS_STR);
+    }
+
+    MPI_Finalize();
+    return (nerrs > 0);
+}
+

--- a/test/largefile/tst_hash_large_nvars.c
+++ b/test/largefile/tst_hash_large_nvars.c
@@ -1,0 +1,186 @@
+/*********************************************************************
+ *
+ *  Copyright (C) 2024, Northwestern University and Argonne National Laboratory
+ *  See COPYRIGHT notice in top-level directory.
+ *
+ *********************************************************************/
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * This program is to test hash function performance using a large number of
+ * variables e.g. > 100K
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h> /* strcpy() */
+#include <libgen.h> /* basename() */
+#include <mpi.h>
+#include <pnetcdf.h>
+#include <testutils.h>
+
+#define NVARS 400000
+
+int main(int argc, char** argv)
+{
+    char filename[256];
+    int i, rank, nprocs, err, nerrs=0, ncid, cmode, dimid, *varid, verbose=1;
+    double timing[3], max_timing[3];
+    MPI_Offset malloc_size[2], sum_size, max_size[2];
+    MPI_Info info;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+
+    /* get command-line arguments */
+    if (argc > 2) {
+        if (!rank) printf("Usage: %s [filename]\n",argv[0]);
+        MPI_Finalize();
+        return 1;
+    }
+    if (argc == 2) snprintf(filename, 256, "%s", argv[1]);
+    else           strcpy(filename, "testfile.nc");
+    MPI_Bcast(filename, 256, MPI_CHAR, 0, MPI_COMM_WORLD);
+
+    if (rank == 0) {
+        char *cmd_str = (char*)malloc(strlen(argv[0]) + 256);
+        sprintf(cmd_str, "*** TESTING C   %s for hashing of large nvars ",
+                basename(argv[0]));
+        printf("%-66s ------ ", cmd_str); fflush(stdout);
+        free(cmd_str);
+    }
+
+    if (verbose && rank == 0) printf("\nNVARS = %d\n", NVARS);
+
+    varid = (int*) malloc(sizeof(int) * NVARS);
+
+    MPI_Info_create(&info);
+    MPI_Info_set(info, "nc_hash_size_var", "2048");
+
+    /* create a new file for writing ----------------------------------------*/
+    cmode = NC_CLOBBER | NC_64BIT_DATA;
+    err = ncmpi_create(MPI_COMM_WORLD, filename, cmode, info, &ncid);
+    CHECK_ERR
+
+    MPI_Info_free(&info);
+
+    err = ncmpi_inq_malloc_size(&malloc_size[0]); CHECK_ERR
+    err = ncmpi_inq_malloc_max_size(&malloc_size[1]); CHECK_ERR
+    MPI_Reduce(&malloc_size, &max_size, 2, MPI_OFFSET, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (verbose && rank == 0) {
+        printf("After ncmpi_create,  PnetCDF memory footprint high watermark %6.1f MB\n",
+               (float)max_size[1]/1048576);
+        printf("After ncmpi_create,  PnetCDF memory footprint                %6.1f MB\n",
+               (float)max_size[0]/1048576);
+    }
+    fflush(stdout);
+
+    err = ncmpi_def_dim(ncid, "dim", nprocs, &dimid);
+    CHECK_ERR
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    timing[0] = MPI_Wtime();
+    for (i=0; i<NVARS; i++) {
+        char name[64];
+        sprintf(name, "v%d.x%d", (i*1747)%8642+100000, (i*8313)%97531+100000);
+        err = ncmpi_def_var(ncid, name, NC_INT, 1, &dimid, &varid[i]);
+        CHECK_ERR
+    }
+    timing[0] = MPI_Wtime() - timing[0];
+
+    err = ncmpi_inq_malloc_size(&malloc_size[0]); CHECK_ERR
+    err = ncmpi_inq_malloc_max_size(&malloc_size[1]); CHECK_ERR
+    MPI_Reduce(&malloc_size, &max_size, 2, MPI_OFFSET, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (verbose && rank == 0) {
+        printf("After ncmpi_def_var, PnetCDF memory footprint high watermark %6.1f MB\n",
+               (float)max_size[1]/1048576);
+        printf("After ncmpi_def_var, PnetCDF memory footprint                %6.1f MB\n",
+               (float)max_size[0]/1048576);
+    }
+    fflush(stdout);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    timing[1] = MPI_Wtime();
+    for (i=0; i<NVARS; i++) {
+        err = ncmpi_put_att(ncid, varid[i], "attr1", NC_INT, 1, &i);
+        CHECK_ERR
+        err = ncmpi_put_att(ncid, varid[i], "attr2", NC_INT, 1, &i);
+        CHECK_ERR
+    }
+    timing[1] = MPI_Wtime() - timing[1];
+
+    err = ncmpi_inq_malloc_size(&malloc_size[0]); CHECK_ERR
+    err = ncmpi_inq_malloc_max_size(&malloc_size[1]); CHECK_ERR
+    MPI_Reduce(&malloc_size, &max_size, 2, MPI_OFFSET, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (verbose && rank == 0) {
+        printf("After ncmpi_put_att, PnetCDF memory footprint high watermark %6.1f MB\n",
+               (float)max_size[1]/1048576);
+        printf("After ncmpi_put_att, PnetCDF memory footprint                %6.1f MB\n",
+               (float)max_size[0]/1048576);
+    }
+    fflush(stdout);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    timing[2] = MPI_Wtime();
+    err = ncmpi_enddef(ncid);
+    CHECK_ERR
+    timing[2] = MPI_Wtime() - timing[2];
+
+    err = ncmpi_inq_malloc_size(&malloc_size[0]); CHECK_ERR
+    err = ncmpi_inq_malloc_max_size(&malloc_size[1]); CHECK_ERR
+    MPI_Reduce(&malloc_size, &max_size, 2, MPI_OFFSET, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (verbose && rank == 0) {
+        MPI_Offset header_size, header_extent;
+        ncmpi_inq_header_extent(ncid, &header_extent);
+        ncmpi_inq_header_size(ncid, &header_size);
+        printf("After ncmpi_enddef,  PnetCDF memory footprint high watermark %6.1f MB\n",
+               (float)max_size[1]/1048576);
+        printf("After ncmpi_enddef,  PnetCDF memory footprint                %6.1f MB\n",
+               (float)max_size[0]/1048576);
+        printf("NetCDF file header size %lld extent %lld\n",header_size,header_extent);
+    }
+    fflush(stdout);
+
+    err = ncmpi_close(ncid);
+    CHECK_ERR
+
+    free(varid);
+
+    err = ncmpi_inq_malloc_size(&malloc_size[0]); CHECK_ERR
+    err = ncmpi_inq_malloc_max_size(&malloc_size[1]); CHECK_ERR
+    MPI_Reduce(&malloc_size, &max_size, 2, MPI_OFFSET, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (verbose && rank == 0) {
+        printf("After ncmpi_close,   PnetCDF memory footprint high watermark %6.1f MB\n",
+               (float)max_size[1]/1048576);
+        printf("After ncmpi_close,   PnetCDF memory footprint                %4lld B\n",
+               max_size[0]);
+    }
+
+    /* check if PnetCDF freed all internal malloc */
+    if (err == NC_NOERR) {
+        MPI_Reduce(&malloc_size[0], &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
+        if (rank == 0 && sum_size > 0) {
+            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+                   sum_size);
+            ncmpi_inq_malloc_list();
+        }
+    }
+
+    MPI_Reduce(&timing, &max_timing, 3, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+    if (verbose && rank == 0)
+        printf("Time ncmpi_def_var = %.4f ncmpi_put_att = %.4f ncmpi_enddef = %.4f\n",
+               max_timing[0],max_timing[1],max_timing[2]);
+
+    MPI_Allreduce(MPI_IN_PLACE, &nerrs, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    if (rank == 0) {
+        if (nerrs) printf(FAIL_STR,nerrs);
+        else       printf(PASS_STR);
+    }
+
+    MPI_Finalize();
+    return (nerrs > 0);
+}
+


### PR DESCRIPTION
As the numbers of variables, dimensions, and attributes can be different significantly,
using the same hash table size will not run efficiently and can waste memory allocated.
This PR allows different hash table sizes, which can also be changed by users through
PnetCDF hints.

4 new PnetCDF user hints have been added.
* nc_hash_size_dim:   Set hash table size for dimension names
* nc_hash_size_var:   Set hash table size for variable names
* nc_hash_size_gattr: Set hash table size for global attribute names
* nc_hash_size_vattr: Set hash table size for variable attribute names

3 new test programs have beed added to test hashing performance.
* test/largefile/tst_hash_large_ndims.c
* test/largefile/tst_hash_large_nvars.c
* test/largefile/tst_hash_large_ngattr.c