### PR TITLE
Update data section movement when file header extent grows

### DIFF
--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -140,6 +140,8 @@ This is essentially a placeholder for the next release note ...
     programs and collapsible bullets to display their manual pages.
 
 * Other updates:
+  + When file header extent size grows, use 64 MiB per process as the move unit
+    size. See [PR #137](https://github.com/Parallel-NetCDF/PnetCDF/pull/137)
   + Since version 1.1.0, PnetCDF has been using file striping size, if
     obtainable from hint `striping_unit` set by users or MPI-IO underneath, to
     align the starting file offset of data section. This offset is also

--- a/src/drivers/ncmpio/ncmpio_header_get.c
+++ b/src/drivers/ncmpio/ncmpio_header_get.c
@@ -371,6 +371,9 @@ hdr_fetch(bufferinfo *gbp) {
         else {
             /* Obtain the actual read amount. It may be smaller than readLen,
              * when the remaining file size is smaller than read chunk size.
+             * Because each MPI File_read reads amount of readLen bytes, and
+             * readLen <= read chunk size which is <= NC_MAX_INT, calling
+             * MPI_Get_count() is sufficient. No need to call MPI_Get_count_c()
              */
             int get_size;
             MPI_Get_count(&mpistatus, MPI_BYTE, &get_size);

--- a/src/drivers/ncmpio/ncmpio_sync.c
+++ b/src/drivers/ncmpio/ncmpio_sync.c
@@ -126,19 +126,17 @@ ncmpio_write_numrecs(NC         *ncp,
             if (err == NC_EFILE) DEBUG_RETURN_ERROR(NC_EWRITE)
         }
         else {
-            /* update the number of bytes written since file open */
-#ifdef HAVE_MPI_GET_COUNT_C
-            MPI_Count put_size;
-            MPI_Get_count_c(&mpistatus, MPI_BYTE, &put_size);
-            ncp->put_size += put_size;
-#else
+            /* update the number of bytes written since file open.
+             * Because the above MPI write writes either 4 or 8 bytes,
+             * calling MPI_Get_count() is sufficient. No need to call
+             * MPI_Get_count_c()
+             */
             int put_size;
             mpireturn = MPI_Get_count(&mpistatus, MPI_BYTE, &put_size);
             if (mpireturn != MPI_SUCCESS || put_size == MPI_UNDEFINED)
                 ncp->put_size += len;
             else
                 ncp->put_size += put_size;
-#endif
         }
     }
     return NC_NOERR;

--- a/test/largefile/large_reqs.c
+++ b/test/largefile/large_reqs.c
@@ -117,8 +117,8 @@ int tst_one_var(char *filename, MPI_Comm comm)
 
     gsize[0] = NY;
     gsize[1] = NX;
-    lsize[0] = count[1];
-    lsize[1] = count[2];
+    lsize[0] = (int)count[1];
+    lsize[1] = (int)count[2];
     lstart[0] = 0;
     lstart[1] = 0;
     MPI_Type_create_subarray(2, gsize, lsize, lstart, MPI_ORDER_C,
@@ -203,31 +203,31 @@ int tst_vars(char *filename, MPI_Comm comm)
     buf = (int*) malloc(buf_len * sizeof(int));
     for (i=0; i<buf_len; i++) buf[i] = (i + rank) % 128;
 
-    /* set subarray offset and length */
-    start[0] = 0;
-    start[1] = LEN * (rank / psize[1]);
-    start[2] = LEN * (rank % psize[1]);
-    count[0] = 1;
-    count[1] = LEN - gap;
-    count[2] = LEN - gap;
-
-    if (verbose)
-        printf("rank %d start=%lld %lld count=%lld %lld\n",
-               rank, start[1],start[2], count[1],count[2]);
-
     /* create a subarray datatype for user buffer */
     int gsize[2], lsize[2], lstart[2];
     MPI_Datatype buftype;
 
     gsize[0] = LEN;
     gsize[1] = LEN;
-    lsize[0] = count[1];
-    lsize[1] = count[2];
+    lsize[0] = LEN - gap;
+    lsize[1] = LEN - gap;
     lstart[0] = 0;
     lstart[1] = 0;
     MPI_Type_create_subarray(2, gsize, lsize, lstart, MPI_ORDER_C,
                              MPI_INT, &buftype);
     MPI_Type_commit(&buftype);
+
+    /* set subarray offset and length */
+    start[0] = 0;
+    start[1] = LEN * (rank / psize[1]);
+    start[2] = LEN * (rank % psize[1]);
+    count[0] = 1;
+    count[1] = lsize[0];
+    count[2] = lsize[1];
+
+    if (verbose)
+        printf("rank %d start=%lld %lld count=%lld %lld\n",
+               rank, start[1],start[2], count[1],count[2]);
 
     if (verbose)
         printf("%d: nonblocking write total amount = %.1f GiB\n",

--- a/test/largefile/large_var.c
+++ b/test/largefile/large_var.c
@@ -61,7 +61,8 @@ swapn(void       *buf,
 int main(int argc, char** argv)
 {
     char filename[256];
-    int i, j, rank, nprocs, err, nerrs=0, bufsize, expected;
+    size_t bufsize;
+    int i, j, rank, nprocs, err, nerrs=0, expected;
     int ncid, cmode, varid, dimid[3], req[3], st[3], *buf, *buf_ptr;
     MPI_Offset offset, var_offset, start[3], count[3];
     MPI_File fh;
@@ -436,7 +437,7 @@ int main(int argc, char** argv)
     for (i=0; i<count[0]; i++) {
         for (j=0; j<count[1]; j++) {
             offset = var_offset + ((start[0] + i) * NY * NX + (start[1] + j) * NX + start[2]) * sizeof(int);
-            MPI_File_read_at(fh, offset, buf_ptr, count[2], MPI_INT, &status);
+            MPI_File_read_at(fh, offset, buf_ptr, (int)count[2], MPI_INT, &status);
 #ifndef WORDS_BIGENDIAN
             swapn(buf_ptr, count[2]);
 #endif
@@ -466,7 +467,7 @@ int main(int argc, char** argv)
     for (i=0; i<count[0]; i++) {
         for (j=0; j<count[1]; j++) {
             offset = var_offset + ((start[0] + i) * NY * NX + (start[1] + j) * NX + start[2]) * sizeof(int);
-            MPI_File_read_at(fh, offset, buf_ptr, count[2], MPI_INT, &status);
+            MPI_File_read_at(fh, offset, buf_ptr, (int)count[2], MPI_INT, &status);
 #ifndef WORDS_BIGENDIAN
             swapn(buf_ptr, count[2]);
 #endif
@@ -495,7 +496,7 @@ int main(int argc, char** argv)
     for (i=0; i<count[0]; i++) {
         for (j=0; j<count[1]; j++) {
             offset = var_offset + ((start[0] + i) * NY * NX + (start[1] + j) * NX + start[2]) * sizeof(int);
-            MPI_File_read_at(fh, offset, buf_ptr, count[2], MPI_INT, &status);
+            MPI_File_read_at(fh, offset, buf_ptr, (int)count[2], MPI_INT, &status);
 #ifndef WORDS_BIGENDIAN
             swapn(buf_ptr, count[2]);
 #endif
@@ -523,7 +524,7 @@ int main(int argc, char** argv)
     for (i=0; i<count[0]; i++) {
         for (j=0; j<count[1]; j++) {
             offset = var_offset + ((start[0] + i) * NY * NX + (start[1] + j) * NX + start[2]) * sizeof(int);
-            MPI_File_read_at(fh, offset, buf_ptr, count[2], MPI_INT, &status);
+            MPI_File_read_at(fh, offset, buf_ptr, (int)count[2], MPI_INT, &status);
 #ifndef WORDS_BIGENDIAN
             swapn(buf_ptr, count[2]);
 #endif

--- a/test/testcases/tst_redefine.c
+++ b/test/testcases/tst_redefine.c
@@ -27,6 +27,8 @@
 
 static int verbose;
 
+#define NUM_RNDUP(x, unit) ((((x) + (unit) - 1) / (unit)) * (unit))
+
 #define LEN 16
 
 #define CHECK_VAL(ncid, varid, ii, val, expect) {                     \
@@ -44,25 +46,24 @@ static int verbose;
 static int
 check_fix_vars(MPI_Comm comm, int ncid, int *varid)
 {
-    int i, nerrs=0, err, rank, nprocs, *buf;
+    int i, nerrs=0, err, rank, *buf;
     MPI_Offset start[2], count[2];
 
     MPI_Comm_rank(comm, &rank);
-    MPI_Comm_size(comm, &nprocs);
 
-    start[0] = 0; start[1] = rank * (LEN / nprocs);
-    count[0] = 1; count[1] = LEN / nprocs;
+    start[0] = 0; start[1] = rank * LEN;
+    count[0] = 1; count[1] = LEN;
 
     buf = (int*) malloc(sizeof(int) * count[0] * count[1]);
 
     for (i=0; i<count[0]*count[1]; i++) buf[i] = -1;
     err = ncmpi_get_vara_int_all(ncid, varid[0], start+1, count+1, buf); CHECK_ERROUT
-    for (i=0; i<LEN/nprocs; i++)
+    for (i=0; i<LEN; i++)
         CHECK_VAL(ncid, varid[0], i, buf[i], rank+i)
 
     for (i=0; i<count[0]*count[1]; i++) buf[i] = -1;
     err = ncmpi_get_vara_int_all(ncid, varid[1], start+1, count+1, buf); CHECK_ERROUT
-    for (i=0; i<LEN/nprocs; i++)
+    for (i=0; i<LEN; i++)
         CHECK_VAL(ncid, varid[1], i, buf[i], rank+i+100)
 
 err_out:
@@ -73,25 +74,24 @@ err_out:
 static int
 check_rec_vars(MPI_Comm comm, int ncid, int *varid)
 {
-    int i, nerrs=0, err, rank, nprocs, *buf;
+    int i, nerrs=0, err, rank, *buf;
     MPI_Offset start[2], count[2];
 
     MPI_Comm_rank(comm, &rank);
-    MPI_Comm_size(comm, &nprocs);
 
-    start[0] = 0; start[1] = rank * (LEN / nprocs);
-    count[0] = 2; count[1] = LEN / nprocs;
+    start[0] = 0; start[1] = rank * LEN;
+    count[0] = 2; count[1] = LEN;
 
     buf = (int*) malloc(sizeof(int) * count[0] * count[1]);
 
     for (i=0; i<count[0]*count[1]; i++) buf[i] = -1;
     err = ncmpi_get_vara_int_all(ncid, varid[0], start,   count,   buf); CHECK_ERROUT
-    for (i=0; i<2*LEN/nprocs; i++)
+    for (i=0; i<2*LEN; i++)
         CHECK_VAL(ncid, varid[0], i, buf[i], rank+i+1000)
 
     for (i=0; i<count[0]*count[1]; i++) buf[i] = -1;
     err = ncmpi_get_vara_int_all(ncid, varid[1], start,   count,   buf); CHECK_ERROUT
-    for (i=0; i<2*LEN/nprocs; i++)
+    for (i=0; i<2*LEN; i++)
         CHECK_VAL(ncid, varid[1], i, buf[i], rank+i+10000)
 
 err_out:
@@ -108,7 +108,7 @@ tst_fmt(char *filename, int cmode)
     MPI_Offset old_hsize, hsize;
     MPI_Offset old_extent, extent;
     MPI_Offset old_var_off, var_off;
-    MPI_Offset v_align, r_align;
+    MPI_Offset v_align, r_align, exp_var_off;
     MPI_Comm comm = MPI_COMM_WORLD;
 
     MPI_Comm_rank(comm, &rank);
@@ -121,7 +121,7 @@ tst_fmt(char *filename, int cmode)
     err = ncmpi_create(comm, filename, cmode, MPI_INFO_NULL, &ncid); CHECK_ERR
 
     err = ncmpi_def_dim(ncid, "time", NC_UNLIMITED, &dimid[0]); CHECK_ERR
-    err = ncmpi_def_dim(ncid, "dim", LEN, &dimid[1]); CHECK_ERR
+    err = ncmpi_def_dim(ncid, "dim", LEN*nprocs, &dimid[1]); CHECK_ERR
     err = ncmpi_def_var(ncid, "fa", NC_INT, 1, dimid+1, &varid[0]); CHECK_ERR
     err = ncmpi_def_var(ncid, "fb", NC_INT, 1, dimid+1, &varid[1]); CHECK_ERR
     err = ncmpi_def_var(ncid, "ta", NC_INT, 2, dimid,   &varid[2]); CHECK_ERR
@@ -130,24 +130,24 @@ tst_fmt(char *filename, int cmode)
     /* disable header alignment */
     err = ncmpi__enddef(ncid, 0, 4, 0, 4); CHECK_ERR
 
-    start[0] = 0; start[1] = rank * (LEN / nprocs);
-    count[0] = 2; count[1] = LEN / nprocs;
+    start[0] = 0; start[1] = rank * LEN;
+    count[0] = 2; count[1] = LEN;
 
     buf = (int*) malloc(sizeof(int) * count[0] * count[1]);
 
-    for (i=0; i<LEN/nprocs; i++) buf[i] = rank + i;
+    for (i=0; i<LEN; i++) buf[i] = rank + i;
     err = ncmpi_put_vara_int_all(ncid, varid[0], start+1, count+1, buf); CHECK_ERR
-    for (i=0; i<LEN/nprocs; i++) buf[i] = rank + i + 100;
+    for (i=0; i<LEN; i++) buf[i] = rank + i + 100;
     err = ncmpi_put_vara_int_all(ncid, varid[1], start+1, count+1, buf); CHECK_ERR
-    for (i=0; i<2*LEN/nprocs; i++) buf[i] = rank + i + 1000;
+    for (i=0; i<2*LEN; i++) buf[i] = rank + i + 1000;
     err = ncmpi_put_vara_int_all(ncid, varid[2], start,   count,   buf); CHECK_ERR
-    for (i=0; i<2*LEN/nprocs; i++) buf[i] = rank + i + 10000;
+    for (i=0; i<2*LEN; i++) buf[i] = rank + i + 10000;
     err = ncmpi_put_vara_int_all(ncid, varid[3], start,   count,   buf); CHECK_ERR
 
-    err = check_fix_vars(comm, ncid, varid);
-    if (err > 0) goto err_out;
-    err = check_rec_vars(comm, ncid, varid+2);
-    if (err > 0) goto err_out;
+    nerrs += check_fix_vars(comm, ncid, varid);
+    if (nerrs > 0) goto err_out;
+    nerrs += check_rec_vars(comm, ncid, varid+2);
+    if (nerrs > 0) goto err_out;
 
     err = ncmpi_close(ncid); CHECK_ERR
 
@@ -201,10 +201,10 @@ tst_fmt(char *filename, int cmode)
                __LINE__,__FILE__, extent, old_extent);
     }
 
-    err = check_fix_vars(comm, ncid, varid);
-    if (err > 0) goto err_out;
-    err = check_rec_vars(comm, ncid, varid+2);
-    if (err > 0) goto err_out;
+    nerrs += check_fix_vars(comm, ncid, varid);
+    if (nerrs > 0) goto err_out;
+    nerrs += check_rec_vars(comm, ncid, varid+2);
+    if (nerrs > 0) goto err_out;
 
     /* enter redefine mode and add nothing */
     err = ncmpi_redef(ncid); CHECK_ERR
@@ -234,10 +234,10 @@ tst_fmt(char *filename, int cmode)
                __LINE__,__FILE__, extent, old_extent + minfree);
     }
 
-    err = check_fix_vars(comm, ncid, varid);
-    if (err > 0) goto err_out;
-    err = check_rec_vars(comm, ncid, varid+2);
-    if (err > 0) goto err_out;
+    nerrs += check_fix_vars(comm, ncid, varid);
+    if (nerrs > 0) goto err_out;
+    nerrs += check_rec_vars(comm, ncid, varid+2);
+    if (nerrs > 0) goto err_out;
 
     /* enter redefine mode and add nothing */
     err = ncmpi_redef(ncid); CHECK_ERR
@@ -267,10 +267,10 @@ tst_fmt(char *filename, int cmode)
                __LINE__,__FILE__, extent);
     }
 
-    err = check_fix_vars(comm, ncid, varid);
-    if (err > 0) goto err_out;
-    err = check_rec_vars(comm, ncid, varid+2);
-    if (err > 0) goto err_out;
+    nerrs += check_fix_vars(comm, ncid, varid);
+    if (nerrs > 0) goto err_out;
+    nerrs += check_rec_vars(comm, ncid, varid+2);
+    if (nerrs > 0) goto err_out;
 
     err = ncmpi_close(ncid); CHECK_ERR
 
@@ -316,10 +316,10 @@ tst_fmt(char *filename, int cmode)
 
     unsetenv("PNETCDF_HINTS");
 
-    err = check_fix_vars(comm, ncid, varid);
-    if (err > 0) goto err_out;
-    err = check_rec_vars(comm, ncid, varid+2);
-    if (err > 0) goto err_out;
+    nerrs += check_fix_vars(comm, ncid, varid);
+    if (nerrs > 0) goto err_out;
+    nerrs += check_rec_vars(comm, ncid, varid+2);
+    if (nerrs > 0) goto err_out;
 
     /* enter redefine mode and add nothing */
     err = ncmpi_redef(ncid); CHECK_ERR
@@ -352,10 +352,10 @@ tst_fmt(char *filename, int cmode)
     /* obtain 1st record variable's file offset */
     err = ncmpi_inq_varoffset(ncid, varid[2], &old_var_off); CHECK_ERR
 
-    err = check_fix_vars(comm, ncid, varid);
-    if (err > 0) goto err_out;
-    err = check_rec_vars(comm, ncid, varid+2);
-    if (err > 0) goto err_out;
+    nerrs += check_fix_vars(comm, ncid, varid);
+    if (nerrs > 0) goto err_out;
+    nerrs += check_rec_vars(comm, ncid, varid+2);
+    if (nerrs > 0) goto err_out;
 
     /* enter redefine mode and add nothing */
     err = ncmpi_redef(ncid); CHECK_ERR
@@ -373,10 +373,10 @@ tst_fmt(char *filename, int cmode)
                __LINE__,__FILE__, var_off, old_var_off+400);
     }
 
-    err = check_fix_vars(comm, ncid, varid);
-    if (err > 0) goto err_out;
-    err = check_rec_vars(comm, ncid, varid+2);
-    if (err > 0) goto err_out;
+    nerrs += check_fix_vars(comm, ncid, varid);
+    if (nerrs > 0) goto err_out;
+    nerrs += check_rec_vars(comm, ncid, varid+2);
+    if (nerrs > 0) goto err_out;
 
 #if 0
     err = ncmpi_close(ncid); CHECK_ERR
@@ -384,6 +384,10 @@ tst_fmt(char *filename, int cmode)
     /* reopen the file and set r_align */
     err = ncmpi_open(comm, filename, NC_WRITE, MPI_INFO_NULL, &ncid); CHECK_ERR
 #endif
+
+    /* obtained the old offset of 1st record variable */
+    err = ncmpi_inq_varoffset(ncid, varid[2], &old_var_off); CHECK_ERR
+
     /* enter redefine mode and add nothing */
     err = ncmpi_redef(ncid); CHECK_ERR
 
@@ -394,17 +398,20 @@ tst_fmt(char *filename, int cmode)
     /* obtain 1st record variable's file offset */
     err = ncmpi_inq_varoffset(ncid, varid[2], &var_off); CHECK_ERR
 
+    /* round up to r_align */
+    exp_var_off = NUM_RNDUP(old_var_off, r_align);
+
     /* var_off should grows into 1500 bytes */
-    if (var_off != r_align) {
+    if (var_off != exp_var_off) {
         nerrs++;
         printf("Error at line %d in %s: 1st record variable offset %lld (expecting %lld)\n",
-               __LINE__,__FILE__, var_off, r_align);
+               __LINE__,__FILE__, var_off, exp_var_off);
     }
 
-    err = check_fix_vars(comm, ncid, varid);
-    if (err > 0) goto err_out;
-    err = check_rec_vars(comm, ncid, varid+2);
-    if (err > 0) goto err_out;
+    nerrs += check_fix_vars(comm, ncid, varid);
+    if (nerrs > 0) goto err_out;
+    nerrs += check_rec_vars(comm, ncid, varid+2);
+    if (nerrs > 0) goto err_out;
 
     err = ncmpi_close(ncid); CHECK_ERR
 
@@ -416,7 +423,7 @@ tst_fmt(char *filename, int cmode)
 
     /* define only record variables */
     err = ncmpi_def_dim(ncid, "time", NC_UNLIMITED, &dimid[0]); CHECK_ERR
-    err = ncmpi_def_dim(ncid, "dim", LEN, &dimid[1]); CHECK_ERR
+    err = ncmpi_def_dim(ncid, "dim", LEN*nprocs, &dimid[1]); CHECK_ERR
     err = ncmpi_def_var(ncid, "ta", NC_INT, 2, dimid,   &varid[2]); CHECK_ERR
     err = ncmpi_def_var(ncid, "tb", NC_INT, 2, dimid,   &varid[3]); CHECK_ERR
 
@@ -427,12 +434,12 @@ tst_fmt(char *filename, int cmode)
     r_align = 512;
     err = ncmpi__enddef(ncid, 0, v_align, 0, r_align); CHECK_ERR
 
-    start[0] = 0; start[1] = rank * (LEN / nprocs);
-    count[0] = 2; count[1] = LEN / nprocs;
+    start[0] = 0; start[1] = rank * LEN;
+    count[0] = 2; count[1] = LEN;
 
-    for (i=0; i<2*LEN/nprocs; i++) buf[i] = rank + i + 1000;
+    for (i=0; i<2*LEN; i++) buf[i] = rank + i + 1000;
     err = ncmpi_put_vara_int_all(ncid, varid[2], start,   count,   buf); CHECK_ERR
-    for (i=0; i<2*LEN/nprocs; i++) buf[i] = rank + i + 10000;
+    for (i=0; i<2*LEN; i++) buf[i] = rank + i + 10000;
     err = ncmpi_put_vara_int_all(ncid, varid[3], start,   count,   buf); CHECK_ERR
 
     err = ncmpi_inq_header_size(ncid, &hsize); CHECK_ERR
@@ -455,13 +462,13 @@ tst_fmt(char *filename, int cmode)
                __LINE__,__FILE__, extent, r_align);
     }
 
-    err = check_rec_vars(comm, ncid, varid+2);
-    if (err > 0) goto err_out;
+    nerrs += check_rec_vars(comm, ncid, varid+2);
+    if (nerrs > 0) goto err_out;
 
+err_out:
     err = ncmpi_close(ncid); CHECK_ERR
     free(buf);
 
-err_out:
     return nerrs;
 }
 

--- a/test/testcases/tst_redefine.c
+++ b/test/testcases/tst_redefine.c
@@ -27,11 +27,84 @@
 
 static int verbose;
 
+#define LEN 16
+
+#define CHECK_VAL(ncid, varid, ii, val, expect) {                     \
+    if (val != expect) {                                              \
+        char name[16];                                                \
+        err = ncmpi_inq_varname(ncid, varid, name);                   \
+        CHECK_ERROUT                                                  \
+        printf("%s line %d: var %s i=%d expecting %d but got %d\n",   \
+               __func__,__LINE__,name,ii,expect,val);                 \
+        nerrs++;                                                      \
+        goto err_out;                                                 \
+    }                                                                 \
+}
+
+static int
+check_fix_vars(MPI_Comm comm, int ncid, int *varid)
+{
+    int i, nerrs=0, err, rank, nprocs, *buf;
+    MPI_Offset start[2], count[2];
+
+    MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &nprocs);
+
+    start[0] = 0; start[1] = rank * (LEN / nprocs);
+    count[0] = 1; count[1] = LEN / nprocs;
+
+    buf = (int*) malloc(sizeof(int) * count[0] * count[1]);
+
+    for (i=0; i<count[0]*count[1]; i++) buf[i] = -1;
+    err = ncmpi_get_vara_int_all(ncid, varid[0], start+1, count+1, buf); CHECK_ERROUT
+    for (i=0; i<LEN/nprocs; i++)
+        CHECK_VAL(ncid, varid[0], i, buf[i], rank+i)
+
+    for (i=0; i<count[0]*count[1]; i++) buf[i] = -1;
+    err = ncmpi_get_vara_int_all(ncid, varid[1], start+1, count+1, buf); CHECK_ERROUT
+    for (i=0; i<LEN/nprocs; i++)
+        CHECK_VAL(ncid, varid[1], i, buf[i], rank+i+100)
+
+err_out:
+    free(buf);
+    return nerrs;
+}
+
+static int
+check_rec_vars(MPI_Comm comm, int ncid, int *varid)
+{
+    int i, nerrs=0, err, rank, nprocs, *buf;
+    MPI_Offset start[2], count[2];
+
+    MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &nprocs);
+
+    start[0] = 0; start[1] = rank * (LEN / nprocs);
+    count[0] = 2; count[1] = LEN / nprocs;
+
+    buf = (int*) malloc(sizeof(int) * count[0] * count[1]);
+
+    for (i=0; i<count[0]*count[1]; i++) buf[i] = -1;
+    err = ncmpi_get_vara_int_all(ncid, varid[0], start,   count,   buf); CHECK_ERROUT
+    for (i=0; i<2*LEN/nprocs; i++)
+        CHECK_VAL(ncid, varid[0], i, buf[i], rank+i+1000)
+
+    for (i=0; i<count[0]*count[1]; i++) buf[i] = -1;
+    err = ncmpi_get_vara_int_all(ncid, varid[1], start,   count,   buf); CHECK_ERROUT
+    for (i=0; i<2*LEN/nprocs; i++)
+        CHECK_VAL(ncid, varid[1], i, buf[i], rank+i+10000)
+
+err_out:
+    free(buf);
+    return nerrs;
+}
+
 static int
 tst_fmt(char *filename, int cmode)
 {
-    int rank, ncid, err, nerrs=0;
-    int dimid[3], varid[4], minfree=100;
+    int i, rank, nprocs, ncid, err, nerrs=0;
+    int *buf, dimid[3], varid[4], minfree=100;
+    MPI_Offset start[2], count[2];
     MPI_Offset old_hsize, hsize;
     MPI_Offset old_extent, extent;
     MPI_Offset old_var_off, var_off;
@@ -39,6 +112,7 @@ tst_fmt(char *filename, int cmode)
     MPI_Comm comm = MPI_COMM_WORLD;
 
     MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &nprocs);
 
     unsetenv("PNETCDF_HINTS");
 
@@ -47,7 +121,7 @@ tst_fmt(char *filename, int cmode)
     err = ncmpi_create(comm, filename, cmode, MPI_INFO_NULL, &ncid); CHECK_ERR
 
     err = ncmpi_def_dim(ncid, "time", NC_UNLIMITED, &dimid[0]); CHECK_ERR
-    err = ncmpi_def_dim(ncid, "dim", 25, &dimid[1]); CHECK_ERR
+    err = ncmpi_def_dim(ncid, "dim", LEN, &dimid[1]); CHECK_ERR
     err = ncmpi_def_var(ncid, "fa", NC_INT, 1, dimid+1, &varid[0]); CHECK_ERR
     err = ncmpi_def_var(ncid, "fb", NC_INT, 1, dimid+1, &varid[1]); CHECK_ERR
     err = ncmpi_def_var(ncid, "ta", NC_INT, 2, dimid,   &varid[2]); CHECK_ERR
@@ -56,10 +130,34 @@ tst_fmt(char *filename, int cmode)
     /* disable header alignment */
     err = ncmpi__enddef(ncid, 0, 4, 0, 4); CHECK_ERR
 
+    start[0] = 0; start[1] = rank * (LEN / nprocs);
+    count[0] = 2; count[1] = LEN / nprocs;
+
+    buf = (int*) malloc(sizeof(int) * count[0] * count[1]);
+
+    for (i=0; i<LEN/nprocs; i++) buf[i] = rank + i;
+    err = ncmpi_put_vara_int_all(ncid, varid[0], start+1, count+1, buf); CHECK_ERR
+    for (i=0; i<LEN/nprocs; i++) buf[i] = rank + i + 100;
+    err = ncmpi_put_vara_int_all(ncid, varid[1], start+1, count+1, buf); CHECK_ERR
+    for (i=0; i<2*LEN/nprocs; i++) buf[i] = rank + i + 1000;
+    err = ncmpi_put_vara_int_all(ncid, varid[2], start,   count,   buf); CHECK_ERR
+    for (i=0; i<2*LEN/nprocs; i++) buf[i] = rank + i + 10000;
+    err = ncmpi_put_vara_int_all(ncid, varid[3], start,   count,   buf); CHECK_ERR
+
+    err = check_fix_vars(comm, ncid, varid);
+    if (err > 0) goto err_out;
+    err = check_rec_vars(comm, ncid, varid+2);
+    if (err > 0) goto err_out;
+
     err = ncmpi_close(ncid); CHECK_ERR
 
     /* reopen the file and check file header size and extent */
     err = ncmpi_open(comm, filename, NC_WRITE, MPI_INFO_NULL, &ncid); CHECK_ERR
+
+    err = ncmpi_inq_varid(ncid, "fa", &varid[0]); CHECK_ERR
+    err = ncmpi_inq_varid(ncid, "fb", &varid[1]); CHECK_ERR
+    err = ncmpi_inq_varid(ncid, "ta", &varid[2]); CHECK_ERR
+    err = ncmpi_inq_varid(ncid, "tb", &varid[3]); CHECK_ERR
 
     err = ncmpi_inq_header_size(ncid, &hsize); CHECK_ERR
     err = ncmpi_inq_header_extent(ncid, &extent); CHECK_ERR
@@ -103,6 +201,11 @@ tst_fmt(char *filename, int cmode)
                __LINE__,__FILE__, extent, old_extent);
     }
 
