### PR TITLE
replace C macros beginning with _ and an uppercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Northwestern University and Argonne National Laboratory.
 * [E3SM I/O kernel study](https://github.com/Parallel-NetCDF/E3SM-IO)
 * [Scorpio](https://github.com/E3SM-Project/scorpio), the I/O module of E3SM.
 * [PIO](https://github.com/NCAR/ParallelIO) - parallel I/O library at NCAR.
-* [WRF](https://github.com/wrf-model/WRF/tree/master/external/io_pnetcdf)
-  - Weather Research & Forecasting Model at NCAR.
+* [WRF](https://github.com/wrf-model/WRF/tree/master/external/io_pnetcdf) -
+  Weather Research & Forecasting Model at NCAR.
 
 
 ### Acknowledgements

--- a/configure.ac
+++ b/configure.ac
@@ -151,8 +151,8 @@ AH_TEMPLATE([ENABLE_REQ_AGGREGATION],   [Define if able to support request aggre
 dnl AH_TEMPLATE([HAVE_MPI_COUNT],       [Define if type MPI_Count is defined])
 AH_TEMPLATE([HAVE_MPI_LARGE_COUNT],     [Define if required MPI APIs have arguments of type MPI_Count])
 
-AH_TOP([#ifndef _CONFIG_H
-#define _CONFIG_H])
+AH_TOP([#ifndef H_CONFIG
+#define H_CONFIG])
 AH_BOTTOM([#include <nctypes.h>
 #endif])
 

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -24,7 +24,9 @@ This is essentially a placeholder for the next release note ...
   + none
 
 * New constants
-  + none
+  + C macro NC_FillValue replaces _FillValue. This conforms with NetCDF4's
+    change in its version 4.9.3 release.
+    See [PR #153](https://github.com/Parallel-NetCDF/PnetCDF/pull/153).
 
 * New APIs
   + none
@@ -63,7 +65,7 @@ This is essentially a placeholder for the next release note ...
   + Fix `pnetcdf-config` of reflecting the installation path when installation
     is done by running command `make install DESTDIR=/alternate/directory`
     which prepends '/alternate/directory' before all installation names.
-    See [PR #145](https://github.com/Parallel-NetCDF/PnetCDF/pull/154).
+    See [PR #154](https://github.com/Parallel-NetCDF/PnetCDF/pull/154).
 
 * New example programs
   + C/flexible_bottom.c and C/vard_bottom.c - These two examples construct MPI

--- a/src/binding/f77/mpinetcdf_impl.h
+++ b/src/binding/f77/mpinetcdf_impl.h
@@ -5,8 +5,8 @@
  */
 /* $Id$ */
 
-#ifndef _MPINETCDF_IMPL_H
-#define _MPINETCDF_IMPL_H
+#ifndef H_MPINETCDF_IMPL
+#define H_MPINETCDF_IMPL
 
 #ifdef HAVE_CONFIG_H
 # include <config.h>

--- a/src/dispatchers/attr_getput.m4
+++ b/src/dispatchers/attr_getput.m4
@@ -64,8 +64,8 @@ sanity_check_put(PNC        *pncp,
 
 #ifdef NO_NC_GLOBAL_FILLVALUE
     /* See r3403 and RELEASE_NOTES 1.9.0 */
-    if (varid == NC_GLOBAL && !strcmp(name, _FillValue))
-        DEBUG_RETURN_ERROR(NC_EGLOBAL) /* global _FillValue is not allowed */
+    if (varid == NC_GLOBAL && !strcmp(name, "_FillValue"))
+        DEBUG_RETURN_ERROR(NC_EGLOBAL) /* global "_FillValue" is not allowed */
 #endif
 
     if (strlen(name) > NC_MAX_NAME) /* name length */

--- a/src/dispatchers/file.c
+++ b/src/dispatchers/file.c
@@ -537,7 +537,7 @@ ncmpi_create(MPI_Comm    comm,
     return status;
 }
 
-#define _NDIMS_ 16
+#define NDIMS_ 16
 
 /*----< ncmpi_open() >-------------------------------------------------------*/
 /* This is a collective subroutine. */
@@ -549,7 +549,7 @@ ncmpi_open(MPI_Comm    comm,
            int        *ncidp)  /* OUT */
 {
     int i, j, nalloc, rank, nprocs, format, status=NC_NOERR, err;
-    int safe_mode=0, mpireturn, relax_coord_bound, DIMIDS[_NDIMS_], *dimids;
+    int safe_mode=0, mpireturn, relax_coord_bound, DIMIDS[NDIMS_], *dimids;
     char *env_str;
     MPI_Info combined_info;
     void *ncp;
@@ -814,7 +814,7 @@ ncmpi_open(MPI_Comm    comm,
      */
 
     /* allocate chunk size for pncp->vars[] */
-    nalloc = _RNDUP(pncp->nvars, PNC_VARS_CHUNK);
+    nalloc = PNETCDF_RNDUP(pncp->nvars, PNC_VARS_CHUNK);
     pncp->vars = NCI_Malloc(nalloc * sizeof(PNC_var));
     if (pncp->vars == NULL) {
         DEBUG_ASSIGN_ERROR(err, NC_ENOMEM)
@@ -825,7 +825,7 @@ ncmpi_open(MPI_Comm    comm,
 
     /* construct array of PNC_var for all variables */
     for (i=0; i<pncp->nvars; i++) {
-        int ndims, max_ndims=_NDIMS_;
+        int ndims, max_ndims=NDIMS_;
         pncp->vars[i].shape  = NULL;
         pncp->vars[i].recdim = -1;   /* if fixed-size variable */
         err = driver->inq_var(pncp->ncp, i, NULL, &pncp->vars[i].xtype, &ndims,

--- a/src/dispatchers/variable.c
+++ b/src/dispatchers/variable.c
@@ -256,7 +256,7 @@ ncmpi_def_var_fill(int         ncid,    /* IN:  file ID */
     }
 
     if (varid == NC_GLOBAL) {
-        /* setting global _FillValue through this API is not allowed */
+        /* setting global attribute _FillValue through this API is not allowed */
         DEBUG_ASSIGN_ERROR(err, NC_EGLOBAL)
         goto err_check;
     }

--- a/src/drivers/common/utf8proc.c
+++ b/src/drivers/common/utf8proc.c
@@ -146,7 +146,7 @@ ncmpii_utf8_validate(const char* name)
 #include "utf8proc_data.h"
 
 
-#ifndef _PNETCDF_H
+#ifndef H_PNETCDF
 UTF8PROC_DLLEXPORT const utf8proc_int8_t utf8proc_utf8class[256] = {
   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -191,7 +191,7 @@ UTF8PROC_DLLEXPORT const utf8proc_int8_t utf8proc_utf8class[256] = {
    be different, being based on ABI compatibility.): */
 #define STRINGIZEx(x) #x
 #define STRINGIZE(x) STRINGIZEx(x)
-#ifndef _PNETCDF_H
+#ifndef H_PNETCDF
 UTF8PROC_DLLEXPORT const char *utf8proc_version(void) {
   return STRINGIZE(UTF8PROC_VERSION_MAJOR) "." STRINGIZE(UTF8PROC_VERSION_MINOR) "." STRINGIZE(UTF8PROC_VERSION_PATCH) "";
 }
@@ -263,7 +263,7 @@ UTF8PROC_DLLEXPORT utf8proc_ssize_t utf8proc_iterate(
   return 4;
 }
 
-#ifndef _PNETCDF_H
+#ifndef H_PNETCDF
 UTF8PROC_DLLEXPORT utf8proc_bool utf8proc_codepoint_valid(utf8proc_int32_t uc) {
     return (((utf8proc_uint32_t)uc)-0xd800 > 0x07ff) && ((utf8proc_uint32_t)uc < 0x110000);
 }
@@ -336,7 +336,7 @@ static const utf8proc_property_t *unsafe_get_property(utf8proc_int32_t uc) {
   );
 }
 
-#ifndef _PNETCDF_H
+#ifndef H_PNETCDF
 UTF8PROC_DLLEXPORT const utf8proc_property_t *utf8proc_get_property(utf8proc_int32_t uc) {
   return uc < 0 || uc >= 0x110000 ? utf8proc_properties : unsafe_get_property(uc);
 }
@@ -417,7 +417,7 @@ static utf8proc_bool grapheme_break_extended(int lbc, int tbc, utf8proc_int32_t 
   return break_permitted;
 }
 
-#ifndef _PNETCDF_H
+#ifndef H_PNETCDF
 UTF8PROC_DLLEXPORT utf8proc_bool utf8proc_grapheme_break_stateful(
     utf8proc_int32_t c1, utf8proc_int32_t c2, utf8proc_int32_t *state) {
 
@@ -444,7 +444,7 @@ static utf8proc_int32_t seqindex_decode_entry(const utf8proc_uint16_t **entry)
   return entry_cp;
 }
 
-#ifndef _PNETCDF_H
+#ifndef H_PNETCDF
 static utf8proc_int32_t seqindex_decode_index(const utf8proc_uint32_t seqindex)
 {
   const utf8proc_uint16_t *entry = &utf8proc_sequences[seqindex];
@@ -471,7 +471,7 @@ static utf8proc_ssize_t seqindex_write_char_decomposed(utf8proc_uint16_t seqinde
   return written;
 }
 
-#ifndef _PNETCDF_H
+#ifndef H_PNETCDF
 UTF8PROC_DLLEXPORT utf8proc_int32_t utf8proc_tolower(utf8proc_int32_t c)
 {
   utf8proc_int32_t cl = utf8proc_get_property(c)->lowercase_seqindex;
@@ -595,7 +595,7 @@ UTF8PROC_DLLEXPORT utf8proc_ssize_t utf8proc_decompose_char(utf8proc_int32_t uc,
   return 1;
 }
 
-#ifndef _PNETCDF_H
+#ifndef H_PNETCDF
 UTF8PROC_DLLEXPORT utf8proc_ssize_t utf8proc_decompose(
   const utf8proc_uint8_t *str, utf8proc_ssize_t strlen,
   utf8proc_int32_t *buffer, utf8proc_ssize_t bufsize, utf8proc_option_t options
@@ -844,7 +844,7 @@ UTF8PROC_DLLEXPORT utf8proc_ssize_t utf8proc_map_custom(
   return result;
 }
 
-#ifndef _PNETCDF_H
+#ifndef H_PNETCDF
 UTF8PROC_DLLEXPORT utf8proc_uint8_t *utf8proc_NFD(const utf8proc_uint8_t *str) {
   utf8proc_uint8_t *retval;
   utf8proc_map(str, 0, &retval, UTF8PROC_NULLTERM | UTF8PROC_STABLE |

--- a/src/drivers/common/utf8proc.h
+++ b/src/drivers/common/utf8proc.h
@@ -120,7 +120,7 @@ typedef bool utf8proc_bool;
 #endif
 #include <limits.h>
 
-#ifndef _PNETCDF_H
+#ifndef H_PNETCDF
 #ifdef _WIN32
 #  ifdef UTF8PROC_EXPORTS
 #    define UTF8PROC_DLLEXPORT __declspec(dllexport)
@@ -146,7 +146,7 @@ extern "C" {
 #  define UINT16_MAX 65535U
 #endif
 
-#ifdef _PNETCDF_H
+#ifdef H_PNETCDF
 /* silence Fujitsu compiler warning: enumerated type mixed with another type */
 #define UTF8PROC_NULLTERM   (1<<0)
 #define UTF8PROC_STABLE     (1<<1)
@@ -409,7 +409,7 @@ typedef enum {
  */
 typedef utf8proc_int32_t (*utf8proc_custom_func)(utf8proc_int32_t codepoint, void *data);
 
-#ifndef _PNETCDF_H
+#ifndef H_PNETCDF
 /**
  * Array containing the byte lengths of a UTF-8 encoded codepoint based
  * on the first byte.

--- a/src/drivers/include/common.h
+++ b/src/drivers/include/common.h
@@ -4,8 +4,8 @@
  */
 /* $Id$ */
 
-#ifndef _COMMON_H
-#define _COMMON_H
+#ifndef H_COMMON
+#define H_COMMON
 
 #include <mpi.h>
 #include <pnetcdf.h>
@@ -26,16 +26,16 @@
 #endif
 
 /* useful for aligning memory */
-#define _RNDUP(x, unit)      ((((x) + (unit) - 1) / (unit)) * (unit))
-#define _RNDDOWN(x, unit)    ((x) - ((x)%(unit)))
+#define PNETCDF_RNDUP(x, unit)      ((((x) + (unit) - 1) / (unit)) * (unit))
+#define PNETCDF_RNDDOWN(x, unit)    ((x) - ((x)%(unit)))
 
 /* #define M_RND_UNIT   (sizeof(double))
  * SIZEOF_DOUBLE is defined in config.h
  */
 #define M_RND_UNIT        SIZEOF_DOUBLE
-#define M_RNDUP(x)        _RNDUP(x, M_RND_UNIT)
-#define M_RNDDOWN(x)      _RNDDOWN(x, M_RND_UNIT)
-#define D_RNDUP(x, align) _RNDUP(x, (off_t)(align))
+#define M_RNDUP(x)        PNETCDF_RNDUP(x, M_RND_UNIT)
+#define M_RNDDOWN(x)      PNETCDF_RNDDOWN(x, M_RND_UNIT)
+#define D_RNDUP(x, align) PNETCDF_RNDUP(x, (off_t)(align))
 
 /* for put request less than 4KB, copy it to a buffer and do byte swap there,
  * so if the user buffer is immutable (assuming smaller than 4KB), it will not

--- a/src/drivers/include/ncx_h.m4
+++ b/src/drivers/include/ncx_h.m4
@@ -9,8 +9,8 @@ dnl
  */
 /* "$Id$" */
 
-#ifndef _NCX_H
-#define _NCX_H
+#ifndef H_NCX
+#define H_NCX
 
 #include <stddef.h>    /* size_t */
 #include <sys/types.h> /* off_t */
@@ -373,4 +373,4 @@ ncmpix_putn_void(void **xpp, MPI_Offset nchars, const void *vp);
 extern int
 ncmpix_pad_putn_void(void **xpp, MPI_Offset nchars, const void *vp);
 
-#endif /* _NCX_H_ */
+#endif /* H_NCX */

--- a/src/drivers/nc4io/nc4io_driver.h
+++ b/src/drivers/nc4io/nc4io_driver.h
@@ -4,8 +4,8 @@
  */
 /* $Id$ */
 
-#ifndef _nc4io_DRIVER_H
-#define _nc4io_DRIVER_H
+#ifndef H_nc4io_DRIVER
+#define H_nc4io_DRIVER
 
 #include <mpi.h>
 #include <pnetcdf.h>

--- a/src/drivers/ncadios/adios_headers/core/adios_timing.h
+++ b/src/drivers/ncadios/adios_headers/core/adios_timing.h
@@ -5,8 +5,8 @@
  * Copyright (c) 2008 - 2009.  UT-BATTELLE, LLC. All rights reserved.
  */
 
-#ifndef _ADIOS_TIMING_H_
-#define _ADIOS_TIMING_H_
+#ifndef H_ADIOS_TIMING
+#define H_ADIOS_TIMING
 
 
 #include <stdint.h>

--- a/src/drivers/ncadios/adios_headers/core/qhashtbl.h
+++ b/src/drivers/ncadios/adios_headers/core/qhashtbl.h
@@ -28,8 +28,8 @@
 /*
   Modified/simplified by ADIOS team for the purpose of variable/attribute store
 */
-#ifndef __HASHTBL_H_
-#define __HASHTBL_H_
+#ifndef H_HASHTBL
+#define H_HASHTBL
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/drivers/ncadios/ncadios_driver.h
+++ b/src/drivers/ncadios/ncadios_driver.h
@@ -3,8 +3,8 @@
  *  See COPYRIGHT notice in top-level directory.
  */
 
-#ifndef _ncadios_DRIVER_H
-#define _ncadios_DRIVER_H
+#ifndef H_ncadios_DRIVER
+#define H_ncadios_DRIVER
 
 #include <mpi.h>
 #include <pnetcdf.h>

--- a/src/drivers/ncbbio/ncbbio_driver.h
+++ b/src/drivers/ncbbio/ncbbio_driver.h
@@ -5,8 +5,8 @@
 
 /* $Id$ */
 
-#ifndef _NCFOO_DRIVER_H
-#define _NCFOO_DRIVER_H
+#ifndef H_NCFOO_DRIVER
+#define H_NCFOO_DRIVER
 
 #include <dispatch.h>
 #include <limits.h>

--- a/src/drivers/ncfoo/ncfoo_driver.h
+++ b/src/drivers/ncfoo/ncfoo_driver.h
@@ -4,8 +4,8 @@
  */
 /* $Id$ */
 
-#ifndef _NCFOO_DRIVER_H
-#define _NCFOO_DRIVER_H
+#ifndef H_NCFOO_DRIVER
+#define H_NCFOO_DRIVER
 
 #include <mpi.h>
 #include <pnetcdf.h>

--- a/src/drivers/ncmpio/ncmpio_NC.h
+++ b/src/drivers/ncmpio/ncmpio_NC.h
@@ -4,8 +4,8 @@
  */
 /* $Id$ */
 
-#ifndef _NC_H
-#define _NC_H
+#ifndef H_NC
+#define H_NC
 
 /*
  * netcdf library 'private' data structures, objects and interfaces
@@ -631,4 +631,4 @@ ncmpio_read_write(NC *ncp, int rw_flag, int coll_indep, MPI_Offset offset,
                   MPI_Offset buf_count, MPI_Datatype buf_type, void *buf,
                   int buftype_is_contig);
 
-#endif /* _NC_H */
+#endif /* H_NC */

--- a/src/drivers/ncmpio/ncmpio_attr.m4
+++ b/src/drivers/ncmpio/ncmpio_attr.m4
@@ -983,7 +983,7 @@ ncmpio_put_att(void         *ncdp,
     /* If this is attribute _FillValue, then let PnetCDF return the
      * same error codes as netCDF
      */
-    if (varid != NC_GLOBAL && !strcmp(name, NC_FillValue)) {
+    if (varid != NC_GLOBAL && !strcmp(name, "_FillValue")) {
         /* Fill value must be of the same data type */
         if (xtype != ncp->vars.value[varid]->xtype) {
             DEBUG_ASSIGN_ERROR(err, NC_EBADTYPE)

--- a/src/drivers/ncmpio/ncmpio_attr.m4
+++ b/src/drivers/ncmpio/ncmpio_attr.m4
@@ -55,7 +55,7 @@ x_len_NC_attrV(nc_type    xtype,
     switch(xtype) {
         case NC_BYTE:
         case NC_CHAR:
-        case NC_UBYTE:  return _RNDUP(nelems, 4);
+        case NC_UBYTE:  return PNETCDF_RNDUP(nelems, 4);
         case NC_SHORT:
         case NC_USHORT: return ((nelems + nelems%2) * 2);
         case NC_INT:
@@ -188,7 +188,7 @@ ncmpio_dup_NC_attrarray(NC_attrarray *ncap, const NC_attrarray *ref)
     }
 
     if (ref->ndefined > 0) {
-        size_t alloc_size = _RNDUP(ref->ndefined, PNC_ARRAY_GROWBY);
+        size_t alloc_size = PNETCDF_RNDUP(ref->ndefined, PNC_ARRAY_GROWBY);
         ncap->value = (NC_attr **) NCI_Calloc(alloc_size, sizeof(NC_attr*));
         if (ncap->value == NULL) DEBUG_RETURN_ERROR(NC_ENOMEM)
     }
@@ -980,10 +980,10 @@ ncmpio_put_att(void         *ncdp,
 
     /* sanity checks for varid, name, xtype has been done in dispatcher */
 
-    /* If this is the _FillValue attribute, then let PnetCDF return the
+    /* If this is attribute _FillValue, then let PnetCDF return the
      * same error codes as netCDF
      */
-    if (varid != NC_GLOBAL && !strcmp(name, _FillValue)) {
+    if (varid != NC_GLOBAL && !strcmp(name, NC_FillValue)) {
         /* Fill value must be of the same data type */
         if (xtype != ncp->vars.value[varid]->xtype) {
             DEBUG_ASSIGN_ERROR(err, NC_EBADTYPE)

--- a/src/drivers/ncmpio/ncmpio_dim.c
+++ b/src/drivers/ncmpio/ncmpio_dim.c
@@ -166,7 +166,7 @@ ncmpio_dup_NC_dimarray(NC_dimarray *ncap, const NC_dimarray *ref)
 
     /* allocate array of NC_dim objects */
     if (ref->ndefined > 0) {
-        size_t alloc_size = _RNDUP(ref->ndefined, PNC_ARRAY_GROWBY);
+        size_t alloc_size = PNETCDF_RNDUP(ref->ndefined, PNC_ARRAY_GROWBY);
         ncap->value = (NC_dim**) NCI_Calloc(alloc_size, sizeof(NC_dim*));
         if (ncap->value == NULL) DEBUG_RETURN_ERROR(NC_ENOMEM)
     }

--- a/src/drivers/ncmpio/ncmpio_driver.h
+++ b/src/drivers/ncmpio/ncmpio_driver.h
@@ -4,8 +4,8 @@
  */
 /* $Id$ */
 
-#ifndef _NCMPIO_DRIVER_H
-#define _NCMPIO_DRIVER_H
+#ifndef H_NCMPIO_DRIVER
+#define H_NCMPIO_DRIVER
 
 #include <mpi.h>
 #include <pnetcdf.h>

--- a/src/drivers/ncmpio/ncmpio_enddef.c
+++ b/src/drivers/ncmpio/ncmpio_enddef.c
@@ -525,7 +525,7 @@ write_NC(NC *ncp)
     header_wlen = ncp->xsz;
 #endif
 
-    header_wlen = _RNDUP(header_wlen, X_ALIGN);
+    header_wlen = PNETCDF_RNDUP(header_wlen, X_ALIGN);
 
     /* if header_wlen is > NC_MAX_INT, then write the header in chunks.
      * Note reading file header is already done in chunks. See

--- a/src/drivers/ncmpio/ncmpio_fill.c
+++ b/src/drivers/ncmpio/ncmpio_fill.c
@@ -93,7 +93,7 @@ fill_var_buf(const NC_var *varp,
 {
     int i, indx;
 
-    indx = ncmpio_NC_findattr(&varp->attrs, _FillValue);
+    indx = ncmpio_NC_findattr(&varp->attrs, "_FillValue");
     if (indx >= 0) {
         /* User defined fill value */
         NC_attr *attrp = varp->attrs.value[indx];
@@ -280,12 +280,12 @@ fillerup(NC *ncp)
              * explicitly filled by calling ncmpi_fill_var_rec() */
             continue;
 
-        /* check if _FillValue attribute is defined */
-        indx = ncmpio_NC_findattr(&ncp->vars.value[i]->attrs, _FillValue);
+        /* check if attribute _FillValue is defined */
+        indx = ncmpio_NC_findattr(&ncp->vars.value[i]->attrs, "_FillValue");
 
         /* only if filling this variable is requested. Fill mode can be
          * enabled by 2 ways: explictly call to ncmpi_def_var_fill() or put
-         * the attribute named _FillValue */
+         * the attribute named "_FillValue" */
         if (ncp->vars.value[i]->no_fill && indx == -1) continue;
 
         /* collectively fill the entire variable */
@@ -309,8 +309,8 @@ fill_added(NC *ncp, NC *old_ncp)
             /* skip record variables */
             continue;
 
-        /* check if _FillValue attribute is defined */
-        indx = ncmpio_NC_findattr(&ncp->vars.value[varid]->attrs, _FillValue);
+        /* check if attribute _FillValue is defined */
+        indx = ncmpio_NC_findattr(&ncp->vars.value[varid]->attrs, "_FillValue");
 
         /* only if filling this variable is requested */
         if (ncp->vars.value[varid]->no_fill && indx == -1) continue;
@@ -338,8 +338,8 @@ fill_added_recs(NC *ncp, NC *old_ncp)
                 /* skip non-record variables */
                 continue;
 
-            /* check if _FillValue attribute is defined */
-            indx = ncmpio_NC_findattr(&ncp->vars.value[varid]->attrs, _FillValue);
+            /* check if attribute _FillValue is defined */
+            indx = ncmpio_NC_findattr(&ncp->vars.value[varid]->attrs, "_FillValue");
 
             /* only if filling this variable is requested */
             if (ncp->vars.value[varid]->no_fill && indx == -1) continue;
@@ -725,8 +725,8 @@ ncmpio_fill_var_rec(void      *ncdp,
         goto err_check;
     }
 
-    /* check if _FillValue attribute is defined */
-    indx = ncmpio_NC_findattr(&varp->attrs, _FillValue);
+    /* check if attribute _FillValue is defined */
+    indx = ncmpio_NC_findattr(&varp->attrs, "_FillValue");
 
     /* error if the fill mode of this variable is not on */
     if (varp->no_fill && indx == -1) {
@@ -891,7 +891,7 @@ ncmpio_def_var_fill(void       *ncdp,
     if (fill_value != NULL && !varp->no_fill) {
 
         /* create/overwrite attribute _FillValue */
-        err = ncmpio_put_att(ncdp, varid, _FillValue, varp->xtype,
+        err = ncmpio_put_att(ncdp, varid, "_FillValue", varp->xtype,
                              1, fill_value, ncmpii_nc2mpitype(varp->xtype));
         if (err != NC_NOERR) return err;
     }
@@ -911,9 +911,9 @@ ncmpio_inq_var_fill(NC_var *varp,
 
     assert(varp != NULL); /* NC_GLOBAL varid is illegal in this context */
 
-    /* Check if _FillValue is defined for this variable */
+    /* Check if attribute _FillValue is defined for this variable */
     for (i=0; i<ncap->ndefined; i++) {
-        if (strcmp(ncap->value[i]->name, _FillValue) == 0)
+        if (strcmp(ncap->value[i]->name, "_FillValue") == 0)
             break;
     }
     if (i == ncap->ndefined) { /* attribute _FillValue is not set */

--- a/src/drivers/ncmpio/ncmpio_header_get.c
+++ b/src/drivers/ncmpio/ncmpio_header_get.c
@@ -112,7 +112,7 @@ hdr_len_NC_name(const NC_string *ncstrp, int sizeof_NON_NEG)
     assert(ncstrp != NULL);
 
     if (ncstrp->nchars != 0)  /* namestring */
-        sz += _RNDUP(ncstrp->nchars, X_ALIGN);
+        sz += PNETCDF_RNDUP(ncstrp->nchars, X_ALIGN);
 
     return sz;
 }
@@ -133,8 +133,8 @@ hdr_len_NC_dim(const NC_dim *dimp, int sizeof_NON_NEG)
 
     assert(dimp != NULL);
 
-    sz  = sizeof_NON_NEG + _RNDUP(dimp->name_len, X_ALIGN); /* name */
-    sz += sizeof_NON_NEG;                                   /* dim_length */
+    sz  = sizeof_NON_NEG + PNETCDF_RNDUP(dimp->name_len, X_ALIGN); /* name */
+    sz += sizeof_NON_NEG;                                          /* dim_length */
 
     return sz;
 }
@@ -195,10 +195,10 @@ hdr_len_NC_attr(const NC_attr *attrp, int sizeof_NON_NEG)
 
     assert(attrp != NULL);
 
-    sz  = sizeof_NON_NEG + _RNDUP(attrp->name_len, X_ALIGN); /* name */
-    sz += X_SIZEOF_NC_TYPE;                                  /* nc_type */
-    sz += sizeof_NON_NEG;                                    /* nelems */
-    sz += attrp->xsz;                                        /* [values ...] */
+    sz  = sizeof_NON_NEG + PNETCDF_RNDUP(attrp->name_len, X_ALIGN); /* name */
+    sz += X_SIZEOF_NC_TYPE;                                         /* nc_type */
+    sz += sizeof_NON_NEG;                                           /* nelems */
+    sz += attrp->xsz;                                               /* [values ...] */
 
     return sz;
 }
@@ -264,13 +264,13 @@ hdr_len_NC_var(const NC_var *varp,
      * for CDF-2, sizeof_off_t == 8 && sizeof_NON_NEG == 4
      * for CDF-5, sizeof_off_t == 8 && sizeof_NON_NEG == 8
      */
-    sz  = sizeof_NON_NEG + _RNDUP(varp->name_len, X_ALIGN);   /* name */
-    sz += sizeof_NON_NEG;                                     /* nelems */
-    sz += sizeof_NON_NEG * varp->ndims;                       /* [dimid ...] */
-    sz += hdr_len_NC_attrarray(&varp->attrs, sizeof_NON_NEG); /* vatt_list */
-    sz += X_SIZEOF_NC_TYPE;                                   /* nc_type */
-    sz += sizeof_NON_NEG;                                     /* vsize */
-    sz += sizeof_off_t;                                       /* begin */
+    sz  = sizeof_NON_NEG + PNETCDF_RNDUP(varp->name_len, X_ALIGN);   /* name */
+    sz += sizeof_NON_NEG;                                            /* nelems */
+    sz += sizeof_NON_NEG * varp->ndims;                              /* [dimid ...] */
+    sz += hdr_len_NC_attrarray(&varp->attrs, sizeof_NON_NEG);        /* vatt_list */
+    sz += X_SIZEOF_NC_TYPE;                                          /* nc_type */
+    sz += sizeof_NON_NEG;                                            /* vsize */
+    sz += sizeof_off_t;                                              /* begin */
 
     return sz;
 }
@@ -553,9 +553,9 @@ hdr_get_NC_name(bufferinfo *gbp, char **namep, size_t *name_len)
     (*namep)[nchars] = '\0'; /* add terminal character */
 
     /* X_SIZEOF_CHAR is defined as 1 in classical CDF formats
-    padding = _RNDUP(X_SIZEOF_CHAR * nchars, X_ALIGN) - X_SIZEOF_CHAR * nchars;
+    padding = PNETCDF_RNDUP(X_SIZEOF_CHAR * nchars, X_ALIGN) - X_SIZEOF_CHAR * nchars;
     */
-    padding = _RNDUP(nchars, X_ALIGN) - nchars;
+    padding = PNETCDF_RNDUP(nchars, X_ALIGN) - nchars;
 
     bufremain = gbp->chunk - (gbp->pos - gbp->base);
 
@@ -759,7 +759,7 @@ hdr_get_NC_dimarray(bufferinfo *gbp, NC_dimarray *ncap)
         DEBUG_RETURN_ERROR(NC_ENOTNC)
     }
 
-    alloc_size = _RNDUP(ncap->ndefined, PNC_ARRAY_GROWBY);
+    alloc_size = PNETCDF_RNDUP(ncap->ndefined, PNC_ARRAY_GROWBY);
     ncap->value = (NC_dim**) NCI_Calloc(alloc_size, sizeof(NC_dim*));
     if (ncap->value == NULL) DEBUG_RETURN_ERROR(NC_ENOMEM)
 
@@ -1004,7 +1004,7 @@ hdr_get_NC_attrarray(bufferinfo *gbp, NC_attrarray *ncap)
         DEBUG_RETURN_ERROR(NC_ENOTNC)
     }
 
-    alloc_size = _RNDUP(ncap->ndefined, PNC_ARRAY_GROWBY);
+    alloc_size = PNETCDF_RNDUP(ncap->ndefined, PNC_ARRAY_GROWBY);
     ncap->value = (NC_attr**) NCI_Calloc(alloc_size, sizeof(NC_attr*));
     if (ncap->value == NULL) DEBUG_RETURN_ERROR(NC_ENOMEM)
 
@@ -1250,7 +1250,7 @@ hdr_get_NC_vararray(bufferinfo  *gbp,
         DEBUG_RETURN_ERROR(NC_ENOTNC)
     }
 
-    alloc_size = _RNDUP(ncap->ndefined, PNC_ARRAY_GROWBY);
+    alloc_size = PNETCDF_RNDUP(ncap->ndefined, PNC_ARRAY_GROWBY);
     ncap->value = (NC_var**) NCI_Calloc(alloc_size, sizeof(NC_var*));
     if (ncap->value == NULL) DEBUG_RETURN_ERROR(NC_ENOMEM)
 
@@ -1343,7 +1343,7 @@ ncmpio_hdr_get_NC(NC *ncp)
         getbuf.coll_mode = 0;
 
     /* CDF-5's minimum header size is 4 bytes more than CDF-1 and CDF-2's */
-    getbuf.chunk = _RNDUP( MAX(MIN_NC_XSZ+4, ncp->chunk), X_ALIGN );
+    getbuf.chunk = PNETCDF_RNDUP( MAX(MIN_NC_XSZ+4, ncp->chunk), X_ALIGN );
 
     getbuf.base = (char*) NCI_Malloc(getbuf.chunk);
     getbuf.pos  = getbuf.base;

--- a/src/drivers/ncmpio/ncmpio_header_put.c
+++ b/src/drivers/ncmpio/ncmpio_header_put.c
@@ -541,7 +541,7 @@ int ncmpio_write_header(NC *ncp)
     if (ncp->rank == 0) { /* only root writes to file header */
         MPI_Offset offset;
         size_t remain;
-        size_t bufLen = _RNDUP(ncp->xsz, X_ALIGN);
+        size_t bufLen = PNETCDF_RNDUP(ncp->xsz, X_ALIGN);
         char *buf, *buf_ptr;
 
         buf = NCI_Malloc(bufLen); /* header's write buffer */

--- a/src/drivers/ncmpio/ncmpio_subfile.c
+++ b/src/drivers/ncmpio/ncmpio_subfile.c
@@ -799,11 +799,12 @@ ncmpio_subfile_getput_vars(NC               *ncp,
                 NCI_Free(cbuf);
                 DEBUG_RETURN_ERROR(NC_EINTOVERFLOW)
             }
-            else
+            else {
                 mpireturn = MPI_Pack(buf, (int)bufcount, buftype, cbuf, (int)outsize,
                                      &position, MPI_COMM_SELF);
                 if (mpireturn != MPI_SUCCESS)
                     return ncmpii_error_mpi2nc(mpireturn, "MPI_Pack");
+            }
 #endif
         }
     }

--- a/src/drivers/ncmpio/ncmpio_subfile.h
+++ b/src/drivers/ncmpio/ncmpio_subfile.h
@@ -3,8 +3,8 @@
  *  See COPYRIGHT notice in top-level directory.
  */
 /* $Id$ */
-#ifndef _SUBFILE_H
-#define _SUBFILE_H
+#ifndef H_SUBFILE
+#define H_SUBFILE
 
 #include "ncmpio_NC.h"
 
@@ -33,4 +33,4 @@ extern int ncmpio_subfile_getput_vars(NC *ncp, NC_var *varp,
            const MPI_Offset  stride[], void *buf, MPI_Offset bufcount,
            MPI_Datatype buftype, int reqMode);
 
-#endif /* _SUBFILE_H */
+#endif /* H_SUBFILE */

--- a/src/drivers/ncmpio/ncmpio_var.c
+++ b/src/drivers/ncmpio/ncmpio_var.c
@@ -174,7 +174,7 @@ ncmpio_dup_NC_vararray(NC_vararray       *ncap,
         return NC_NOERR;
     }
 
-    alloc_size = _RNDUP(ref->ndefined, PNC_ARRAY_GROWBY);
+    alloc_size = PNETCDF_RNDUP(ref->ndefined, PNC_ARRAY_GROWBY);
     ncap->value = (NC_var **) NCI_Calloc(alloc_size, sizeof(NC_var*));
     if (ncap->value == NULL) DEBUG_RETURN_ERROR(NC_ENOMEM)
 

--- a/src/include/dispatch.h
+++ b/src/include/dispatch.h
@@ -4,8 +4,8 @@
  */
 /* $Id$ */
 
-#ifndef _PNC_DISPATCH_H
-#define _PNC_DISPATCH_H
+#ifndef H_PNC_DISPATCH
+#define H_PNC_DISPATCH
 
 #include <pnetcdf.h>
 #include <mpi.h>
@@ -155,4 +155,4 @@ extern PNC_driver* ncbbio_inq_driver(void);
 
 extern int PNC_check_id(int ncid, PNC **pncp);
 
-#endif /* _PNC_DISPATCH_H */
+#endif /* H_PNC_DISPATCH */

--- a/src/include/pnc_debug.h
+++ b/src/include/pnc_debug.h
@@ -4,8 +4,8 @@
  */
 /* $Id$ */
 
-#ifndef _PNC_DEBUG_H
-#define _PNC_DEBUG_H
+#ifndef H_PNC_DEBUG
+#define H_PNC_DEBUG
 
 #include <stdio.h>
 
@@ -75,4 +75,4 @@
 #define DEBUG_TRACE_ERROR(err)
 #endif
 
-#endif /* _PNC_DEBUG_H */
+#endif /* H_PNC_DEBUG */

--- a/src/include/pnetcdf.h.in
+++ b/src/include/pnetcdf.h.in
@@ -144,7 +144,7 @@ typedef int nc_type;
  * the same type as the variable and this reserved name. The value you
  * give the attribute will be used as the fill value for that
  * variable. */
-#define _FillValue      "_FillValue"
+#define NC_FillValue    "_FillValue"
 #define NC_FILL         0       /**< Argument to nc_set_fill() to clear NC_NOFILL */
 #define NC_NOFILL       0x100   /**< Argument to nc_set_fill() to turn off filling of data. */
 

--- a/src/include/pnetcdf.h.in
+++ b/src/include/pnetcdf.h.in
@@ -7,8 +7,8 @@
  * @configure_input@
  */
 
-#ifndef _PNETCDF_H
-#define _PNETCDF_H
+#ifndef H_PNETCDF
+#define H_PNETCDF
 
 #include <mpi.h>
 

--- a/src/utils/ncmpidump/ncmpidump.c
+++ b/src/utils/ncmpidump/ncmpidump.c
@@ -538,18 +538,18 @@ do_ncdump(const char *path, struct fspec* specp)
 
                     var.has_fillval = 1; /* by default, but turn off for bytes */
 
-                    /* get _FillValue attribute */
-                    ncmpi_status = ncmpi_inq_att(ncid, varid, _FillValue,
+                    /* get attribute _FillValue */
+                    ncmpi_status = ncmpi_inq_att(ncid, varid, "_FillValue",
                                                  &att.type, &att.len);
                     if (ncmpi_status == NC_NOERR &&
                         att.type == var.type && att.len == 1) {
                         if (var.type == NC_CHAR) {
                             char fillc;
-                            NC_CHECK(ncmpi_get_att_text(ncid, varid, _FillValue,
+                            NC_CHECK(ncmpi_get_att_text(ncid, varid, "_FillValue",
                                                         &fillc));
                             var.fillval = fillc;
                         } else
-                            NC_CHECK(ncmpi_get_att_double(ncid, varid, _FillValue,
+                            NC_CHECK(ncmpi_get_att_double(ncid, varid, "_FillValue",
                                                           &var.fillval));
                     } else {
                         switch (var.type) {

--- a/src/utils/ncmpigen/ncmpigen.y
+++ b/src/utils/ncmpigen/ncmpigen.y
@@ -1221,13 +1221,13 @@ void equalatt(void)
     /* shrink space down to what was really needed */
     att_space = erealloc(att_space, valnum*nctypesize(valtype));
     atts[natts].val = att_space;
-    if (STREQ(atts[natts].name, _FillValue) &&
+    if (STREQ(atts[natts].name, "_FillValue") &&
         atts[natts].var != NC_GLOBAL) {
         nc_putfill(atts[natts].type,atts[natts].val,
                    &vars[atts[natts].var].fill_value);
         if(atts[natts].type != vars[atts[natts].var].type) {
             derror("variable %s: %s type mismatch",
-                   vars[atts[natts].var].name, _FillValue);
+                   vars[atts[natts].var].name, "_FillValue");
         }
     }
     natts++;

--- a/src/utils/ncmpigen/ncmpigentab.c
+++ b/src/utils/ncmpigen/ncmpigentab.c
@@ -483,13 +483,13 @@ void equalatt(void)
     /* shrink space down to what was really needed */
     att_space = erealloc(att_space, valnum*nctypesize(valtype));
     atts[natts].val = att_space;
-    if (STREQ(atts[natts].name, _FillValue) &&
+    if (STREQ(atts[natts].name, "_FillValue") &&
         atts[natts].var != NC_GLOBAL) {
         nc_putfill(atts[natts].type,atts[natts].val,
                    &vars[atts[natts].var].fill_value);
         if(atts[natts].type != vars[atts[natts].var].type) {
             derror("variable %s: %s type mismatch",
-                   vars[atts[natts].var].name, _FillValue);
+                   vars[atts[natts].var].name, "_FillValue");
         }
     }
     natts++;

--- a/src/utils/ncoffsets/ncoffsets.c
+++ b/src/utils/ncoffsets/ncoffsets.c
@@ -102,17 +102,17 @@ typedef enum {
 #define X_ALIGN                 4
 
 /* useful for aligning memory */
-#define _RNDUP(x, unit)  ((((x) + (unit) - 1) / (unit)) * (unit))
+#define PNETCDF_RNDUP(x, unit)  ((((x) + (unit) - 1) / (unit)) * (unit))
 #define M_RND_UNIT       X_SIZEOF_DOUBLE
-#define M_RNDUP(x)       _RNDUP(x, M_RND_UNIT)
+#define M_RNDUP(x)       PNETCDF_RNDUP(x, M_RND_UNIT)
 
-#define ncmpix_len_char(nelems)   _RNDUP((nelems), X_ALIGN)
+#define ncmpix_len_char(nelems)   PNETCDF_RNDUP((nelems), X_ALIGN)
 #define ncmpix_len_short(nelems)  (((nelems) + (nelems)%2)  * X_SIZEOF_SHORT)
 #define ncmpix_len_int(nelems)    ((nelems) * X_SIZEOF_INT)
 #define ncmpix_len_long(nelems)   ((nelems) * X_SIZEOF_LONG)
 #define ncmpix_len_float(nelems)  ((nelems) * X_SIZEOF_FLOAT)
 #define ncmpix_len_double(nelems) ((nelems) * X_SIZEOF_DOUBLE)
-#define ncmpix_len_ubyte(nelems)  _RNDUP((nelems), X_ALIGN)
+#define ncmpix_len_ubyte(nelems)  PNETCDF_RNDUP((nelems), X_ALIGN)
 #define ncmpix_len_ushort(nelems) (((nelems) + (nelems)%2)  * X_SIZEOF_USHORT)
 #define ncmpix_len_uint(nelems)   ((nelems) * X_SIZEOF_UINT)
 #define ncmpix_len_int64(nelems)  ((nelems) * X_SIZEOF_INT64)
@@ -534,7 +534,7 @@ hdr_len_NC_name(const NC_string *ncstrp,
     assert(ncstrp != NULL);
 
     if (ncstrp->nchars != 0)  /* namestring */
-        sz += _RNDUP(ncstrp->nchars, X_ALIGN);
+        sz += PNETCDF_RNDUP(ncstrp->nchars, X_ALIGN);
 
     return sz;
 }
@@ -919,7 +919,7 @@ hdr_get_NC_name(bufferinfo  *gbp,
     ncstrp = ncmpii_new_NC_string(nchars, NULL);
 
     nbytes = nchars;
-    padding = _RNDUP(ncstrp->nchars, X_ALIGN) - ncstrp->nchars;
+    padding = PNETCDF_RNDUP(ncstrp->nchars, X_ALIGN) - ncstrp->nchars;
     bufremain = gbp->size - ((char*)gbp->pos - (char*)gbp->base);
     cpos = ncstrp->cp;
 

--- a/src/utils/ncvalidator/ncvalidator.c
+++ b/src/utils/ncvalidator/ncvalidator.c
@@ -49,7 +49,7 @@ static const char *off_limit = "https://docs.unidata.ucar.edu/nug/current/file_s
 #endif
 
 /* useful for aligning memory */
-#define _RNDUP(x, unit) ((((x) + (unit) - 1) / (unit)) * (unit))
+#define PNETCDF_RNDUP(x, unit) ((((x) + (unit) - 1) / (unit)) * (unit))
 
 #define ERR_ADDR (((size_t)gbp->pos - (size_t)gbp->base) + (size_t)(gbp->offset - gbp->size))
 
@@ -368,7 +368,7 @@ hdr_len_NC_name(size_t nchars,
     long long sz = sizeof_t; /* nelems */
 
     if (nchars != 0)  /* namestring */
-        sz += _RNDUP(nchars, X_ALIGN);
+        sz += PNETCDF_RNDUP(nchars, X_ALIGN);
 
     return sz;
 }
@@ -1012,7 +1012,7 @@ hdr_get_name(int          fd,
     if (*namep == NULL) DEBUG_RETURN_ERROR(NC_ENOMEM)
     (*namep)[nchars] = '\0'; /* add terminal character */
 
-    padding   = _RNDUP(nchars, X_ALIGN) - nchars;
+    padding   = PNETCDF_RNDUP(nchars, X_ALIGN) - nchars;
     pos_addr  = (size_t) gbp->pos;
     base_addr = (size_t) gbp->base;
     bufremain = gbp->size - (pos_addr - base_addr);
@@ -1347,7 +1347,7 @@ x_len_NC_attrV(nc_type    xtype,
     switch(xtype) {
         case NC_BYTE:
         case NC_CHAR:
-        case NC_UBYTE:  return _RNDUP(nelems, 4);
+        case NC_UBYTE:  return PNETCDF_RNDUP(nelems, 4);
         case NC_SHORT:
         case NC_USHORT: return ((nelems + (nelems)%2) * 2);
         case NC_INT:    return (nelems * 4);

--- a/test/nc_test/t_nc.c
+++ b/test/nc_test/t_nc.c
@@ -151,7 +151,7 @@ static const char * const reqattr[] = {
 	"SCALEMIN",
 	"SCALEMAX",
 	"FIELDNAM",
-	_FillValue
+	"_FillValue"
 };
 #define NUM_RATTRS	6
 
@@ -359,8 +359,8 @@ int t_nc(char *filename, int cmode)
 
  	{
  	int ifill = -1; double dfill = -9999;
- 	err = ncmpi_put_att_int(id, Long_id, _FillValue, NC_INT, 1, &ifill); ERR
- 	err = ncmpi_put_att_double(id, Double_id, _FillValue, NC_DOUBLE, 1, &dfill); ERR
+ 	err = ncmpi_put_att_int(id, Long_id, "_FillValue", NC_INT, 1, &ifill); ERR
+ 	err = ncmpi_put_att_double(id, Double_id, "_FillValue", NC_DOUBLE, 1, &dfill); ERR
  	}
 
 #ifdef REDEF

--- a/test/testcases/tst_info.c
+++ b/test/testcases/tst_info.c
@@ -33,7 +33,7 @@
 
 #include <testutils.h>
 
-#define _RNDUP(x, unit) ((((x) + (unit) - 1) / (unit)) * (unit))
+#define PNETCDF_RNDUP(x, unit) ((((x) + (unit) - 1) / (unit)) * (unit))
 
 #define CHECK_HINT(hint) { \
     MPI_Info_get(info_used, hint, len, value, &flag); \
@@ -156,7 +156,7 @@ int main(int argc, char** argv) {
     MPI_Info_get_valuelen(info_used, "nc_header_align_size", &len, &flag);
     if (flag) {
         MPI_Info_get(info_used, "nc_header_align_size", len+1, value, &flag);
-        expect = _RNDUP(1, 4);
+        expect = PNETCDF_RNDUP(1, 4);
         if (expect != strtoll(value,NULL,10)) {
             printf("Error: nc_header_align_size expect %lld but got %lld\n",
                     expect, strtoll(value,NULL,10));
@@ -170,7 +170,7 @@ int main(int argc, char** argv) {
     MPI_Info_get_valuelen(info_used, "nc_var_align_size", &len, &flag);
     if (flag) {
         MPI_Info_get(info_used, "nc_var_align_size", len+1, value, &flag);
-        expect = _RNDUP(197, 4);
+        expect = PNETCDF_RNDUP(197, 4);
         if (expect != strtoll(value,NULL,10)) {
             printf("Error: nc_var_align_size expect %lld but got %lld\n",
                    expect, strtoll(value,NULL,10));


### PR DESCRIPTION
C99: All identifiers that begin with an underscore and either an
           uppercase letter or another underscore are always reserved for any use.

* Replace C macro _FillValue with NC_FillValue to conform with NetCDF4's
   header, netcdf.hs, changed in 4.9.3.
   See https://github.com/Unidata/netcdf-c/pull/2911
