### PR TITLE
Use MPI independent I/O when number of processes is 1

### DIFF
--- a/src/drivers/ncmpio/ncmpio_NC.h
+++ b/src/drivers/ncmpio/ncmpio_NC.h
@@ -407,6 +407,8 @@ struct NC {
     MPI_Offset    get_size;  /* amount of reads  committed so far in bytes */
 
     MPI_Comm      comm;           /* MPI communicator */
+    int           rank;           /* MPI rank of this process */
+    int           nprocs;         /* number of MPI processes */
     MPI_Info      mpiinfo;        /* used MPI info object */
     MPI_File      collective_fh;  /* file handle for collective mode */
     MPI_File      independent_fh; /* file handle for independent mode */
@@ -474,7 +476,7 @@ typedef struct bufferinfo {
     int         chunk;    /* chunk size for reading the header */
     int         version;  /* 1, 2, and 5 for CDF-1, 2, and 5 respectively */
     int         safe_mode;/* 0: disabled, 1: enabled */
-    int         rw_mode;  /* 0: independent, 1: collective */
+    int         coll_mode;/* 0: independent, 1: collective */
     char       *base;     /* beginning of read/write buffer */
     char       *pos;      /* current position in buffer */
     char       *end;      /* end position of buffer */

--- a/src/drivers/ncmpio/ncmpio_attr.m4
+++ b/src/drivers/ncmpio/ncmpio_attr.m4
@@ -477,7 +477,7 @@ ncmpio_rename_att(void       *ncdp,
 
 err_check:
     if (nname != NULL) NCI_Free(nname);
-    if (ncp->safe_mode) {
+    if (ncp->safe_mode && ncp->nprocs > 1) {
         int minE, mpireturn;
 
         /* check error code across processes */
@@ -597,7 +597,7 @@ ncmpio_copy_att(void       *ncdp_in,
     }
 
 err_check:
-    if (ncp_out->safe_mode) {
+    if (ncp_out->safe_mode && ncp_out->nprocs > 1) {
         int minE, mpireturn;
 
         /* check the error code across processes */
@@ -710,7 +710,7 @@ ncmpio_del_att(void       *ncdp,
 
 err_check:
     if (nname != NULL) NCI_Free(nname);
-    if (ncp->safe_mode) {
+    if (ncp->safe_mode && ncp->nprocs > 1) {
         int minE, mpireturn;
 
         /* find min error code across processes */
@@ -1044,7 +1044,8 @@ ncmpio_put_att(void         *ncdp,
     }
 
 err_check:
-    if (ncp->safe_mode) { /* check the error code across processes */
+    if (ncp->safe_mode && ncp->nprocs > 1) {
+        /* check the error code across processes */
         int minE, mpireturn;
 
         TRACE_COMM(MPI_Allreduce)(&err, &minE, 1, MPI_INT, MPI_MIN, ncp->comm);

--- a/src/drivers/ncmpio/ncmpio_close.c
+++ b/src/drivers/ncmpio/ncmpio_close.c
@@ -69,7 +69,7 @@ ncmpio_close_files(NC *ncp, int doUnlink) {
             return ncmpii_error_mpi2nc(mpireturn, "MPI_File_close");
     }
 
-    if (ncp->collective_fh != MPI_FILE_NULL) {
+    if (ncp->nprocs > 1 && ncp->collective_fh != MPI_FILE_NULL) {
         TRACE_IO(MPI_File_close)(&ncp->collective_fh);
         if (mpireturn != MPI_SUCCESS)
             return ncmpii_error_mpi2nc(mpireturn, "MPI_File_close");
@@ -78,9 +78,13 @@ ncmpio_close_files(NC *ncp, int doUnlink) {
     if (doUnlink) {
         /* called from ncmpi_abort, if the file is being created and is still
          * in define mode, the file is deleted */
-        TRACE_IO(MPI_File_delete)((char *)ncp->path, ncp->mpiinfo);
-        if (mpireturn != MPI_SUCCESS)
-            return ncmpii_error_mpi2nc(mpireturn, "MPI_File_delete");
+        if (ncp->rank == 0) {
+            TRACE_IO(MPI_File_delete)((char *)ncp->path, ncp->mpiinfo);
+            if (mpireturn != MPI_SUCCESS)
+                return ncmpii_error_mpi2nc(mpireturn, "MPI_File_delete");
+        }
+        if (ncp->nprocs > 1)
+            MPI_Barrier(ncp->comm);
     }
     return NC_NOERR;
 }
@@ -163,13 +167,10 @@ ncmpio_close(void *ncdp)
 
     /* file is open for write and no variable has been defined */
     if (!NC_readonly(ncp) && ncp->vars.ndefined == 0) {
-        int rank;
-
         /* wait until all processes close the file */
-        MPI_Barrier(ncp->comm);
+        if (ncp->nprocs > 1) MPI_Barrier(ncp->comm);
 
-        MPI_Comm_rank(ncp->comm, &rank);
-        if (rank == 0) {
+        if (ncp->rank == 0) {
             /* ignore all errors, as unexpected file size if not a fatal error */
 #ifdef HAVE_TRUNCATE
             /* when calling POSIX I/O, remove file type prefix from file name */
@@ -222,7 +223,7 @@ ncmpio_close(void *ncdp)
             }
 #endif
         }
-        MPI_Barrier(ncp->comm);
+        if (ncp->nprocs > 1) MPI_Barrier(ncp->comm);
     }
 
     /* free up space occupied by the header metadata */

--- a/src/drivers/ncmpio/ncmpio_create.c
+++ b/src/drivers/ncmpio/ncmpio_create.c
@@ -293,8 +293,10 @@ ncmpio_create(MPI_Comm     comm,
     ncp->comm           = comm;  /* reuse comm duplicated in dispatch layer */
     ncp->mpiinfo        = info_used; /* is not MPI_INFO_NULL */
     ncp->mpiomode       = mpiomode;
+    ncp->rank           = rank;
+    ncp->nprocs         = nprocs;
     ncp->collective_fh  = fh;
-    ncp->independent_fh = MPI_FILE_NULL;
+    ncp->independent_fh = (nprocs > 1) ? MPI_FILE_NULL : fh;
     ncp->path = (char*) NCI_Malloc(strlen(path) + 1);
     strcpy(ncp->path, path);
 

--- a/src/drivers/ncmpio/ncmpio_dim.c
+++ b/src/drivers/ncmpio/ncmpio_dim.c
@@ -346,10 +346,10 @@ ncmpio_rename_dim(void       *ncdp,
 #endif
 
 err_check:
-    if (ncp->safe_mode) {
+    if (ncp->safe_mode && ncp->nprocs > 1) {
+        /* check the error so far across processes */
         int status, mpireturn;
 
-        /* check the error so far across processes */
         TRACE_COMM(MPI_Allreduce)(&err, &status, 1, MPI_INT, MPI_MIN,ncp->comm);
         if (mpireturn != MPI_SUCCESS) {
             NCI_Free(nnewname);

--- a/src/drivers/ncmpio/ncmpio_file_io.c
+++ b/src/drivers/ncmpio/ncmpio_file_io.c
@@ -128,7 +128,7 @@ ncmpio_read_write(NC           *ncp,
             xbuf = NCI_Malloc((size_t)req_size);
         }
 
-        if (coll_indep == NC_REQ_COLL) {
+        if (ncp->nprocs > 1 && coll_indep == NC_REQ_COLL) {
             TRACE_IO(MPI_File_read_at_all)(fh, offset, xbuf, xlen, xbuf_type,
                                            &mpistatus);
             if (mpireturn != MPI_SUCCESS) {
@@ -274,7 +274,7 @@ ncmpio_read_write(NC           *ncp,
             }
         }
 
-        if (coll_indep == NC_REQ_COLL) {
+        if (ncp->nprocs > 1 && coll_indep == NC_REQ_COLL) {
             TRACE_IO(MPI_File_write_at_all)(fh, offset, xbuf, xlen, xbuf_type,
                                             &mpistatus);
             if (mpireturn != MPI_SUCCESS) {

--- a/src/drivers/ncmpio/ncmpio_getput.m4
+++ b/src/drivers/ncmpio/ncmpio_getput.m4
@@ -266,12 +266,11 @@ err_check:
      * have to process this one record at a time.
      */
 
-    if (fIsSet(reqMode, NC_REQ_COLL)) {
+    fh = ncp->independent_fh;
+    coll_indep = NC_REQ_INDEP;
+    if (ncp->nprocs > 1 && fIsSet(reqMode, NC_REQ_COLL)) {
         fh = ncp->collective_fh;
         coll_indep = NC_REQ_COLL;
-    } else {
-        fh = ncp->independent_fh;
-        coll_indep = NC_REQ_INDEP;
     }
 
     /* MPI_File_set_view is collective */
@@ -317,12 +316,14 @@ err_check:
              * different among processes. First, find the max numrecs among
              * all processes.
              */
-            MPI_Offset max_numrecs;
-            TRACE_COMM(MPI_Allreduce)(&new_numrecs, &max_numrecs, 1,
-                                      MPI_OFFSET, MPI_MAX, ncp->comm);
-            if (mpireturn != MPI_SUCCESS) {
-                err = ncmpii_error_mpi2nc(mpireturn, "MPI_Allreduce");
-                if (status == NC_NOERR) status = err;
+            MPI_Offset max_numrecs = new_numrecs;
+            if (ncp->nprocs > 1) {
+                TRACE_COMM(MPI_Allreduce)(&new_numrecs, &max_numrecs, 1,
+                                          MPI_OFFSET, MPI_MAX, ncp->comm);
+                if (mpireturn != MPI_SUCCESS) {
+                    err = ncmpii_error_mpi2nc(mpireturn, "MPI_Allreduce");
+                    if (status == NC_NOERR) status = err;
+                }
             }
             /* In collective mode, ncp->numrecs is always sync-ed among
                processes */
@@ -493,12 +494,11 @@ err_check:
      * have to process this one record at a time.
      */
 
-    if (fIsSet(reqMode, NC_REQ_COLL)) {
+    fh = ncp->independent_fh;
+    coll_indep = NC_REQ_INDEP;
+    if (ncp->nprocs > 1 && fIsSet(reqMode, NC_REQ_COLL)) {
         fh = ncp->collective_fh;
         coll_indep = NC_REQ_COLL;
-    } else {
-        fh = ncp->independent_fh;
-        coll_indep = NC_REQ_INDEP;
     }
 
     /* MPI_File_set_view is collective */

--- a/src/drivers/ncmpio/ncmpio_open.c
+++ b/src/drivers/ncmpio/ncmpio_open.c
@@ -113,10 +113,12 @@ ncmpio_open(MPI_Comm     comm,
 
     ncp->iomode         = omode;
     ncp->comm           = comm;  /* reuse comm duplicated in dispatch layer */
+    MPI_Comm_rank(comm, &ncp->rank);
+    MPI_Comm_size(comm, &ncp->nprocs);
     ncp->mpiinfo        = info_used; /* is not MPI_INFO_NULL */
     ncp->mpiomode       = mpiomode;
     ncp->collective_fh  = fh;
-    ncp->independent_fh = MPI_FILE_NULL;
+    ncp->independent_fh = (ncp->nprocs > 1) ? MPI_FILE_NULL : fh;
     ncp->path = (char*) NCI_Malloc(strlen(path) + 1);
     strcpy(ncp->path, path);
 

--- a/src/drivers/ncmpio/ncmpio_var.c
+++ b/src/drivers/ncmpio/ncmpio_var.c
@@ -415,10 +415,10 @@ ncmpio_def_var(void       *ncdp,
     ncp->vars.ndefined++;
 
 err_check:
-    if (ncp->safe_mode) {
+    if (ncp->safe_mode && ncp->nprocs > 1) {
         int minE, mpireturn;
 
-        /* first check the error code across processes */
+        /* First check the error code across processes */
         TRACE_COMM(MPI_Allreduce)(&err, &minE, 1, MPI_INT, MPI_MIN, ncp->comm);
         if (mpireturn != MPI_SUCCESS) {
             if (nname != NULL) NCI_Free(nname);
@@ -600,7 +600,7 @@ ncmpio_rename_var(void       *ncdp,
 #endif
 
 err_check:
-    if (ncp->safe_mode) {
+    if (ncp->safe_mode && ncp->nprocs > 1) {
         int minE, mpireturn;
 
         /* First check error code so far across processes */


### PR DESCRIPTION
Check if the number of processes is 1. If this is the case, call only the MPI independent I/O functions. In addition, it avoids calls to MPI_Barrier, MPI_Bcast, and MPI_Allreduce.