+    err = check_fix_vars(comm, ncid, varid);
+    if (err > 0) goto err_out;
+    err = check_rec_vars(comm, ncid, varid+2);
+    if (err > 0) goto err_out;
+
     /* enter redefine mode and add nothing */
     err = ncmpi_redef(ncid); CHECK_ERR
 
@@ -130,6 +233,11 @@ tst_fmt(char *filename, int cmode)
         printf("Error at line %d in %s: File header extent %lld fails to grow into %lld\n",
                __LINE__,__FILE__, extent, old_extent + minfree);
     }
+
+    err = check_fix_vars(comm, ncid, varid);
+    if (err > 0) goto err_out;
+    err = check_rec_vars(comm, ncid, varid+2);
+    if (err > 0) goto err_out;
 
     /* enter redefine mode and add nothing */
     err = ncmpi_redef(ncid); CHECK_ERR
@@ -159,6 +267,11 @@ tst_fmt(char *filename, int cmode)
                __LINE__,__FILE__, extent);
     }
 
+    err = check_fix_vars(comm, ncid, varid);
+    if (err > 0) goto err_out;
+    err = check_rec_vars(comm, ncid, varid+2);
+    if (err > 0) goto err_out;
+
     err = ncmpi_close(ncid); CHECK_ERR
 
 
