### PR TITLE
fix install path when DESTDIR is used in make install command line

### DIFF
--- a/.github/workflows/mac_mpich.yml
+++ b/.github/workflows/mac_mpich.yml
@@ -98,6 +98,18 @@ jobs:
           run: |
             cd ${GITHUB_WORKSPACE}
             make -j 8 distcheck DISTCHECK_CONFIGURE_FLAGS="--silent --with-mpi=${GITHUB_WORKSPACE}/MPICH"
+        - name: make install
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            prefix_path=${GITHUB_WORKSPACE}/pnetcdf_install
+            echo "---- test make install prefix=${prefix_path}"
+            make install prefix=${prefix_path}
+            test/tst_install.sh ${prefix_path}
+            prefix_path=pnetcdf_install
+            destdir_path=${GITHUB_WORKSPACE}/inst/
+            echo "---- test make install prefix=${prefix_path} DESTDIR=${destdir_path}"
+            make install prefix=${prefix_path} DESTDIR=${destdir_path}
+            test/tst_install.sh ${destdir_path}${prefix_path}
         - name: Cleanup
           if: ${{ always() }}
           run: |
@@ -105,4 +117,6 @@ jobs:
             make -s distclean
             rm -rf ${GITHUB_WORKSPACE}/pnetcdf_output
             rm -rf ${GITHUB_WORKSPACE}/MPICH
+            rm -rf ${GITHUB_WORKSPACE}/pnetcdf_install
+            rm -rf ${GITHUB_WORKSPACE}/inst
 

--- a/.github/workflows/mac_openmpi.yml
+++ b/.github/workflows/mac_openmpi.yml
@@ -101,6 +101,18 @@ jobs:
           run: |
             cd ${GITHUB_WORKSPACE}
             make -j 8 distcheck DISTCHECK_CONFIGURE_FLAGS="--silent --with-mpi=${GITHUB_WORKSPACE}/OPENMPI"
+        - name: make install
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            prefix_path=${GITHUB_WORKSPACE}/pnetcdf_install
+            echo "---- test make install prefix=${prefix_path}"
+            make install prefix=${prefix_path}
+            test/tst_install.sh ${prefix_path}
+            prefix_path=pnetcdf_install
+            destdir_path=${GITHUB_WORKSPACE}/inst/
+            echo "---- test make install prefix=${prefix_path} DESTDIR=${destdir_path}"
+            make install prefix=${prefix_path} DESTDIR=${destdir_path}
+            test/tst_install.sh ${destdir_path}${prefix_path}
         - name: Cleanup
           if: ${{ always() }}
           run: |
@@ -108,4 +120,6 @@ jobs:
             make -s distclean
             rm -rf ${GITHUB_WORKSPACE}/pnetcdf_output
             rm -rf ${GITHUB_WORKSPACE}/OPENMPI
+            rm -rf ${GITHUB_WORKSPACE}/pnetcdf_install
+            rm -rf ${GITHUB_WORKSPACE}/inst
 

--- a/.github/workflows/ubuntu_mpich.yml
+++ b/.github/workflows/ubuntu_mpich.yml
@@ -110,10 +110,25 @@ jobs:
           run: |
             cd ${GITHUB_WORKSPACE}
             make -j 8 distcheck DISTCHECK_CONFIGURE_FLAGS="--silent --with-mpi=${GITHUB_WORKSPACE}/MPICH"
+        - name: make install
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            prefix_path=${GITHUB_WORKSPACE}/pnetcdf_install
+            echo "---- test make install prefix=${prefix_path}"
+            make install prefix=${prefix_path}
+            test/tst_install.sh ${prefix_path}
+            prefix_path=pnetcdf_install
+            destdir_path=${GITHUB_WORKSPACE}/inst/
+            echo "---- test make install prefix=${prefix_path} DESTDIR=${destdir_path}"
+            make install prefix=${prefix_path} DESTDIR=${destdir_path}
+            test/tst_install.sh ${destdir_path}${prefix_path}
         - name: Cleanup
           if: ${{ always() }}
           run: |
             cd ${GITHUB_WORKSPACE}
             make -s distclean
+            rm -rf ${GITHUB_WORKSPACE}/pnetcdf_output
             rm -rf ${GITHUB_WORKSPACE}/MPICH
+            rm -rf ${GITHUB_WORKSPACE}/pnetcdf_install
+            rm -rf ${GITHUB_WORKSPACE}/inst
 

--- a/.github/workflows/ubuntu_openmpi.yml
+++ b/.github/workflows/ubuntu_openmpi.yml
@@ -107,6 +107,18 @@ jobs:
           run: |
             cd ${GITHUB_WORKSPACE}
             make -j 8 distcheck DISTCHECK_CONFIGURE_FLAGS="--silent --with-mpi=${GITHUB_WORKSPACE}/OPENMPI"
