### PR TITLE
Change default to build shared libraries

### DIFF
--- a/.github/workflows/mac_mpich.yml
+++ b/.github/workflows/mac_mpich.yml
@@ -64,7 +64,6 @@ jobs:
                         pnc_ac_debug=yes \
                         --enable-burst_buffering \
                         --enable-subfiling \
-                        --enable-shared \
                         --enable-thread-safe \
                         --with-pthread \
                         --disable-fortran \

--- a/.github/workflows/mac_openmpi.yml
+++ b/.github/workflows/mac_openmpi.yml
@@ -66,7 +66,6 @@ jobs:
                         pnc_ac_debug=yes \
                         --enable-burst_buffering \
                         --enable-subfiling \
-                        --enable-shared \
                         --enable-thread-safe \
                         --with-pthread \
                         --disable-fortran \

--- a/.github/workflows/ubuntu_mpich.yml
+++ b/.github/workflows/ubuntu_mpich.yml
@@ -78,7 +78,6 @@ jobs:
                         pnc_ac_debug=yes \
                         --enable-burst_buffering \
                         --enable-subfiling \
-                        --enable-shared \
                         --enable-thread-safe \
                         --with-pthread \
                         --with-mpi=${GITHUB_WORKSPACE}/MPICH

--- a/.github/workflows/ubuntu_openmpi.yml
+++ b/.github/workflows/ubuntu_openmpi.yml
@@ -73,7 +73,6 @@ jobs:
                         pnc_ac_debug=yes \
                         --enable-burst_buffering \
                         --enable-subfiling \
-                        --enable-shared \
                         --enable-thread-safe \
                         --with-pthread \
                         --with-mpi=${GITHUB_WORKSPACE}/OPENMPI \

--- a/configure.ac
+++ b/configure.ac
@@ -452,7 +452,8 @@ dnl Travis CI only has v2.4.2
 LT_PREREQ([2.4.6])
 dnl LT_INIT([dlopen disable-shared])
 dnl LT_INIT([dlopen])
-LT_INIT([disable-shared])
+dnl LT_INIT([disable-shared])  # build without shared libraries
+LT_INIT
 
 dnl check MPI C++ compiler
 AC_ARG_ENABLE(cxx,

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -12,7 +12,8 @@ This is essentially a placeholder for the next release note ...
   + none
 
 * Configure options
-  + none
+  + The default has been changed to build both shared and static libraries.
+    See [PR #143](https://github.com/Parallel-NetCDF/PnetCDF/pull/143).
 
 * Configure updates:
   + none


### PR DESCRIPTION
PnetCDF-Python requires shared libraries.