### PR TITLE
Fix logic of enabling in-place byte swap

### DIFF
--- a/src/drivers/ncmpio/ncmpio_i_varn.m4
+++ b/src/drivers/ncmpio/ncmpio_i_varn.m4
@@ -169,13 +169,13 @@ igetput_varn(NC                *ncp,
 
     if (fIsSet(reqMode, NC_REQ_WR)) {
         /* check if in-place byte swap can be enabled */
-        int in_place_swap = 0;
+        int can_swap_in_place = 1;
         if (need_swap) {
-            if (fIsSet(ncp->flags, NC_MODE_SWAP_ON))
-                in_place_swap = 1;
-            else if (! fIsSet(ncp->flags, NC_MODE_SWAP_OFF)) { /* auto mode */
+            if (! fIsSet(ncp->flags, NC_MODE_SWAP_OFF)) /* hint set by user */
+                can_swap_in_place = 0;
+            else if (! fIsSet(ncp->flags, NC_MODE_SWAP_ON)) { /* auto mode */
                 if (nbytes > NC_BYTE_SWAP_BUFFER_SIZE)
-                    in_place_swap = 1;
+                    can_swap_in_place = 0;
             }
         }
 
@@ -195,7 +195,7 @@ igetput_varn(NC                *ncp,
             err = ncmpio_abuf_malloc(ncp, nbytes, &xbuf, &abuf_index);
             if (err != NC_NOERR) goto fn_exit;
         }
-        else if (!need_convert && in_place_swap && isContig) {
+        else if (!need_convert && can_swap_in_place && isContig) {
             /* reuse buf and break it into multiple vara requests */
             xbuf = buf;
             if (need_swap) need_swap_back_buf = 1;

--- a/src/drivers/ncmpio/ncmpio_vard.c
+++ b/src/drivers/ncmpio/ncmpio_vard.c
@@ -194,17 +194,19 @@ getput_vard(NC               *ncp,
     need_swap    = NEED_BYTE_SWAP(varp->xtype, etype);
 
     if (fIsSet(reqMode, NC_REQ_WR)) {
-        int in_place_swap = 0;
+        /* check if in-place byte swap can be enabled */
+        int can_swap_in_place = 1;
         if (need_swap) {
-            if (fIsSet(ncp->flags, NC_MODE_SWAP_ON))
-                in_place_swap = 1;
-            else if (! fIsSet(ncp->flags, NC_MODE_SWAP_OFF)) { /* auto mode */
+            if (! fIsSet(ncp->flags, NC_MODE_SWAP_OFF)) /* hint set by user */
+                can_swap_in_place = 0;
+            else if (! fIsSet(ncp->flags, NC_MODE_SWAP_ON)) { /* auto mode */
                 if (filetype_size > NC_BYTE_SWAP_BUFFER_SIZE)
-                    in_place_swap = 1;
+                    can_swap_in_place = 0;
             }
         }
+
         if (!need_convert &&
-            (!need_swap || (in_place_swap && buftype_is_contig))) {
+            (!need_swap || (can_swap_in_place && buftype_is_contig))) {
             /* reuse buftype, bufcount, buf in later MPI file write */
             xbuf = buf;
             if (need_swap) {


### PR DESCRIPTION
This affects only when running on a Big Endian machine.

When byte swapping is not necessary, this commit avoids
extra internal buffer allocation.