+        - name: make install
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            prefix_path=${GITHUB_WORKSPACE}/pnetcdf_install
+            echo "---- test make install prefix=${prefix_path}"
+            make install prefix=${prefix_path}
+            test/tst_install.sh ${prefix_path}
+            prefix_path=pnetcdf_install
+            destdir_path=${GITHUB_WORKSPACE}/inst/
+            echo "---- test make install prefix=${prefix_path} DESTDIR=${destdir_path}"
+            make install prefix=${prefix_path} DESTDIR=${destdir_path}
+            test/tst_install.sh ${destdir_path}${prefix_path}
         - name: Cleanup
           if: ${{ always() }}
           run: |
@@ -114,4 +126,6 @@ jobs:
             make -s distclean
             rm -rf ${GITHUB_WORKSPACE}/pnetcdf_output
             rm -rf ${GITHUB_WORKSPACE}/OPENMPI
+            rm -rf ${GITHUB_WORKSPACE}/pnetcdf_install
+            rm -rf ${GITHUB_WORKSPACE}/inst
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -61,6 +61,14 @@ check-local:
 	@echo '|  All sequential test programs have run successfully.'
 	@echo '|'
 
+# Note on DESTDIR. GNU autoconf manual Section 16.4 Installation Names has the
+# following statement. "The second method involves providing the 'DESTDIR'
+# variable. For example, 'make install DESTDIR=/alternate/directory' will
+# prepend '/alternate/directory' before all installation names. The approach of
+# 'DESTDIR' overrides is not required by the GNU Coding Standards, and does not
+# work on platforms that have drive letters. On the other hand, it does better
+# at avoiding recompilation issues, and works well even when some directory
+# options were not specified in terms of '${prefix}' at configure time."
 install-data-hook:
 	@echo '+----------------------------------------------------------------------------+'
 	@echo '|'

--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,11 @@ echo '' >& AS_MESSAGE_LOG_FD
 
 dnl Note getting command line should be done before calling AM_INIT_AUTOMAKE
 dnl as AM_INIT_AUTOMAKE modifies command line $*
-CONFIGURE_ARGS_CLEAN=`echo $* | tr '"' ' '`
+if test "x$ac_configure_args_raw" = x ; then
+   CONFIGURE_ARGS_CLEAN=`echo $* | tr '"' ' '`
+else
+   CONFIGURE_ARGS_CLEAN=$ac_configure_args_raw
+fi
 
 dnl automake version 1.16.5 was released in 2021-10-03
 dnl AM_INIT_AUTOMAKE([subdir-objects])

--- a/examples/C/Makefile.am
+++ b/examples/C/Makefile.am
@@ -43,7 +43,7 @@ check_PROGRAMS = collective_write \
 
 if INSTALL_EXAMPLES
    example_execbin_PROGRAMS = $(check_PROGRAMS)
-   example_execbindir = $(exec_prefix)/pnetcdf_examples/C
+   example_execbindir = $(DESTDIR)$(exec_prefix)/pnetcdf_examples/C
    example_execbin_SCRIPTS = run_c_examples.sh
 endif
 

--- a/examples/CXX/Makefile.am
+++ b/examples/CXX/Makefile.am
@@ -32,7 +32,7 @@ check_PROGRAMS = collective_write \
 
 if INSTALL_EXAMPLES
    example_execbin_PROGRAMS = $(check_PROGRAMS)
-   example_execbindir = $(exec_prefix)/pnetcdf_examples/CXX
+   example_execbindir = $(DESTDIR)$(exec_prefix)/pnetcdf_examples/CXX
    example_execbin_SCRIPTS = run_cxx_examples.sh
 endif
 

--- a/examples/F77/Makefile.am
+++ b/examples/F77/Makefile.am
@@ -52,7 +52,7 @@ check_PROGRAMS = nonblocking_write \
 
 if INSTALL_EXAMPLES
    example_execbin_PROGRAMS = $(check_PROGRAMS)
-   example_execbindir = $(exec_prefix)/pnetcdf_examples/F77
+   example_execbindir = $(DESTDIR)$(exec_prefix)/pnetcdf_examples/F77
    example_execbin_SCRIPTS = run_f77_examples.sh
 endif
 

--- a/examples/F90/Makefile.am
+++ b/examples/F90/Makefile.am
@@ -41,7 +41,7 @@ check_PROGRAMS = nonblocking_write \
 
 if INSTALL_EXAMPLES
    example_execbin_PROGRAMS = $(check_PROGRAMS)
-   example_execbindir = $(exec_prefix)/pnetcdf_examples/F90
+   example_execbindir = $(DESTDIR)$(exec_prefix)/pnetcdf_examples/F90
    example_execbin_SCRIPTS = run_f90_examples.sh
 endif
 

