### PR TITLE
Fix warning when using clang -Wshorten-64-to-32

### DIFF
--- a/examples/C/block_cyclic.c
+++ b/examples/C/block_cyclic.c
@@ -223,7 +223,7 @@ int main(int argc, char** argv) {
                    i, start[0],start[1], count[0],count[1]);
 
         if (i % block_len == block_len-1)  {
-            int stride = MIN(myNX-1-i, block_len);
+            MPI_Offset stride = MIN(myNX-1-i, block_len);
             block_start += block_len * nprocs;
             start[1] = block_start + stride * rank;
         }
@@ -297,7 +297,7 @@ int main(int argc, char** argv) {
         ERR
 
         if (i % block_len == block_len-1)  {
-            int stride = MIN(myNX-1-i, block_len);
+            MPI_Offset stride = MIN(myNX-1-i, block_len);
             block_start += block_len * nprocs;
             start[1] = block_start + stride * rank;
         }

--- a/examples/C/ghost_cell.c
+++ b/examples/C/ghost_cell.c
@@ -128,9 +128,10 @@ pnetcdf_check_mem_usage(MPI_Comm comm)
 static int
 pnetcdf_io(MPI_Comm comm, char *filename, int cmode, int len)
 {
-    int i, j, rank, nprocs, ncid, bufsize, err, nerrs=0;
+    int i, j, rank, nprocs, ncid, err, nerrs=0;
     int psizes[2], local_rank[2], dimids[2], varid, nghosts;
     int *buf, *buf_ptr;
+    size_t bufsize;
     MPI_Offset gsizes[2], starts[2], counts[2], imap[2];
 
     MPI_Comm_rank(comm, &rank);

--- a/examples/C/global_attributes.c
+++ b/examples/C/global_attributes.c
@@ -123,7 +123,7 @@ int main(int argc, char** argv)
     sprintf(str_att, "Mon Aug 13 21:27:48 2018");
 
     /* make sure the time string are consistent among all processes */
-    MPI_Bcast(str_att, strlen(str_att), MPI_CHAR, 0, MPI_COMM_WORLD);
+    MPI_Bcast(str_att, (int)strlen(str_att), MPI_CHAR, 0, MPI_COMM_WORLD);
 
     err = ncmpi_put_att_text(ncid, NC_GLOBAL, "history", strlen(str_att),
                              &str_att[0]); ERR

--- a/examples/C/transpose.c
+++ b/examples/C/transpose.c
@@ -141,9 +141,10 @@ pnetcdf_io(MPI_Comm comm, char *filename, int cmode, int len)
     for (j=0; j<counts[1]; j++)
     for (i=0; i<counts[2]; i++)
         buf[k*counts[1]*counts[2] +
-                      j*counts[2] + i] = (starts[0]+k)*gsizes[1]*gsizes[2]
+                      j*counts[2] + i] = (int)(
+                                         (starts[0]+k)*gsizes[1]*gsizes[2]
                                        + (starts[1]+j)*gsizes[2]
-                                       + (starts[2]+i);
+                                       + (starts[2]+i));
 
     /* set an MPI-IO hint to disable file offset alignment for fixed-size
      * variables */

--- a/examples/C/transpose2D.c
+++ b/examples/C/transpose2D.c
@@ -116,7 +116,7 @@ pnetcdf_io(MPI_Comm comm, char *filename, int cmode, int len)
     char str[512];
     int i, j, rank, nprocs, ncid, bufsize, err, nerrs=0;
     int *buf, psizes[NDIMS], dimids[NDIMS], dimidsT[NDIMS];
-    int XY_id, YX_id;
+    int XY_id, YX_id, lower_dims;
     MPI_Offset gsizes[NDIMS], start[NDIMS], count[NDIMS], imap[NDIMS];
     MPI_Offset startT[NDIMS], countT[NDIMS];
     MPI_Info info;
@@ -137,7 +137,7 @@ pnetcdf_io(MPI_Comm comm, char *filename, int cmode, int len)
 
     /* for each MPI rank, find its local rank IDs along each dimension in
      * start[] */
-    int lower_dims=1;
+    lower_dims = 1;
     for (i=NDIMS-1; i>=0; i--) {
         start[i] = rank / lower_dims % psizes[i];
         lower_dims *= psizes[i];
@@ -160,7 +160,7 @@ pnetcdf_io(MPI_Comm comm, char *filename, int cmode, int len)
     buf = (int *) malloc(bufsize * sizeof(int));
     for (i=0; i<count[0]; i++)
     for (j=0; j<count[1]; j++)
-        buf[i*count[1] + j] = (start[0]+i)*gsizes[1] + (start[1]+j);
+        buf[i*count[1] + j] = (int)((start[0]+i)*gsizes[1] + (start[1]+j));
 
     /* set an MPI-IO hint to disable file offset alignment for fixed-size
      * variables */
@@ -219,12 +219,12 @@ pnetcdf_io(MPI_Comm comm, char *filename, int cmode, int len)
     /* check the contents */
     for (i=0; i<countT[0]; i++)
     for (j=0; j<countT[1]; j++) {
-        int expect = (start[1]+i) + gsizes[1] * (start[0]+j);
+        int expect = (int)((start[1]+i) + gsizes[1] * (start[0]+j));
         if (buf[i*countT[1] + j] !=  expect) {
             printf("Error at %s:%d: expect buf[%lld]=%d but got %d\n",
                    __FILE__,__LINE__,i*countT[1]+j,expect,buf[i*count[1]+j]);
             nerrs++;
-            i = count[1]; /* break loop i */
+            i = (int)count[1]; /* also break loop i */
             break;
         }
     }

--- a/examples/C/vard_int.c
+++ b/examples/C/vard_int.c
@@ -107,7 +107,8 @@ int main(int argc, char **argv) {
     int          i, j, err, nerrs=0, ncid, varid0, varid1, dimids[2];
     int          rank, nprocs, array_of_blocklengths[2], buf[NY][NX];
     int          array_of_sizes[2], array_of_subsizes[2], array_of_starts[2];
-    MPI_Offset   start[2], count[2], recsize, bufcount, len;
+    int          start[2], count[2];
+    MPI_Offset   recsize, bufcount, len;
     MPI_Aint     array_of_displacements[2];
     MPI_Datatype buftype, rec_filetype, fix_filetype;
 

--- a/examples/C/vard_mvars.c
+++ b/examples/C/vard_mvars.c
@@ -146,7 +146,7 @@ int main(int argc, char **argv)
     int          rank, nprocs, *buf[2];
     int          array_of_sizes[2], array_of_subsizes[2], array_of_starts[2];
     int          array_of_blocklengths[NY];
-    MPI_Offset   recsize, start[2], count[2], offset[2];
+    MPI_Offset   recsize, offset[2];
     MPI_Aint     a0, a1, array_of_displacements[NY];
     MPI_Datatype buftype, vtype[2], filetype;
 
@@ -217,16 +217,14 @@ int main(int argc, char **argv)
 
     /* specify the access pattern, a subarray for each variable of size
      * NY * NX from each MPI process */
-    start[0] = 0;  start[1] = NX*rank;
-    count[0] = NY; count[1] = NX;
-
-    /* create the first datatype using MPI subarray constructor */
     array_of_sizes[0]    = 2;
     array_of_sizes[1]    = NX*nprocs;
-    array_of_subsizes[0] = count[0];
-    array_of_subsizes[1] = count[1];
-    array_of_starts[0]   = start[0];
-    array_of_starts[1]   = start[1];
+    array_of_subsizes[0] = NY;
+    array_of_subsizes[1] = NX;
+    array_of_starts[0]   = 0;
+    array_of_starts[1]   = NX*rank;
+
+    /* create the first datatype using MPI subarray constructor */
     MPI_Type_create_subarray(2, array_of_sizes, array_of_subsizes,
                              array_of_starts, MPI_ORDER_C, MPI_INT, &vtype[0]);
     MPI_Type_commit(&vtype[0]);

--- a/examples/tutorial/pnetcdf-permute.c
+++ b/examples/tutorial/pnetcdf-permute.c
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
     char filename[256];
     int i, j, k, rank, nprocs, ret;
     int ncfile, ndims=NDIMS;
-    MPI_Offset dim_sizes[NDIMS];
+    int dim_sizes[NDIMS];
     MPI_Offset start[NDIMS], count[NDIMS], nitems;
     int dimids[NDIMS], transposed_dims[NDIMS];
     int varid1, transposed_varid, flexible_varid;

--- a/examples/tutorial/pnetcdf-read-from-master.c
+++ b/examples/tutorial/pnetcdf-read-from-master.c
@@ -159,8 +159,11 @@ int main(int argc, char **argv) {
         }
 
         /*and finally all processors have the data */
-        err = MPI_Bcast(data, var_size, MPI_INT, 0, MPI_COMM_WORLD);
-        MPI_ERR(err)
+        if (var_size < NC_MAX_INT) {
+            err = MPI_Bcast(data, (int)var_size, MPI_INT, 0, MPI_COMM_WORLD);
+            MPI_ERR(err)
+        }
+        /* else: must call MPI_Bcast_c() for large count requests */
 
         /* Here, every process can do computation on the local buffer, data,
            or copy the contents to somewhere else */

--- a/src/dispatchers/attribute.c
+++ b/src/dispatchers/attribute.c
@@ -187,7 +187,7 @@ err_check:
 
         /* check if name is consistent among all processes */
         assert(name != NULL);
-        root_name_len = strlen(name) + 1;
+        root_name_len = (int)strlen(name) + 1;
         TRACE_COMM(MPI_Bcast)(&root_name_len, 1, MPI_INT, 0, pncp_out->comm);
         if (mpireturn != MPI_SUCCESS)
             return ncmpii_error_mpi2nc(mpireturn, "MPI_Bcast root_name_len");
@@ -300,7 +300,7 @@ err_check:
 
         /* check if name is consistent among all processes */
         assert(name != NULL);
-        root_name_len = strlen(name) + 1;
+        root_name_len = (int)strlen(name) + 1;
         TRACE_COMM(MPI_Bcast)(&root_name_len, 1, MPI_INT, 0, pncp->comm);
         if (mpireturn != MPI_SUCCESS)
             return ncmpii_error_mpi2nc(mpireturn, "MPI_Bcast root_name_len");
@@ -318,7 +318,7 @@ err_check:
 
         /* check if newname is consistent among all processes */
         assert(newname != NULL);
-        root_name_len = strlen(newname) + 1;
+        root_name_len = (int)strlen(newname) + 1;
         TRACE_COMM(MPI_Bcast)(&root_name_len, 1, MPI_INT, 0, pncp->comm);
         if (mpireturn != MPI_SUCCESS)
             return ncmpii_error_mpi2nc(mpireturn, "MPI_Bcast root_name_len");
@@ -410,7 +410,7 @@ err_check:
 
         /* check if name is consistent among all processes */
         assert(name != NULL);
-        root_name_len = strlen(name) + 1;
+        root_name_len = (int)strlen(name) + 1;
         TRACE_COMM(MPI_Bcast)(&root_name_len, 1, MPI_INT, 0, pncp->comm);
         if (mpireturn != MPI_SUCCESS)
             return ncmpii_error_mpi2nc(mpireturn, "MPI_Bcast root_name_len");

--- a/src/dispatchers/dimension.c
+++ b/src/dispatchers/dimension.c
@@ -117,7 +117,7 @@ err_check:
 
         /* check if name is consistent among all processes */
         assert(name != NULL);
-        root_name_len = strlen(name) + 1;
+        root_name_len = (int)strlen(name) + 1;
         TRACE_COMM(MPI_Bcast)(&root_name_len, 1, MPI_INT, 0, pncp->comm);
         if (mpireturn != MPI_SUCCESS)
             return ncmpii_error_mpi2nc(mpireturn, "MPI_Bcast root_name_len");
@@ -297,7 +297,7 @@ err_check:
 
         /* check if name is consistent among all processes */
         assert(newname != NULL);
-        root_name_len = strlen(newname) + 1;
+        root_name_len = (int)strlen(newname) + 1;
         TRACE_COMM(MPI_Bcast)(&root_name_len, 1, MPI_INT, 0, pncp->comm);
         if (mpireturn != MPI_SUCCESS)
             return ncmpii_error_mpi2nc(mpireturn, "MPI_Bcast root_name_len");

--- a/src/dispatchers/variable.c
+++ b/src/dispatchers/variable.c
@@ -141,7 +141,7 @@ err_check:
 
         /* check if name is consistent among all processes */
         assert(name != NULL);
-        root_name_len = strlen(name) + 1;
+        root_name_len = (int)strlen(name) + 1;
         TRACE_COMM(MPI_Bcast)(&root_name_len, 1, MPI_INT, 0, pncp->comm);
         if (mpireturn != MPI_SUCCESS)
             return ncmpii_error_mpi2nc(mpireturn, "MPI_Bcast root_name_len");
@@ -666,7 +666,7 @@ err_check:
 
         /* check if newname is consistent among all processes */
         assert(newname != NULL);
-        root_name_len = strlen(newname) + 1;
+        root_name_len = (int)strlen(newname) + 1;
         TRACE_COMM(MPI_Bcast)(&root_name_len, 1, MPI_INT, 0, pncp->comm);
         if (mpireturn != MPI_SUCCESS)
             return ncmpii_error_mpi2nc(mpireturn, "MPI_Bcast root_name_len");

--- a/src/drivers/common/ncx.m4
+++ b/src/drivers/common/ncx.m4
@@ -2120,9 +2120,14 @@ APIPrefix`x_put_off_t'(void **xpp, const off_t *lp, size_t sizeof_off_t)
 #ifdef WORDS_BIGENDIAN
         memcpy(*xpp, lp, 4);
 #else
-        int xtmp, itmp = *lp;
-        xtmp = SWAP4(itmp);
-        memcpy(*xpp, &xtmp, 4);
+        if (*lp > X_INT_MAX)
+            DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
+        else {
+            int xtmp, itmp;
+            itmp = (int)*lp;
+            xtmp = SWAP4(itmp);
+            memcpy(*xpp, &xtmp, 4);
+        }
 #endif
     } else {
 #ifdef WORDS_BIGENDIAN

--- a/src/drivers/common/utils.c
+++ b/src/drivers/common/utils.c
@@ -79,7 +79,7 @@ char* ncmpii_remove_file_system_type_prefix(const char *filename)
         /* check if prefix is one of recognized file system types */
         int i=0;
         while (fstypes[i] != NULL) {
-            int prefix_len = strlen(fstypes[i]);
+            size_t prefix_len = strlen(fstypes[i]);
             if (!strncmp(filename, fstypes[i], prefix_len)) { /* found */
                 ret_filename += prefix_len + 1;
                 break;

--- a/src/drivers/ncbbio/ncbbio_driver.h
+++ b/src/drivers/ncbbio/ncbbio_driver.h
@@ -70,7 +70,7 @@ typedef struct NC_bb_metadataheader {
     MPI_Offset max_ndims;
     MPI_Offset num_entries;
     MPI_Offset entry_begin;
-    int basenamelen;
+    size_t basenamelen;
     char basename[1]; /* The hack to keep basename inside the structure */
 } NC_bb_metadataheader;
 
@@ -97,7 +97,7 @@ typedef struct NC_bb_metadataptr {
 typedef struct NC_bb_metadataidx {
     NC_bb_metadataptr *entries;
     int nused;
-    int nalloc;
+    size_t nalloc;
 } NC_bb_metadataidx;
 
 /* Buffer structure */
@@ -134,8 +134,8 @@ typedef struct NC_bb_put_req {
 typedef struct NC_bb_put_list {
     NC_bb_put_req *reqs;  // Array of request object
     int *ids;             // Array of request ids
-    int nalloc;           // Size of the pool
-    int nused;            // Number of ids issued
+    size_t nalloc;        // Size of the pool
+    size_t nused;         // Number of ids issued
 } NC_bb_put_list;
 
 /* Shared file object */

--- a/src/drivers/ncbbio/ncbbio_log.c
+++ b/src/drivers/ncbbio/ncbbio_log.c
@@ -28,7 +28,7 @@
 int ncbbio_log_create(NC_bb* ncbbp,
                       __attribute__((unused)) MPI_Info info)
 {
-    int i, rank, np, err, flag, masterrank, procname_len;
+    int rank, np, err, flag, masterrank, procname_len;
     char logbase[NC_LOG_MAX_PATH], basename[NC_LOG_MAX_PATH];
     char procname[MPI_MAX_PROCESSOR_NAME];
     char *abspath, *fname, *path, *fdir = NULL;
@@ -86,7 +86,7 @@ int ncbbio_log_create(NC_bb* ncbbp,
         logbasep = ncmpii_remove_file_system_type_prefix(ncbbp->logbase);
     }
     else {
-        i = strlen(path);
+        size_t i = strlen(path);
         fdir = (char*)NCI_Malloc((i + 1) * sizeof(char));
         strncpy(fdir, path, i + 1);
         /* Search for first '\' from the back */

--- a/src/drivers/ncbbio/ncbbio_nonblocking.c
+++ b/src/drivers/ncbbio/ncbbio_nonblocking.c
@@ -88,8 +88,7 @@ int ncbbio_put_list_init(NC_bb *ncbbp) {
  */
 static int ncbbio_put_list_resize(NC_bb *ncbbp)
 {
-    int i;
-    ssize_t nsize;
+    size_t i, nsize;
     void *ptr;
     NC_bb_put_list *lp = &(ncbbp->putlist);
 
@@ -109,8 +108,11 @@ static int ncbbio_put_list_resize(NC_bb *ncbbp)
     /* Initialize values of ids and reqs
      * Assign increasing unique id
      */
+    if (nsize > NC_MAX_INT)
+        DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
+
     for (i=lp->nalloc; i<nsize; i++) {
-        lp->ids[i] = i; // Unique ids
+        lp->ids[i] = (int)i; // Unique ids
         lp->reqs[i].valid = 0; // Not in use
     }
 

--- a/src/drivers/ncbbio/ncbbio_sharedfile.c
+++ b/src/drivers/ncbbio/ncbbio_sharedfile.c
@@ -144,8 +144,8 @@ int ncbbio_sharedfile_pwrite(NC_bb_sharedfile *f,
                              size_t            count,
                              off_t             offset)
 {
-    int i, err;
-    int sblock, eblock;   // start and end block
+    int err;
+    size_t i, sblock, eblock;   // start and end block
     off_t offstart, offend, wsize = 0; // Start and end offset to write for current block in physical file
     ssize_t ioret;
 
@@ -317,8 +317,8 @@ int ncbbio_sharedfile_pread(NC_bb_sharedfile *f,
                             size_t            count,
                             off_t             offset)
 {
-    int i, err;
-    int sblock, eblock;   // start and end block
+    int err;
+    size_t i, sblock, eblock;   // start and end block
     off_t offstart, offend, rsize = 0; // Start and end offset to write for current block in physical file
     ssize_t ioret;
 

--- a/src/drivers/ncmpio/ncmpio_NC.h
+++ b/src/drivers/ncmpio/ncmpio_NC.h
@@ -382,7 +382,7 @@ struct NC {
     MPI_Comm      comm_sf;      /* subfile MPI communicator */
 #endif
     int           striping_unit; /* stripe size of the file */
-    int           chunk;       /* chunk size for reading header */
+    int           chunk;       /* chunk size for reading header, one chunk at a time */
     MPI_Offset    h_align;     /* file alignment for header size */
     MPI_Offset    v_align;     /* alignment of the beginning of fixed-size variables */
     MPI_Offset    r_align;     /* file alignment for record variable section */
@@ -471,7 +471,7 @@ typedef struct bufferinfo {
     MPI_File    collective_fh;
     MPI_Offset  get_size; /* amount of file read n bytes so far */
     MPI_Offset  offset;   /* current read/write offset in the file */
-    size_t      size;     /* allocated size of the buffer */
+    int         chunk;    /* chunk size for reading the header */
     int         version;  /* 1, 2, and 5 for CDF-1, 2, and 5 respectively */
     int         safe_mode;/* 0: disabled, 1: enabled */
     int         rw_mode;  /* 0: independent, 1: collective */

--- a/src/drivers/ncmpio/ncmpio_file_io.c
+++ b/src/drivers/ncmpio/ncmpio_file_io.c
@@ -64,7 +64,7 @@ ncmpio_read_write(NC           *ncp,
     }
 
     /* request size in bytes, may be > NC_MAX_INT */
-    req_size = (MPI_Offset)btype_size * buf_count;
+    req_size = buf_count * btype_size;
 
     /* explicitly initialize mpistatus object to 0. For zero-length read,
      * MPI_Get_count may report incorrect result for some MPICH version,
@@ -109,7 +109,7 @@ ncmpio_read_write(NC           *ncp,
             }
             else {
                 xbuf_type = MPI_BYTE;
-                xlen = req_size;
+                xlen = (int)req_size;
             }
             xbuf = NCI_Malloc((size_t)req_size);
         }
@@ -217,7 +217,7 @@ ncmpio_read_write(NC           *ncp,
             }
             else {
                 int pos=0;
-                xlen = req_size;
+                xlen = (int)req_size;
                 xbuf = NCI_Malloc(xlen);
                 MPI_Pack(buf, (int)buf_count, buf_type, xbuf, xlen, &pos,
                          MPI_COMM_SELF);

--- a/src/drivers/ncmpio/ncmpio_file_io.c
+++ b/src/drivers/ncmpio/ncmpio_file_io.c
@@ -51,7 +51,7 @@ ncmpio_read_write(NC           *ncp,
         err = (err == NC_EFILE) ? NC_EREAD : err;
     }
     else if (btype_size == MPI_UNDEFINED)
-        err = NC_EINTOVERFLOW;
+        DEBUG_ASSIGN_ERROR(err, NC_EINTOVERFLOW)
 
     if (err != NC_NOERR) {
         if (coll_indep == NC_REQ_COLL) {

--- a/src/drivers/ncmpio/ncmpio_filetype.c
+++ b/src/drivers/ncmpio/ncmpio_filetype.c
@@ -561,7 +561,11 @@ ncmpio_filetype_create_vars(const NC         *ncp,
         NCI_Free(blocklens_c);
         NCI_Free(disps_c);
 #else
-        DEBUG_ASSIGN_ERROR(ret, NC_ESMALL)
+        NCI_Free(disps);
+        NCI_Free(blocklens);
+        *offset_ptr   = offset;
+        *filetype_ptr = MPI_DATATYPE_NULL;
+        return NC_EINTOVERFLOW;
 #endif
     }
     else {
@@ -623,7 +627,7 @@ ncmpio_file_set_view(const NC     *ncp,
 
         /* check if header size > 2^31 */
         if (ncp->begin_var > NC_MAX_INT) {
-            status = NC_EINTOVERFLOW;
+            DEBUG_ASSIGN_ERROR(status, NC_EINTOVERFLOW);
             goto err_out;
         }
 #endif
@@ -640,7 +644,7 @@ ncmpio_file_set_view(const NC     *ncp,
 
 #if !defined(HAVE_MPI_LARGE_COUNT) && (SIZEOF_MPI_AINT != SIZEOF_MPI_OFFSET)
         if (*offset > NC_MAX_INT) {
-            status = NC_EINTOVERFLOW;
+            DEBUG_ASSIGN_ERROR(status, NC_EINTOVERFLOW);
             goto err_out;
         }
 #endif

--- a/src/drivers/ncmpio/ncmpio_fill.c
+++ b/src/drivers/ncmpio/ncmpio_fill.c
@@ -642,7 +642,9 @@ fillerup_aggregate(NC *ncp, NC *old_ncp)
             buf_len = 1;
         }
 #else
-        if (status == NC_NOERR) status = NC_EINTOVERFLOW;
+        if (status == NC_NOERR)
+            DEBUG_ASSIGN_ERROR(status, NC_EINTOVERFLOW)
+
         buf_len = 0; /* participate collective write with 0-length request */
 #endif
     }

--- a/src/drivers/ncmpio/ncmpio_hash_func.c
+++ b/src/drivers/ncmpio/ncmpio_hash_func.c
@@ -116,7 +116,7 @@ int ncmpio_Pearson_hash(const char *str_name, int hash_size)
     }
     else {
         size_t len=strlen(str_name);
-        unsigned int i, hash=len;
+        unsigned int i, hash=(int)len;
         for (i=0; i<len; ++i)
             hash ^= str_name[i];
 

--- a/src/drivers/ncmpio/ncmpio_util.c
+++ b/src/drivers/ncmpio/ncmpio_util.c
@@ -95,9 +95,9 @@ void ncmpio_set_pnetcdf_hints(NC *ncp,
         MPI_Info_get(user_info, "nc_header_read_chunk_size", MPI_MAX_INFO_VAL-1,
                      value, &flag);
         if (flag) {
-            long int chunk;
+            int chunk;
             errno = 0;  /* errno must set to zero before calling strtoll */
-            chunk = (int) strtol(value, NULL, 10);
+            chunk = atoi(value);
             if (errno != 0) ncp->chunk = 0;
             else if (ncp->chunk < 0)
                 ncp->chunk = 0;
@@ -164,7 +164,7 @@ void ncmpio_set_pnetcdf_hints(NC *ncp,
                      value, &flag);
         if (flag) {
             errno = 0;
-            ncp->num_subfiles = strtoll(value, NULL, 10);
+            ncp->num_subfiles = atoi(value);
             if (errno != 0) ncp->num_subfiles = 0;
             else if (ncp->num_subfiles < 0) ncp->num_subfiles = 0;
             sprintf(value, "%d", ncp->num_subfiles);

--- a/src/drivers/ncmpio/ncmpio_wait.c
+++ b/src/drivers/ncmpio/ncmpio_wait.c
@@ -127,7 +127,8 @@ ncmpio_cancel(void *ncdp,
               int  *req_ids,  /* [num_req]: IN/OUT */
               int  *statuses) /* [num_req] can be NULL (ignore status) */
 {
-    int i, j, status=NC_NOERR;
+    int status=NC_NOERR;
+    size_t i, j;
     NC *ncp=(NC*)ncdp;
 
     if (num_req == 0) return NC_NOERR;

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -894,7 +894,6 @@ Available values for OPTION include:
   --in-place-swap             Whether using buffer in-place Endianness byte swap
   --erange-fill               Whether using fill values for NC_ERANGE error
   --subfiling                 Whether subfiling is enabled or disabled
-  --large-single-req          Whether to allow single >2GiB MPI-IO requests
   --null-byte-header-padding  Whether to check null-byte padding in header
   --burst-buffering           Whether burst buffer driver is built or not
   --profiling                 Whether internal profiling is enabled or not

--- a/src/utils/ncmpidump/ncmpidump.c
+++ b/src/utils/ncmpidump/ncmpidump.c
@@ -743,7 +743,8 @@ enum FILE_KIND check_file_signature(char *path)
     char *cdf_signature="CDF";
     char *hdf5_signature="\211HDF\r\n\032\n";
     char signature[8];
-    int fd, rlen;
+    int fd;
+    size_t rlen;
 
     if ((fd = open(path, O_RDONLY, 0700)) == -1) {
         fprintf(stderr,"%s error at opening file %s (%s)\n",progname,path,strerror(errno));

--- a/src/utils/ncmpilogdump/ncmpilogdump.m4
+++ b/src/utils/ncmpilogdump/ncmpilogdump.m4
@@ -36,8 +36,8 @@ define(`PRINTTYPE',dnl
 #include <pnetcdf.h>
 
 int main(int argc, char *argv[]) {
-    int i, j, k, fd, ret, err = NC_NOERR;
-    size_t offset;
+    int i, j, k, fd, err = NC_NOERR;
+    size_t offset, rlen;
     FILE *fmeta=NULL, *fdata=NULL;
     struct stat metastat;
     struct stat datastat;
@@ -71,8 +71,8 @@ int main(int argc, char *argv[]) {
     Meta = (char*)malloc(metastat.st_size);
 
     /* Read the metadata */
-    ret = fread(Meta, metastat.st_size, 1, fmeta);
-    if (ret != 1) {
+    rlen = fread(Meta, metastat.st_size, 1, fmeta);
+    if (rlen != 1) {
         err = NC_EBADLOG;
         goto fn_exit;
     }
@@ -96,8 +96,8 @@ int main(int argc, char *argv[]) {
         /* Allocate buffer */
         Data = (char*)malloc(datastat.st_size);
         /* Read the data */
-        ret = fread(Data, datastat.st_size, 1, fdata);
-        if (ret != 1) {
+        rlen = fread(Data, datastat.st_size, 1, fdata);
+        if (rlen != 1) {
             err = NC_EBADLOG;
             goto fn_exit;
         }

--- a/src/utils/pnetcdf-config.in
+++ b/src/utils/pnetcdf-config.in
@@ -117,7 +117,6 @@ Available values for OPTION include:
   --in-place-swap             Whether using buffer in-place Endianness byte swap
   --erange-fill               Whether using fill values for NC_ERANGE error
   --subfiling                 Whether subfiling is enabled or disabled
-  --large-single-req          Whether to allow single >2GiB MPI-IO requests
   --null-byte-header-padding  Whether to check null-byte padding in header
   --burst-buffering           Whether burst buffer driver is built or not
   --profiling                 Whether internal profiling is enabled or not

--- a/test/common/testutils.c
+++ b/test/common/testutils.c
@@ -273,7 +273,7 @@ char* remove_file_system_type_prefix(const char *filename)
         /* check if prefix is one of recognized file system types */
         int i=0;
         while (fstypes[i] != NULL) {
-            int prefix_len = strlen(fstypes[i]);
+            size_t prefix_len = strlen(fstypes[i]);
             if (!strncmp(filename, fstypes[i], prefix_len)) { /* found */
                 ret_filename += prefix_len + 1;
                 break;

--- a/test/largefile/large_dims_vars_attrs.c
+++ b/test/largefile/large_dims_vars_attrs.c
@@ -30,7 +30,7 @@
 int main(int argc, char** argv)
 {
     char filename[256], str[32];
-    int i, rank, nprocs, err, nerrs=0;
+    int i, rank, nprocs, err, nerrs=0, verbose=0;
     int ncid, cmode, *varid, *dimids, intBuf[1];
 
     MPI_Init(&argc, &argv);
@@ -143,9 +143,11 @@ int main(int argc, char** argv)
         }
     }
 
-    err = ncmpi_inq_malloc_max_size(&malloc_size);
-    printf("%d: PnetCDF internal memory footprint high water mark %.2f MB\n",
-           rank, (float)malloc_size/1048576);
+    if (verbose) {
+        err = ncmpi_inq_malloc_max_size(&malloc_size);
+        printf("\n%d: PnetCDF internal memory footprint high water mark %.2f MB\n",
+               rank, (float)malloc_size/1048576);
+    }
 
     MPI_Allreduce(MPI_IN_PLACE, &nerrs, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
     if (rank == 0) {

--- a/test/nc_test/test_iput.m4
+++ b/test/nc_test/test_iput.m4
@@ -102,9 +102,9 @@ hash2nc(const nc_type var_type, int var_rank, MPI_Offset *index)
 }
 
 static int
-dbls2ncs(int nels, int var_type, double *inBuf, void *outBuf)
+dbls2ncs(size_t nels, int var_type, double *inBuf, void *outBuf)
 {
-    int i;
+    size_t i;
     char *p = (char*)outBuf;
     for (i=0; i<nels; i++) {
         switch (var_type) {

--- a/test/nc_test/test_read.m4
+++ b/test/nc_test/test_read.m4
@@ -1699,7 +1699,7 @@ ifdef(`PNETCDF',`dnl
                         }
                     }
  */
-                    j = fromMixedBase(var_rank[i], index, var_shape[i]);
+                    j = (int)fromMixedBase(var_rank[i], index, var_shape[i]);
                     p = (char *) buf + j * (IntType)sizeof_nctype(var_type[i]);
                     err = GetVarm(ncid, i, index, count, stride, imap2, p, nels, datatype);
                 }

--- a/test/nc_test/test_write.m4
+++ b/test/nc_test/test_write.m4
@@ -1743,7 +1743,7 @@ edge1:
                         }
                     }
  */
-                    j = fromMixedBase(var_rank[i], index, var_shape[i]);
+                    j = (int)fromMixedBase(var_rank[i], index, var_shape[i]);
                     p = (char *) buf + (int)j * sizeof_nctype(var_type[i]);
                     ifdef(`PNETCDF', `for (bufcount=1,j=0; j<var_rank[i]; j++) bufcount *= count[j];')
                     err = PutVarm(ncid, i, index, count, stride, imap2, p, bufcount, datatype);

--- a/test/nc_test/util.c
+++ b/test/nc_test/util.c
@@ -1047,7 +1047,7 @@ check_atts(int ncid, int numGatts, int numVars)
             }
         }
     }
-    /* print_nok(nok); */
+    if (verbose) print_nok(nok);
 }
 
 

--- a/test/nonblocking/mcoll_perf.c
+++ b/test/nonblocking/mcoll_perf.c
@@ -38,7 +38,8 @@ static int verbose;
 }
 
 #define CHECK_GLOBAL_ATT_DIFF(type, func, nctype) {                          \
-    int   pos, len = attlen1 * sizeof(type);                                 \
+    int pos;                                                                 \
+    size_t len = sizeof(type) * attlen1;                                     \
     type *b1 = (type *)malloc(len);                                          \
     type *b2 = (type *)malloc(len);                                          \
     err = func(ncid1, NC_GLOBAL, name1, b1);                                 \
@@ -56,7 +57,8 @@ static int verbose;
 }
 
 #define CHECK_VAR_ATT_DIFF(type, func, nctype) {                             \
-    int   pos, len = attlen1 * sizeof(type);                                 \
+    int pos;                                                                 \
+    size_t len = sizeof(type) * attlen1;                                     \
     type *b1 = (type *)malloc(len);                                          \
     type *b2 = (type *)malloc(len);                                          \
     err = func(ncid1, i, name1, b1);                                         \
@@ -75,7 +77,8 @@ static int verbose;
 
 
 #define CHECK_VAR_DIFF(type, func, nctype) {                                 \
-    int   pos, len = varsize * sizeof(type);                                 \
+    int pos;                                                                 \
+    size_t len = sizeof(type) * varsize;                                     \
     type *b1 = (type *)malloc(len);                                          \
     type *b2 = (type *)malloc(len);                                          \
     err = func(ncid1, i, start, shape, b1);                                  \

--- a/test/subfile/test_subfile.c
+++ b/test/subfile/test_subfile.c
@@ -61,28 +61,28 @@ int main(int argc, char **argv)
     /* process 0 takes the file name as a command-line argument and
        broadcasts it to other processes */
     if (rank == 0) {
-	while ((opt = getopt(argc, argv, "f:s:p:n:l:r")) != EOF) {
-	    switch (opt) {
-	    case 'f': fbasename = optarg;
-		break;
-	    case 's': num_sf = (int)strtol(optarg,NULL,10);
-		break;
-	    case 'r': do_read = 1;
-		break;
+        while ((opt = getopt(argc, argv, "f:s:p:n:l:r")) != EOF) {
+            switch (opt) {
+            case 'f': fbasename = optarg;
+                break;
+            case 's': num_sf = (int)strtol(optarg,NULL,10);
+                break;
+            case 'r': do_read = 1;
+                break;
             case 'p': par_dim_id = (int)strtol(optarg,NULL,10);
                 break;
             case 'n': nvars = (int)strtol(optarg,NULL,10);
                 break;
             case 'l': length = (int)strtol(optarg,NULL,10);
                 break;
-	    default:
-		break;
-	    }
-	}
-	if (fbasename == NULL) {
-	    fprintf(stderr, "\n*#  Usage: test_subfile -f pathname -s num_sf -p par_dim_id \n\n");
-	    nerrs++;
-	}
+            default:
+                break;
+            }
+        }
+        if (fbasename == NULL) {
+            fprintf(stderr, "\n*#  Usage: test_subfile -f pathname -s num_sf -p par_dim_id \n\n");
+            nerrs++;
+        }
     }
     MPI_Bcast(&nerrs, 1, MPI_INT, 0, MPI_COMM_WORLD);
     if (nerrs > 0) {
@@ -91,12 +91,12 @@ int main(int argc, char **argv)
     }
 
     if (rank == 0) {
-	len = (fbasename == NULL) ?  0 : strlen(fbasename);
-	MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
+        len = (fbasename == NULL) ?  0 : (int)strlen(fbasename);
+        MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
     }
     else {
-	MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
-	fbasename = (char *) malloc(len+1);
+        MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
+        fbasename = (char *) malloc(len+1);
     }
     MPI_Bcast(fbasename, len+1, MPI_CHAR, 0, MPI_COMM_WORLD);
     MPI_Bcast(&num_sf, 1, MPI_INT, 0, MPI_COMM_WORLD);
@@ -141,16 +141,16 @@ int main(int argc, char **argv)
     }
 
     for (i=0; i<nvars; i++) {
-	starts_list[i] = (MPI_Offset *)malloc(ndims*sizeof(MPI_Offset));
-	if (starts_list[i] == NULL){
-	    printf("starts_list[%d] malloc error\n", i);
-	    nerrs++; goto fn_exit;
-	}
-	count_list[i] = (MPI_Offset *)malloc(ndims*sizeof(MPI_Offset));
-	if (count_list[i] == NULL){
-	    printf("count_list[%d] malloc error\n", i);
-	    nerrs++; goto fn_exit;
-	}
+        starts_list[i] = (MPI_Offset *)malloc(ndims*sizeof(MPI_Offset));
+        if (starts_list[i] == NULL){
+            printf("starts_list[%d] malloc error\n", i);
+            nerrs++; goto fn_exit;
+        }
+        count_list[i] = (MPI_Offset *)malloc(ndims*sizeof(MPI_Offset));
+        if (count_list[i] == NULL){
+            printf("count_list[%d] malloc error\n", i);
+            nerrs++; goto fn_exit;
+        }
     }
 
     bufcount = 1;
@@ -161,7 +161,7 @@ int main(int argc, char **argv)
     MPI_Dims_create(nprocs, ndims, array_of_psizes);
     if (verbose && rank == 0)
         for(i=0; i<ndims; i++)
-	    printf("array_of_psizes[%d]=%d\n", i, array_of_psizes[i]);
+            printf("array_of_psizes[%d]=%d\n", i, array_of_psizes[i]);
 
     /* subarray in each process is len x len x len */
     for (i=0; i<ndims; i++)
@@ -177,23 +177,23 @@ int main(int argc, char **argv)
         array_of_starts[i] = (MPI_Offset)length * rank_dim[i];
 
     for (i=0; i<nvars; i++) {
-	for (j=0; j<ndims; j++) {
-	    starts_list[i][j] = array_of_starts[j];
-	    count_list[i][j]  = length;
-	}
+        for (j=0; j<ndims; j++) {
+            starts_list[i][j] = array_of_starts[j];
+            count_list[i][j]  = length;
+        }
         bufcount_list[i] = bufcount;
         datatype_list[i] = MPI_INT;
     }
 
     for (i=0; i<nvars; i++) {
-	buf[i] = (int *) malloc(bufcount * sizeof(int));
-	if (buf[i] == NULL){
-	    printf("buf[i]malloc error\n");
-	    nerrs++; goto fn_exit;
-	}
+        buf[i] = (int *) malloc(bufcount * sizeof(int));
+        if (buf[i] == NULL){
+            printf("buf[i]malloc error\n");
+            nerrs++; goto fn_exit;
+        }
 
-	for (j=0; j<bufcount; j++)
-	    buf[i][j]=rank+1;
+        for (j=0; j<bufcount; j++)
+            buf[i][j]=rank+1;
     }
 
     MPI_Info_create(&info);
@@ -227,16 +227,16 @@ int main(int argc, char **argv)
     /* define variables */
     varid = (int *)malloc(nvars*sizeof(int));
     for (i=0; i<nvars; i++) {
-	sprintf(varname, "var0_%d", i);
-	err = ncmpi_def_var(ncid, varname, NC_INT, ndims, dimids0, &varid[i]);
-	CHECK_ERR
+        sprintf(varname, "var0_%d", i);
+        err = ncmpi_def_var(ncid, varname, NC_INT, ndims, dimids0, &varid[i]);
+        CHECK_ERR
     }
 
     if (par_dim_id != 0) {
         for (i=0; i<nvars; i++) {
             err = ncmpi_put_att_int(ncid, varid[i], "par_dim_id",
                                     NC_INT, 1, &dimids0[par_dim_id]);
-	    CHECK_ERR
+            CHECK_ERR
         }
     }
 
@@ -260,7 +260,7 @@ int main(int argc, char **argv)
                             &nattsp);
         CHECK_ERR
 
-	sprintf(varname, "var0_%d", i);
+        sprintf(varname, "var0_%d", i);
         if (strcmp(name, varname)) {
             printf("Error at line %d in %s: unexpected var[%d] name %s, should be %s\n",
             __LINE__,__FILE__,i,name,varname);

--- a/test/testcases/flexible.c
+++ b/test/testcases/flexible.c
@@ -233,10 +233,10 @@ int main(int argc, char **argv) {
 
     /* create a buftype with ghost cells on each side */
     ncbuf = (int *) malloc((count[0]+4)*(count[1]+4)*sizeof(int));
-    array_of_sizes[0] = count[0]+4;
-    array_of_sizes[1] = count[1]+4;
-    array_of_subsizes[0] = count[0];
-    array_of_subsizes[1] = count[1];
+    array_of_sizes[0] = (int)count[0]+4;
+    array_of_sizes[1] = (int)count[1]+4;
+    array_of_subsizes[0] = (int)count[0];
+    array_of_subsizes[1] = (int)count[1];
     array_of_starts[0] = 2;
     array_of_starts[1] = 2;
     MPI_Type_create_subarray(2, array_of_sizes, array_of_subsizes,

--- a/test/testcases/modes.c
+++ b/test/testcases/modes.c
@@ -194,7 +194,7 @@ int main(int argc, char** argv)
     }
     if (argc == 2) filename = strdup(argv[1]);
     else           filename = strdup("testfile.nc");
-    len = strlen(filename) + 1;
+    len = (int)strlen(filename) + 1;
     MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
     MPI_Bcast(filename, len, MPI_CHAR, 0, MPI_COMM_WORLD);
 

--- a/test/testcases/noclobber.c
+++ b/test/testcases/noclobber.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
     }
     if (argc == 2) filename = strdup(argv[1]);
     else           filename = strdup("testfile.nc");
-    len = strlen(filename) + 1;
+    len = (int)strlen(filename) + 1;
     MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
     MPI_Bcast(filename, len, MPI_CHAR, 0, MPI_COMM_WORLD);
 

--- a/test/testcases/test_vard.c
+++ b/test/testcases/test_vard.c
@@ -205,20 +205,20 @@ int main(int argc, char **argv) {
     /* create a file type for the fixed-size variable */
     array_of_sizes[0] = 2;
     array_of_sizes[1] = NX*nprocs;
-    array_of_subsizes[0] = count[0];
-    array_of_subsizes[1] = count[1];
-    array_of_starts[0] = start[0];
-    array_of_starts[1] = start[1];
+    array_of_subsizes[0] = (int)count[0];
+    array_of_subsizes[1] = (int)count[1];
+    array_of_starts[0] = (int)start[0];
+    array_of_starts[1] = (int)start[1];
     MPI_Type_create_subarray(2, array_of_sizes, array_of_subsizes,
                              array_of_starts, MPI_ORDER_C,
                              MPI_INT, &fix_filetype);
     MPI_Type_commit(&fix_filetype);
 
     /* create a buftype with ghost cells on each side */
-    array_of_sizes[0] = count[0]+4;
-    array_of_sizes[1] = count[1]+4;
-    array_of_subsizes[0] = count[0];
-    array_of_subsizes[1] = count[1];
+    array_of_sizes[0] = (int)count[0]+4;
+    array_of_sizes[1] = (int)count[1]+4;
+    array_of_subsizes[0] = (int)count[0];
+    array_of_subsizes[1] = (int)count[1];
     array_of_starts[0] = 2;
     array_of_starts[1] = 2;
     MPI_Type_create_subarray(2, array_of_sizes, array_of_subsizes,
@@ -252,8 +252,8 @@ int main(int argc, char **argv) {
     MPI_Offset recsize;
     err = ncmpi_inq_recsize(ncid, &recsize);
     for (i=0; i<count[0]; i++) {
-        array_of_blocklengths[i] = count[1];
-        array_of_displacements[i] = start[1]*sizeof(int) + recsize * i;
+        array_of_blocklengths[i] = (int)count[1];
+        array_of_displacements[i] = (int)start[1]*sizeof(int) + recsize * i;
     }
     MPI_Type_create_hindexed(2, array_of_blocklengths, array_of_displacements,
                              MPI_INT, &rec_filetype);
@@ -454,7 +454,7 @@ int main(int argc, char **argv) {
 
     /* construct rec_filetype for dummy_rec of type NC_BYTE */
     for (i=0; i<count[0]; i++) {
-        array_of_blocklengths[i] = count[1];
+        array_of_blocklengths[i] = (int)count[1];
         array_of_displacements[i] = start[1]*sizeof(signed char) + recsize * i;
     }
     MPI_Type_create_hindexed(2, array_of_blocklengths, array_of_displacements,

--- a/test/testcases/test_vard_multiple.c
+++ b/test/testcases/test_vard_multiple.c
@@ -189,10 +189,10 @@ int main(int argc, char **argv) {
     /* create the first datatype using subarray */
     array_of_sizes[0]    = 2;
     array_of_sizes[1]    = NX*nprocs;
-    array_of_subsizes[0] = count[0];
-    array_of_subsizes[1] = count[1];
-    array_of_starts[0]   = start[0];
-    array_of_starts[1]   = start[1];
+    array_of_subsizes[0] = (int)count[0];
+    array_of_subsizes[1] = (int)count[1];
+    array_of_starts[0]   = (int)start[0];
+    array_of_starts[1]   = (int)start[1];
     MPI_Type_create_subarray(2, array_of_sizes, array_of_subsizes,
                              array_of_starts, MPI_ORDER_C, MPI_INT, &vtype[0]);
     MPI_Type_commit(&vtype[0]);

--- a/test/testcases/tst_symlink.c
+++ b/test/testcases/tst_symlink.c
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
     }
     if (argc == 2) filename = strdup(argv[1]);
     else           filename = strdup("testfile.nc");
-    len = strlen(filename) + 1;
+    len = (int)strlen(filename) + 1;
     MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
     MPI_Bcast(filename, len, MPI_CHAR, 0, MPI_COMM_WORLD);
 

--- a/test/testcases/varn_int.c
+++ b/test/testcases/varn_int.c
@@ -294,7 +294,7 @@ int main(int argc, char** argv)
 
     /* test flexible API, using a noncontiguous buftype */
     MPI_Datatype buftype;
-    MPI_Type_vector(w_len, 1, 2, MPI_INT, &buftype);
+    MPI_Type_vector((int)w_len, 1, 2, MPI_INT, &buftype);
     MPI_Type_commit(&buftype);
     free(buffer);
     buffer = (int*) malloc(w_len * 2 * sizeof(int));

--- a/test/testcases/vectors.c
+++ b/test/testcases/vectors.c
@@ -26,7 +26,8 @@ int main(int argc, char ** argv)
     int ncid, dimid, varid, rank, nprocs;
     MPI_Datatype vtype, rtype, usertype;
     MPI_Aint lb, extent;
-    int userbufsz, *userbuf, *cmpbuf, i, err, errs=0, nerrs=0;
+    int *userbuf, *cmpbuf, i, err, errs=0, nerrs=0;
+    size_t userbufsz;
     int count = 25;
     double pi = 3.14159;
     MPI_Offset start, acount;


### PR DESCRIPTION
MPICH [Helpful Compiler Flags For Testing](https://github.com/pmodels/mpich/blob/main/doc/wiki/testing/Helpful_Compiler_Flags_For_Testing.md)