@@ -166,6 +279,11 @@ tst_fmt(char *filename, int cmode)
 
     /* reopen the file and check file header size and extent */
     err = ncmpi_open(comm, filename, NC_WRITE, MPI_INFO_NULL, &ncid); CHECK_ERR
+
+    err = ncmpi_inq_varid(ncid, "fa", &varid[0]); CHECK_ERR
+    err = ncmpi_inq_varid(ncid, "fb", &varid[1]); CHECK_ERR
+    err = ncmpi_inq_varid(ncid, "ta", &varid[2]); CHECK_ERR
+    err = ncmpi_inq_varid(ncid, "tb", &varid[3]); CHECK_ERR
 
     /* enter redefine mode and add nothing */
     err = ncmpi_redef(ncid); CHECK_ERR
@@ -198,6 +316,11 @@ tst_fmt(char *filename, int cmode)
 
     unsetenv("PNETCDF_HINTS");
 
+    err = check_fix_vars(comm, ncid, varid);
+    if (err > 0) goto err_out;
+    err = check_rec_vars(comm, ncid, varid+2);
+    if (err > 0) goto err_out;
+
     /* enter redefine mode and add nothing */
     err = ncmpi_redef(ncid); CHECK_ERR
 
@@ -229,6 +352,11 @@ tst_fmt(char *filename, int cmode)
     /* obtain 1st record variable's file offset */
     err = ncmpi_inq_varoffset(ncid, varid[2], &old_var_off); CHECK_ERR
 