--- a/src/packaging/Makefile.am
+++ b/src/packaging/Makefile.am
@@ -9,7 +9,9 @@
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = pnetcdf.pc
 
+# GNU autoconf allows DESTDIR variable when running 'make install' which will
+# prepend it before all installation names.
 install-data-hook:
-	$(SED_I) -e 's|INSTALL_PREFIX|$(prefix)|g ; s|INSTALL_EXEC_PREFIX|$(exec_prefix)|g' $(DESTDIR)$(libdir)/pkgconfig/pnetcdf.pc
+	$(SED_I) -e 's|INSTALL_PREFIX|$(DESTDIR)$(prefix)|g ; s|INSTALL_EXEC_PREFIX|$(DESTDIR)$(exec_prefix)|g' $(DESTDIR)$(libdir)/pkgconfig/pnetcdf.pc
 
 

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -33,7 +33,9 @@ distclean-local:
 dist-hook:
 	$(SED_I) -e "s|PNETCDF_RELEASE_DATE|@PNETCDF_RELEASE_DATE@|g" $(distdir)/pnetcdf-config.in
 
+# GNU autoconf allows DESTDIR variable when running 'make install' which will
+# prepend it before all installation names.
 install-exec-hook:
-	$(SED_I) -e 's|INSTALL_PREFIX|$(prefix)|g ; s|INSTALL_EXEC_PREFIX|$(exec_prefix)|g' $(DESTDIR)$(bindir)/pnetcdf-config
+	$(SED_I) -e 's|INSTALL_PREFIX|$(DESTDIR)$(prefix)|g ; s|INSTALL_EXEC_PREFIX|$(DESTDIR)$(exec_prefix)|g' $(DESTDIR)$(bindir)/pnetcdf-config
 	chmod +x $(DESTDIR)$(bindir)/pnetcdf-config
 

--- a/test/tst_install.sh
+++ b/test/tst_install.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+#
+# Copyright (C) 2024, Northwestern University and Argonne National Laboratory
+# See COPYRIGHT notice in top-level directory.
+#
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# This requires one command-line option, the installation path
+if [ "x$1" = x ] ; then
+   echo "Usage: $0 /pnetcdf/install/path"
+   exit 1
+fi
+
+installation_path=$1
+
+# check if folder installation_path exists
+if [ ! -d $installation_path ]; then
+    echo "Error: folder $installation_path cannot be found"
+    exit 1
+fi
+
+# remove trailing '/' character
+# Note on Mac OSX, realpath does not support option -s
+# Ideally, -s should be used to avoid expanding a symlink
+installation_path=$(realpath $installation_path)
+
+# check if pnetcdf_version exists in the install folder
+if [ ! -x $installation_path/bin/pnetcdf_version ]; then
+    echo "Error: pnetcdf_version not found in $installation_path/bin"
+    exit 1
+fi
+
+# check if pnetcdf.pc exists in the install folder
+if [ ! -f $installation_path/lib/pkgconfig/pnetcdf.pc ]; then
+    echo "Error: pnetcdf.pc not found in $installation_path/lib/pkgconfig"
+    exit 1
+fi
+
+# check if pnetcdf-config exists in the install folder
+if [ ! -x $installation_path/bin/pnetcdf-config ]; then
+    echo "Error: pnetcdf-config not found in $installation_path/bin"
+    exit 1
+else
+   # check if --prefix is correctly reflecting the install path
+   prefixdir=`$installation_path/bin/pnetcdf-config --prefix`
+   if [ $prefixdir != $installation_path ] ; then
+       echo "Error: expecting '$installation_path' from 'pnetcdf-config --prefix' but got $prefixdir"
+       exit 1
+   fi
+   # check if --libdir is correctly reflecting the install path
+   libdir=`$installation_path/bin/pnetcdf-config --libdir`
+   if [ $libdir != $installation_path/lib ] ; then
+       echo "Error: expecting '$installation_path/lib' from 'pnetcdf-config --libdir' but got $libdir"
+       exit 1
+   fi
+   # check if --includedir is correctly reflecting the install path
+   incdir=`$installation_path/bin/pnetcdf-config --includedir`
+   if [ $incdir != $installation_path/include ] ; then
+       echo "Error: expecting '$installation_path/include' from 'pnetcdf-config --includedir' but got $incdir"
+       exit 1
+   fi
+fi
+


### PR DESCRIPTION
Note on DESTDIR. GNU autoconf manual Section 16.4 Installation Names has the
following statement. "The second method involves providing the 'DESTDIR'
variable. For example, 'make install DESTDIR=/alternate/directory' will
prepend '/alternate/directory' before all installation names. The approach of
'DESTDIR' overrides is not required by the GNU Coding Standards, and does not
work on platforms that have drive letters. On the other hand, it does better
at avoiding recompilation issues, and works well even when some directory
options were not specified in terms of '${prefix}' at configure time."