+    err = check_fix_vars(comm, ncid, varid);
+    if (err > 0) goto err_out;
+    err = check_rec_vars(comm, ncid, varid+2);
+    if (err > 0) goto err_out;
+
     /* enter redefine mode and add nothing */
     err = ncmpi_redef(ncid); CHECK_ERR
 
@@ -244,6 +372,11 @@ tst_fmt(char *filename, int cmode)
         printf("Error at line %d in %s: 1st record variable offset %lld (expecting %lld)\n",
                __LINE__,__FILE__, var_off, old_var_off+400);
     }
+
+    err = check_fix_vars(comm, ncid, varid);
+    if (err > 0) goto err_out;
+    err = check_rec_vars(comm, ncid, varid+2);
+    if (err > 0) goto err_out;
 
 #if 0
     err = ncmpi_close(ncid); CHECK_ERR
@@ -268,6 +401,11 @@ tst_fmt(char *filename, int cmode)
                __LINE__,__FILE__, var_off, r_align);
     }
 
+    err = check_fix_vars(comm, ncid, varid);
+    if (err > 0) goto err_out;
+    err = check_rec_vars(comm, ncid, varid+2);
+    if (err > 0) goto err_out;
+
     err = ncmpi_close(ncid); CHECK_ERR
 
     unsetenv("PNETCDF_HINTS");
@@ -278,7 +416,7 @@ tst_fmt(char *filename, int cmode)
 
     /* define only record variables */
     err = ncmpi_def_dim(ncid, "time", NC_UNLIMITED, &dimid[0]); CHECK_ERR
-    err = ncmpi_def_dim(ncid, "dim", 25, &dimid[1]); CHECK_ERR
+    err = ncmpi_def_dim(ncid, "dim", LEN, &dimid[1]); CHECK_ERR
     err = ncmpi_def_var(ncid, "ta", NC_INT, 2, dimid,   &varid[2]); CHECK_ERR
     err = ncmpi_def_var(ncid, "tb", NC_INT, 2, dimid,   &varid[3]); CHECK_ERR
 
@@ -288,6 +426,14 @@ tst_fmt(char *filename, int cmode)
     v_align = 100;
     r_align = 512;
     err = ncmpi__enddef(ncid, 0, v_align, 0, r_align); CHECK_ERR
+
+    start[0] = 0; start[1] = rank * (LEN / nprocs);
+    count[0] = 2; count[1] = LEN / nprocs;
+
+    for (i=0; i<2*LEN/nprocs; i++) buf[i] = rank + i + 1000;
+    err = ncmpi_put_vara_int_all(ncid, varid[2], start,   count,   buf); CHECK_ERR
+    for (i=0; i<2*LEN/nprocs; i++) buf[i] = rank + i + 10000;
+    err = ncmpi_put_vara_int_all(ncid, varid[3], start,   count,   buf); CHECK_ERR
 
     err = ncmpi_inq_header_size(ncid, &hsize); CHECK_ERR
     err = ncmpi_inq_header_extent(ncid, &extent); CHECK_ERR
@@ -309,8 +455,13 @@ tst_fmt(char *filename, int cmode)
                __LINE__,__FILE__, extent, r_align);
     }
 
-    err = ncmpi_close(ncid); CHECK_ERR
+    err = check_rec_vars(comm, ncid, varid+2);
+    if (err > 0) goto err_out;
 
+    err = ncmpi_close(ncid); CHECK_ERR
+    free(buf);
+
+err_out:
     return nerrs;
 }
 


### PR DESCRIPTION
When file header extent size grows, data section needs to be moved to a higher offset.
This PR moves data section by dividing the data amount to be moved among all ranks.
If the divided amount is larger than MOVE_UNIT (set to 64 MiB in this PR), then the
movement is done in multiple rounds, one chunk at a time. The chunk size has an
upper bound of MOVE_UNIT.
