### PR TITLE
clarify and implement the precedences of I/O hints

### DIFF
--- a/benchmarks/C/aggregation.c
+++ b/benchmarks/C/aggregation.c
@@ -172,10 +172,9 @@ int benchmark_write(char       *filename,
 
     /* set PnetCDF I/O hints */
     MPI_Info_create(&info);
-    /* disable the header extent alignments
-    MPI_Info_set(info, "nc_header_align_size", "1");    size in bytes
-    */
-    /* disable the fixed-size variable alignments */
+    /* disable the fixed-size variable alignments, which also
+     * disable the header extent alignments
+     */
     MPI_Info_set(info, "nc_var_align_size", "1");
 
     nvars = 0;

--- a/benchmarks/C/write_block_read_column.c
+++ b/benchmarks/C/write_block_read_column.c
@@ -84,7 +84,6 @@ int benchmark_write(char       *filename,
 
     /* set PnetCDF I/O hints */
     MPI_Info_create(&info);
-    MPI_Info_set(info, "nc_header_align_size",      "1");   /* size in bytes */
     MPI_Info_set(info, "nc_var_align_size",         "1");   /* size in bytes */
     MPI_Info_set(info, "nc_header_read_chunk_size", "512"); /* size in bytes */
     /* note that set the above values to 1 to disable the alignment */

--- a/examples/C/get_info.c
+++ b/examples/C/get_info.c
@@ -15,7 +15,7 @@
  *
  *    Example standard output:
 
-    MPI File Info: nkeys = 35
+    MPI File Info: nkeys = 34
     MPI File Info: [ 0] key =            cb_buffer_size, value = 16777216
     MPI File Info: [ 1] key =             romio_cb_read, value = automatic
     MPI File Info: [ 2] key =            romio_cb_write, value = automatic
@@ -39,18 +39,17 @@
     MPI File Info: [20] key =             striping_unit, value = 0
     MPI File Info: [21] key =           striping_factor, value = 0
     MPI File Info: [22] key =            start_iodevice, value = 0
-    MPI File Info: [23] key =      nc_header_align_size, value = 512
-    MPI File Info: [24] key =         nc_var_align_size, value = 4
-    MPI File Info: [25] key =      nc_record_align_size, value = 4
-    MPI File Info: [26] key = nc_header_read_chunk_size, value = 262144
-    MPI File Info: [27] key =          nc_in_place_swap, value = auto
-    MPI File Info: [28] key =              nc_ibuf_size, value = 16777216
-    MPI File Info: [29] key =         pnetcdf_subfiling, value = disable
-    MPI File Info: [30] key =           nc_num_subfiles, value = 0
-    MPI File Info: [31] key =          nc_hash_size_dim, value = 256
-    MPI File Info: [32] key =          nc_hash_size_var, value = 256
-    MPI File Info: [33] key =        nc_hash_size_gattr, value = 64
-    MPI File Info: [34] key =        nc_hash_size_vattr, value = 8
+    MPI File Info: [23] key =         nc_var_align_size, value = 4
+    MPI File Info: [24] key =      nc_record_align_size, value = 4
+    MPI File Info: [25] key = nc_header_read_chunk_size, value = 262144
+    MPI File Info: [26] key =          nc_in_place_swap, value = auto
+    MPI File Info: [27] key =              nc_ibuf_size, value = 16777216
+    MPI File Info: [28] key =         pnetcdf_subfiling, value = disable
+    MPI File Info: [29] key =           nc_num_subfiles, value = 0
+    MPI File Info: [30] key =          nc_hash_size_dim, value = 256
+    MPI File Info: [31] key =          nc_hash_size_var, value = 256
+    MPI File Info: [32] key =        nc_hash_size_gattr, value = 64
+    MPI File Info: [33] key =        nc_hash_size_vattr, value = 8
  */
 
 #include <stdio.h>

--- a/examples/C/hints.c
+++ b/examples/C/hints.c
@@ -7,8 +7,8 @@
 /* $Id$ */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- * This example sets two PnetCDF hints:
- *    nc_header_align_size and nc_var_align_size
+ * This example sets PnetCDF hint:
+ *    nc_var_align_size
  * and prints the hint values as well as the header size, header extent, and
  * two variables' starting file offsets.
  *
@@ -18,7 +18,6 @@
  *
  *    % mpiexec -l -n 4 ./hints /pvfs2/wkliao/testfile.nc
  *
- *    nc_header_align_size      set to = 1024
  *    nc_var_align_size         set to = 512
  *    nc_header_read_chunk_size set to = 256
  *    header size                      = 252
@@ -94,7 +93,7 @@ int print_hints(int ncid,
     char value[MPI_MAX_INFO_VAL];
     int err, len, flag, nerrs=0;
     MPI_Offset header_size, header_extent, var_zy_start, var_yx_start;
-    MPI_Offset h_align=-1, v_align=-1, h_chunk=-1;
+    MPI_Offset v_align=-1, h_chunk=-1;
     MPI_Info info_used;
 
     err = ncmpi_inq_header_size  (ncid, &header_size);      ERR
@@ -103,12 +102,7 @@ int print_hints(int ncid,
     err = ncmpi_inq_varoffset(ncid, varid1, &var_yx_start); ERR
 
     err = ncmpi_inq_file_info(ncid, &info_used); ERR
-    MPI_Info_get_valuelen(info_used, "nc_header_align_size", &len, &flag);
-    if (flag) {
-        MPI_Info_get(info_used, "nc_header_align_size", len+1, value, &flag);
-        h_align = strtoll(value,NULL,10);
-    }
-        MPI_Info_get_valuelen(info_used, "nc_var_align_size", &len, &flag);
+    MPI_Info_get_valuelen(info_used, "nc_var_align_size", &len, &flag);
     if (flag) {
         MPI_Info_get(info_used, "nc_var_align_size", len+1, value, &flag);
         v_align = strtoll(value,NULL,10);
@@ -119,11 +113,6 @@ int print_hints(int ncid,
         h_chunk = strtoll(value,NULL,10);
     }
     MPI_Info_free(&info_used);
-
-    if (h_align == -1)
-        printf("nc_header_align_size      is NOT set\n");
-    else
-        printf("nc_header_align_size      set to = %lld\n", h_align);
 
     if (v_align == -1)
         printf("nc_var_align_size         is NOT set\n");
@@ -171,7 +160,6 @@ int main(int argc, char** argv)
     else                      snprintf(filename, 256, "%s", argv[optind]);
 
     MPI_Info_create(&info);
-    MPI_Info_set(info, "nc_header_align_size",      "1024"); /* size in bytes */
     MPI_Info_set(info, "nc_var_align_size",         "512");  /* size in bytes */
     MPI_Info_set(info, "nc_header_read_chunk_size", "256");  /* size in bytes */
     /* note that set the above values to 1 to disable the alignment */

--- a/examples/CXX/get_info.cpp
+++ b/examples/CXX/get_info.cpp
@@ -15,7 +15,7 @@
  *
  *    Example standard output:
 
-    MPI File Info: nkeys = 18
+    MPI File Info: nkeys = 17
     MPI File Info: [ 0] key =            cb_buffer_size, value = 16777216
     MPI File Info: [ 1] key =             romio_cb_read, value = automatic
     MPI File Info: [ 2] key =            romio_cb_write, value = automatic
@@ -31,9 +31,8 @@
     MPI File Info: [12] key =             romio_ds_read, value = automatic
     MPI File Info: [13] key =            romio_ds_write, value = automatic
     MPI File Info: [14] key =            cb_config_list, value = *:1
-    MPI File Info: [15] key =      nc_header_align_size, value = 512
-    MPI File Info: [16] key =         nc_var_align_size, value = 512
-    MPI File Info: [17] key = nc_header_read_chunk_size, value = 0
+    MPI File Info: [15] key =         nc_var_align_size, value = 512
+    MPI File Info: [16] key = nc_header_read_chunk_size, value = 0
  */
 
 #include <stdio.h>

--- a/examples/CXX/hints.cpp
+++ b/examples/CXX/hints.cpp
@@ -7,8 +7,8 @@
 /* $Id$ */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- * This example sets two PnetCDF hints:
- *    nc_header_align_size and nc_var_align_size
+ * This example sets PnetCDF hint:
+ *    nc_var_align_size
  * and prints the hint values as well as the header size, header extent, and
  * two variables' starting file offsets.
  *
@@ -18,7 +18,6 @@
  *
  *    % mpiexec -l -n 4 ./hints /pvfs2/wkliao/testfile.nc
  *
- *    nc_header_align_size      set to = 1024
  *    nc_var_align_size         set to = 512
  *    nc_header_read_chunk_size set to = 256
  *    header size                      = 252
@@ -64,7 +63,7 @@ void print_hints(NcmpiFile &ncFile,
     char value[MPI_MAX_INFO_VAL];
     int len, flag;
     MPI_Offset header_size, header_extent, var_zy_start, var_yx_start;
-    MPI_Offset h_align=-1, v_align=-1, h_chunk=-1;
+    MPI_Offset v_align=-1, h_chunk=-1;
     MPI_Info info_used;
 
     ncFile.Inq_header_size(&header_size);
@@ -76,12 +75,7 @@ void print_hints(NcmpiFile &ncFile,
     /* get all the hints used */
     ncFile.Inq_file_info(&info_used);
 
-    MPI_Info_get_valuelen(info_used, (char*)"nc_header_align_size", &len, &flag);
-    if (flag) {
-        MPI_Info_get(info_used, (char*)"nc_header_align_size", len+1, value, &flag);
-        h_align = strtoll(value,NULL,10);
-    }
-        MPI_Info_get_valuelen(info_used, (char*)"nc_var_align_size", &len, &flag);
+    MPI_Info_get_valuelen(info_used, (char*)"nc_var_align_size", &len, &flag);
     if (flag) {
         MPI_Info_get(info_used, (char*)"nc_var_align_size", len+1, value, &flag);
         v_align = strtoll(value,NULL,10);
@@ -92,11 +86,6 @@ void print_hints(NcmpiFile &ncFile,
         h_chunk = strtoll(value,NULL,10);
     }
     MPI_Info_free(&info_used);
-
-    if (h_align == -1)
-        printf("nc_header_align_size      is NOT set\n");
-    else
-        printf("nc_header_align_size      set to = %lld\n", h_align);
 
     if (v_align == -1)
         printf("nc_var_align_size         is NOT set\n");
@@ -141,7 +130,6 @@ int main(int argc, char** argv)
 
     try {
         MPI_Info_create(&info);
-        MPI_Info_set(info, (char*)"nc_header_align_size",      (char*)"1024");
         MPI_Info_set(info, (char*)"nc_var_align_size",         (char*)"512");
         MPI_Info_set(info, (char*)"nc_header_read_chunk_size", (char*)"256");
         /* note that set the above values to 1 to disable the alignment */

--- a/examples/F77/get_info.f
+++ b/examples/F77/get_info.f
@@ -15,7 +15,7 @@
 !
 !    Example standard output:
 !
-!   MPI File Info: nkeys =          18
+!   MPI File Info: nkeys =          17
 !   MPI File Info: [ 0] key =            cb_buffer_size, value =16777216
 !   MPI File Info: [ 1] key =             romio_cb_read, value =automatic
 !   MPI File Info: [ 2] key =            romio_cb_write, value =automatic
@@ -31,9 +31,8 @@
 !   MPI File Info: [12] key =             romio_ds_read, value =automatic
 !   MPI File Info: [13] key =            romio_ds_write, value =automatic
 !   MPI File Info: [14] key =            cb_config_list, value =*:1
-!   MPI File Info: [15] key =      nc_header_align_size, value =0
-!   MPI File Info: [16] key =         nc_var_align_size, value =0
-!   MPI File Info: [17] key = nc_header_read_chunk_size, value =0
+!   MPI File Info: [15] key =         nc_var_align_size, value =0
+!   MPI File Info: [16] key = nc_header_read_chunk_size, value =0
 
 
         program main

--- a/examples/F77/hints.f
+++ b/examples/F77/hints.f
@@ -6,8 +6,8 @@
 ! $Id$
 
 !
-! This example sets two PnetCDF hints:
-!    nc_header_align_size and nc_var_align_size
+! This example sets PnetCDF hint:
+!    nc_var_align_size
 ! and prints the hint values as well as the header size, header extent, and
 ! two variables' starting file offsets.
 !
@@ -17,7 +17,6 @@
 !
 !    % mpiexec -n 4 ./hints /pvfs2/wkliao/testfile.nc
 !
-!    nc_header_align_size      set to = 1024
 !    nc_var_align_size         set to = 512
 !    nc_header_read_chunk_size set to = 256
 !    header size                      = 252
@@ -54,9 +53,8 @@
           logical flag
           integer*8 header_size, header_extent
           integer*8 var_zy_start, var_yx_start
-          integer*8 h_align, v_align, h_chunk
+          integer*8 v_align, h_chunk
 
-          h_align=-1
           v_align=-1
           h_chunk=-1
 
@@ -72,13 +70,6 @@
           err = nfmpi_inq_file_info(ncid, info_used)
           call check(err, 'In nfmpi_inq_file_info : ')
 
-          call MPI_Info_get_valuelen(info_used, "nc_header_align_size",
-     +                               len, flag, err)
-          if (flag) then
-              call MPI_Info_get(info_used, "nc_header_align_size",
-     +                          len+1, value, flag, err)
-              read(value, '(i16)') h_align
-          endif
           call MPI_Info_get_valuelen(info_used, "nc_var_align_size",
      +                               len, flag, err)
           if (flag) then
@@ -96,11 +87,6 @@
           endif
           call MPI_Info_free(info_used, err)
 
-          if (h_align .EQ. -1) then
-              print*,"nc_header_align_size      is NOT set"
-          else
-              print*,"nc_header_align_size      set to = ", h_align
-          endif
           if (v_align .EQ. -1) then
               print*,"nc_var_align_size         is NOT set"
           else
@@ -178,7 +164,6 @@
      +               MPI_COMM_WORLD, err)
 
       call MPI_Info_create(info, err)
-      call MPI_Info_set(info, "nc_header_align_size",      "1024", err)
       call MPI_Info_set(info, "nc_var_align_size",         "512",  err)
       call MPI_Info_set(info, "nc_header_read_chunk_size", "256",  err)
       ! note that set the above values to 1 to disable the alignment

--- a/examples/F90/get_info.f90
+++ b/examples/F90/get_info.f90
@@ -16,7 +16,7 @@
 !
 !    Example standard output:
 !
-!   MPI File Info: nkeys =          18
+!   MPI File Info: nkeys =          17
 !   MPI File Info: [ 0] key =            cb_buffer_size, value =16777216
 !   MPI File Info: [ 1] key =             romio_cb_read, value =automatic
 !   MPI File Info: [ 2] key =            romio_cb_write, value =automatic
@@ -32,9 +32,8 @@
 !   MPI File Info: [12] key =             romio_ds_read, value =automatic
 !   MPI File Info: [13] key =            romio_ds_write, value =automatic
 !   MPI File Info: [14] key =            cb_config_list, value =*:1
-!   MPI File Info: [15] key =      nc_header_align_size, value =0
-!   MPI File Info: [16] key =         nc_var_align_size, value =0
-!   MPI File Info: [17] key = nc_header_read_chunk_size, value =0
+!   MPI File Info: [15] key =         nc_var_align_size, value =0
+!   MPI File Info: [16] key = nc_header_read_chunk_size, value =0
 
 
         program main

--- a/examples/F90/hints.f90
+++ b/examples/F90/hints.f90
@@ -7,8 +7,8 @@
 ! $Id$
 
 !
-! This example sets two PnetCDF hints:
-!    nc_header_align_size and nc_var_align_size
+! This example sets PnetCDF hint:
+!    nc_var_align_size
 ! and prints the hint values as well as the header size, header extent, and
 ! two variables' starting file offsets.
 !
@@ -18,7 +18,6 @@
 !
 !    % mpiexec -n 4 ./hints /pvfs2/wkliao/testfile.nc
 !
-!    nc_header_align_size      set to = 1024
 !    nc_var_align_size         set to = 512
 !    nc_header_read_chunk_size set to = 256
 !    header size                      = 252
@@ -55,9 +54,8 @@
           logical flag
           integer(kind=MPI_OFFSET_KIND) header_size, header_extent
           integer(kind=MPI_OFFSET_KIND) var_zy_start, var_yx_start
-          integer(kind=MPI_OFFSET_KIND) h_align, v_align, h_chunk
+          integer(kind=MPI_OFFSET_KIND) v_align, h_chunk
 
-          h_align=-1
           v_align=-1
           h_chunk=-1
 
@@ -73,13 +71,6 @@
           err = nf90mpi_inq_file_info(ncid, info_used)
           call check(err, 'In nf90mpi_inq_file_info : ')
 
-          call MPI_Info_get_valuelen(info_used, "nc_header_align_size", &
-                                     len, flag, err)
-          if (flag) then
-              call MPI_Info_get(info_used, "nc_header_align_size", &
-                                len+1, value, flag, err)
-              read(value, '(i16)') h_align
-          endif
           call MPI_Info_get_valuelen(info_used, "nc_var_align_size", &
                                      len, flag, err)
           if (flag) then
@@ -97,11 +88,6 @@
           endif
           call MPI_Info_free(info_used, err)
 
-          if (h_align .EQ. -1) then
-              print*,"nc_header_align_size      is NOT set"
-          else
-              print*,"nc_header_align_size      set to = ", h_align
-          endif
           if (v_align .EQ. -1) then
               print*,"nc_var_align_size         is NOT set"
           else
@@ -176,7 +162,6 @@
       call MPI_Bcast(filename, 256, MPI_CHARACTER, 0, MPI_COMM_WORLD, err)
 
       call MPI_Info_create(info, err)
-      call MPI_Info_set(info, "nc_header_align_size",      "1024", err)
       call MPI_Info_set(info, "nc_var_align_size",         "512",  err)
       call MPI_Info_set(info, "nc_header_read_chunk_size", "256",  err)
       ! note that set the above values to 1 to disable the alignment

--- a/examples/README.md
+++ b/examples/README.md
@@ -92,8 +92,8 @@ with C, C++, F77, and F90 versions.
   + ./CXX/hints.cpp
   + ./F77/hints.f
   + ./F90/hints.f90
-  + This example sets two PnetCDF hints: `nc_header_align_size` and
-    `nc_var_align_size` and prints the hint values, the header size, header
+  + This example sets PnetCDF hint: `nc_var_align_size`
+    and prints the hint values, the header size, header
     extent, and variables' starting file offsets.
 
 * ./C/mput.c

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -90,6 +90,47 @@ This is essentially a placeholder for the next release note ...
 * Issues related to Darshan library:
   + none
 
-* Clarifications
-  + none
+* Clarifications about of PnetCDF hints
+  + There are three ways in PnetCDF for user to set hints to align the starting
+    file offset for the data section (header extent) and record variable
+    section.
+    1. through a call to API `nc_header_align_size` by setting arguments of
+       `h_minfree`, `v_align`, `v_minfree`, and `r_align`.
+    2. through an MPI info object passed to calls of `ncmpi_create()` and
+       `ncmpi_open()`. Hints are `nc_header_align_size`, `nc_var_align_size`,
+       and `nc_record_align_size`.
+    3. through a run-time environment variable `PNETCDF_HINTS`. Hints are
+       `nc_header_align_size`, `nc_var_align_size`, and `nc_record_align_size`.
+  + As the same hints may be set by one or more of the above methods, PnetCDF
+    implements the following hint precedence.
+    * `PNETCDF_HINTS` > `ncmpi__enddef()` > `MPI info`.
+    * 1st priority: hints set in the environment variable `PNETCDF_HINTS`, e.g.
+      `PNETCDF_HINTS="nc_var_align_size=1048576"`. Making this the first
+      priority is because it allows to run the same application executable
+      without source code modification using different alignment settings
+      through a run-time environment variable.
+    * 2nd priority: hints set in the MPI info object passed to calls of
+      `ncmpi_create()` and `ncmpi_open()`, e.g.
+      `MPI_Info_set("nc_var_align_size", "1048576");`. The reasoning is when a
+      3rd-party library built on top of PnetCDF implements its codes using
+      'ncmpi__enddef'. An application that uses such 3rd-party library can pass
+      an MPI info object to it, which further passes the info to PnetCDF. This
+      precedence allows that application to exercise different hints without
+      changing the 3rd-party library's source codes.
+    * 3rd priority: hints used in the arguments of `ncmpi__enddef()`, e.g.
+      `ncmpi__enddef(..., v_align=1048576,...)`.
+  + PnetCDF I/O hint `nc_header_align_size` is essentially the same as hint
+    `nc_var_align_size`, but its name appears to be closer to the hint's
+    intent, i.e. to reserve some space for the header growth in the future when
+    new data objects are added. Please note when both hints are set, only hint
+    `nc_var_align_size` will take effect and `nc_header_align_size` ignored.
+  + When there is no fix-sized variable (i.e. non-record variable) defined,
+    argument `v_minfree` passed to `ncmpi__enddef()` is ignored. In this
+    case, users should set `h_minfree`, if an extra header space is desired.
+  + When there is no fix-sized variables defined and none of hints
+    `nc_header_align_size`, `nc_var_align_size`, or argument `v_align` is set,
+    `nc_record_align_size` or `r_align`, if set, will be used to align the
+    header extent.
+  + For the above update to the hint precedence, see
+    PnetCDF See [PR #173](https://github.com/Parallel-NetCDF/PnetCDF/pull/173).
 

--- a/src/drivers/ncmpio/ncmpio_NC.h
+++ b/src/drivers/ncmpio/ncmpio_NC.h
@@ -17,6 +17,11 @@
 #include <dispatch.h>
 #include "ncmpio_driver.h"
 
+#define NC_DEFAULT_H_MINFREE 0
+#define NC_DEFAULT_V_ALIGN   512
+#define NC_DEFAULT_V_MINFREE 0
+#define NC_DEFAULT_R_ALIGN   4
+
 #define FILE_ALIGNMENT_DEFAULT 512
 #define FILE_ALIGNMENT_LB      4
 
@@ -383,12 +388,12 @@ struct NC {
 #endif
     int           striping_unit; /* stripe size of the file */
     int           chunk;       /* chunk size for reading header, one chunk at a time */
-    MPI_Offset    h_align;     /* file alignment for header size */
     MPI_Offset    v_align;     /* alignment of the beginning of fixed-size variables */
     MPI_Offset    r_align;     /* file alignment for record variable section */
-    MPI_Offset    env_h_align; /* h_align set in environment variable */
     MPI_Offset    env_v_align; /* v_align set in environment variable */
     MPI_Offset    env_r_align; /* r_align set in environment variable */
+    MPI_Offset    info_v_align;/* v_align set in MPI Info object */
+    MPI_Offset    info_r_align;/* r_align set in MPI Info object */
     MPI_Offset    h_minfree;   /* pad at the end of the header section */
     MPI_Offset    v_minfree;   /* pad at the end of the data section for fixed-size variables */
     MPI_Offset    ibuf_size;   /* packing buffer size for flushing noncontig

--- a/src/drivers/ncmpio/ncmpio_file_misc.c
+++ b/src/drivers/ncmpio/ncmpio_file_misc.c
@@ -362,9 +362,6 @@ ncmpio_inq_misc(void       *ncdp,
          * user.
          */
 
-        sprintf(value, "%lld", ncp->h_align);
-        MPI_Info_set(*info_used, "nc_header_align_size", value);
-
         sprintf(value, "%lld", ncp->v_align);
         MPI_Info_set(*info_used, "nc_var_align_size", value);
 

--- a/src/drivers/ncmpio/ncmpio_subfile.c
+++ b/src/drivers/ncmpio/ncmpio_subfile.c
@@ -262,7 +262,6 @@ int ncmpio_subfile_partition(NC *ncp)
     /* NOTE: the following "for loop" should be before NC_begins() */
 
     /* adjust the hints to be used by PnetCDF; use the same value in master */
-    ncp->ncp_sf->h_align = ncp->h_align;
     ncp->ncp_sf->v_align = ncp->v_align;
     ncp->ncp_sf->r_align = ncp->r_align;
 

--- a/test/F90/f90tst_vars.f90
+++ b/test/F90/f90tst_vars.f90
@@ -60,8 +60,7 @@ program f90tst_vars
   end do
 
   call MPI_Info_create(info, ierr)
-  call MPI_Info_set(info, "nc_header_align_size",      "1024", ierr)
-  call MPI_Info_set(info, "nc_var_align_size",         "512",  ierr)
+  call MPI_Info_set(info, "nc_var_align_size",         "1024", ierr)
   call MPI_Info_set(info, "nc_header_read_chunk_size", "256",  ierr)
 
   ! Create the netCDF file.

--- a/test/cdf_format/dim_cdf12.c
+++ b/test/cdf_format/dim_cdf12.c
@@ -72,9 +72,9 @@ int main(int argc, char** argv)
 
     /* Note this test program must use the 512-byte alignment setting */
     MPI_Info_create(&info);
-    /* use the 512-byte header align size */
-    MPI_Info_set(info, "nc_header_align_size", "512");
-    /* use the 512-byte fixed-size variable starting file offset alignment */
+    /* use the 512-byte fixed-size variable starting file offset alignment,
+     * which is also the header extent align size
+     */
     MPI_Info_set(info, "nc_var_align_size", "512");
 
     /* get command-line arguments */

--- a/test/testcases/alignment_test.c
+++ b/test/testcases/alignment_test.c
@@ -134,8 +134,7 @@ int main(int argc, char** argv) {
 
     /* mimic netCDF that does not do alignments */
     MPI_Info_create(&info);
-    MPI_Info_set(info, "nc_header_align_size", "1"); /* size in bytes */
-    MPI_Info_set(info, "nc_var_align_size",    "197"); /* size in bytes */
+    MPI_Info_set(info, "nc_var_align_size", "197"); /* size in bytes */
 
     /* open the file for adding more metadata */
     err = ncmpi_open(MPI_COMM_WORLD, filename, NC_WRITE, info, &ncid);

--- a/test/testcases/tst_info.c
+++ b/test/testcases/tst_info.c
@@ -53,7 +53,6 @@ int check_pnetcdf_hints(int ncid)
     err = ncmpi_inq_file_info(ncid, &info_used);
     CHECK_ERR;
 
-    CHECK_HINT("nc_header_align_size");
     CHECK_HINT("nc_var_align_size");
     CHECK_HINT("nc_header_read_chunk_size");
     CHECK_HINT("nc_record_align_size");
@@ -108,7 +107,6 @@ int main(int argc, char** argv) {
 
     /* create some PnetCDF-level I/O hints */
     MPI_Info_create(&info);
-    MPI_Info_set(info, "nc_header_align_size", "1");   /* size in bytes */
     MPI_Info_set(info, "nc_var_align_size",    "197"); /* size in bytes */
 
     /* create another new file using a non-NULL MPI info --------------------*/
@@ -152,20 +150,6 @@ int main(int argc, char** argv) {
         printf("header_extent=%lld\n\n",header_extent);
     }
 #endif
-
-    MPI_Info_get_valuelen(info_used, "nc_header_align_size", &len, &flag);
-    if (flag) {
-        MPI_Info_get(info_used, "nc_header_align_size", len+1, value, &flag);
-        expect = PNETCDF_RNDUP(1, 4);
-        if (expect != strtoll(value,NULL,10)) {
-            printf("Error: nc_header_align_size expect %lld but got %lld\n",
-                    expect, strtoll(value,NULL,10));
-            nerrs++;
-        }
-    } else {
-        printf("Error: hint \"nc_header_align_size\" is missing\n");
-        nerrs++;
-    }
 
     MPI_Info_get_valuelen(info_used, "nc_var_align_size", &len, &flag);
     if (flag) {

--- a/test/testcases/tst_redefine.c
+++ b/test/testcases/tst_redefine.c
@@ -6,7 +6,14 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *
- * This program tests header extent alignment if entering the redefine mode.
+ * This program tests all alignment features available from PnetCDF:
+ * 1. v_align: header extent alignment (starting file offset of data section)
+ * 2. h_minfree: header free space
+ * 3. r_align: record variable section alignment
+ * 4. v_minfree: free space between record variable section and the end of last
+ *    fix-sized variable.
+ *
+ * Tests are done by reentering the define mode multiple times.
  *
  * The compile and run commands are given below.
  *
@@ -25,11 +32,11 @@
 
 #include <testutils.h>
 
-static int verbose;
-
-#define NUM_RNDUP(x, unit) ((((x) + (unit) - 1) / (unit)) * (unit))
-
 #define LEN 16
+
+#define RNDUP(x, unit) ((((x) + (unit) - 1) / (unit)) * (unit))
+
+static int verbose;
 
 #define CHECK_VAL(ncid, varid, ii, val, expect) {                     \
     if (val != expect) {                                              \
@@ -43,443 +50,465 @@ static int verbose;
     }                                                                 \
 }
 
+/*----< check_vars() >-------------------------------------------------------*/
+/* read back variables from file and check their contents */
 static int
-check_fix_vars(MPI_Comm comm, int ncid, int *varid)
+check_vars(MPI_Comm comm, int ncid, int *varid)
 {
-    int i, nerrs=0, err, rank, *buf;
+    int i, nerrs=0, err, rank, *buf, nvars;
     MPI_Offset start[2], count[2];
 
     MPI_Comm_rank(comm, &rank);
 
-    start[0] = 0; start[1] = rank * LEN;
-    count[0] = 1; count[1] = LEN;
+    err = ncmpi_inq_nvars(ncid, &nvars); CHECK_ERROUT
 
-    buf = (int*) malloc(sizeof(int) * count[0] * count[1]);
+    /* check fix-sized variables */
+    start[0] = 0;
+    start[1] = rank * LEN;
+    count[1] = LEN;
 
-    for (i=0; i<count[0]*count[1]; i++) buf[i] = -1;
-    err = ncmpi_get_vara_int_all(ncid, varid[0], start+1, count+1, buf); CHECK_ERROUT
-    for (i=0; i<LEN; i++)
-        CHECK_VAL(ncid, varid[0], i, buf[i], rank+i)
+    buf = (int*) malloc(sizeof(int) * 2 * LEN);
 
-    for (i=0; i<count[0]*count[1]; i++) buf[i] = -1;
-    err = ncmpi_get_vara_int_all(ncid, varid[1], start+1, count+1, buf); CHECK_ERROUT
-    for (i=0; i<LEN; i++)
-        CHECK_VAL(ncid, varid[1], i, buf[i], rank+i+100)
-
-err_out:
-    free(buf);
-    return nerrs;
-}
-
-static int
-check_rec_vars(MPI_Comm comm, int ncid, int *varid)
-{
-    int i, nerrs=0, err, rank, *buf;
-    MPI_Offset start[2], count[2];
-
-    MPI_Comm_rank(comm, &rank);
-
-    start[0] = 0; start[1] = rank * LEN;
-    count[0] = 2; count[1] = LEN;
-
-    buf = (int*) malloc(sizeof(int) * count[0] * count[1]);
+    /* check record variables */
+    count[0] = 2;
 
     for (i=0; i<count[0]*count[1]; i++) buf[i] = -1;
-    err = ncmpi_get_vara_int_all(ncid, varid[0], start,   count,   buf); CHECK_ERROUT
+    err = ncmpi_get_vara_int_all(ncid, varid[0], start,   count,   buf);
+    CHECK_ERROUT
     for (i=0; i<2*LEN; i++)
         CHECK_VAL(ncid, varid[0], i, buf[i], rank+i+1000)
 
     for (i=0; i<count[0]*count[1]; i++) buf[i] = -1;
-    err = ncmpi_get_vara_int_all(ncid, varid[1], start,   count,   buf); CHECK_ERROUT
+    err = ncmpi_get_vara_int_all(ncid, varid[1], start,   count,   buf);
+    CHECK_ERROUT
     for (i=0; i<2*LEN; i++)
         CHECK_VAL(ncid, varid[1], i, buf[i], rank+i+10000)
+
+    if (nvars == 2) goto err_out;
+
+    /* check fix-sized variables */
+    count[0] = 1;
+
+    for (i=0; i<count[0]*count[1]; i++) buf[i] = -1;
+    err = ncmpi_get_vara_int_all(ncid, varid[2], start+1, count+1, buf);
+    CHECK_ERROUT
+    for (i=0; i<LEN; i++)
+        CHECK_VAL(ncid, varid[2], i, buf[i], rank+i)
+
+    for (i=0; i<count[0]*count[1]; i++) buf[i] = -1;
+    err = ncmpi_get_vara_int_all(ncid, varid[3], start+1, count+1, buf);
+    CHECK_ERROUT
+    for (i=0; i<LEN; i++)
+        CHECK_VAL(ncid, varid[3], i, buf[i], rank+i+100)
 
 err_out:
     free(buf);
     return nerrs;
 }
 
+#define GET_HEADER_SIZE { \
+    old_hsize   = hsize; \
+    old_extent  = extent; \
+    old_r_begin = r_begin; \
+    old_h_free  = h_free; \
+    old_v_free  = v_free; \
+    err = ncmpi_inq_header_size(ncid, &hsize); CHECK_ERR \
+    err = ncmpi_inq_header_extent(ncid, &extent); CHECK_ERR \
+    h_free = extent - hsize; \
+    err = ncmpi_inq_varoffset(ncid, varid[0], &r_begin); CHECK_ERR \
+    v_free = r_begin - (extent + fix_v_size); \
+    if (verbose && rank == 0) { \
+        printf("Line %d: header size   old = %6lld new = %6lld\n", \
+               __LINE__,old_hsize, hsize); \
+        printf("Line %d: header extent old = %6lld new = %6lld\n", \
+               __LINE__,old_extent, extent); \
+        printf("Line %d: header free   old = %6lld new = %6lld\n", \
+               __LINE__,old_h_free, h_free); \
+        printf("Line %d: record begin  old = %6lld new = %6lld\n", \
+               __LINE__,old_r_begin, r_begin); \
+        printf("Line %d: var free      old = %6lld new = %6lld\n", \
+               __LINE__,old_v_free, v_free); \
+    } \
+}
+
+#define CHECK_HEADER_SIZE { \
+    if (hsize != exp_hsize) { \
+        nerrs++; \
+        printf("Error at line %d in %s: header size expecting %lld but got %lld\n", \
+               __LINE__,__FILE__, exp_hsize, hsize); \
+    } \
+    if (extent != exp_extent) { \
+        nerrs++; \
+        printf("Error at line %d in %s: header extent expecting %lld but got %lld\n", \
+               __LINE__,__FILE__, exp_extent, extent); \
+    } \
+    if (extent - hsize < exp_h_free) { \
+        nerrs++; \
+        printf("Error at line %d in %s: header free expecting %lld but got %lld\n", \
+               __LINE__,__FILE__, exp_h_free, extent - hsize); \
+    } \
+    if (has_fix_vars && v_free != exp_v_free) { \
+        nerrs++; \
+        printf("Error at line %d in %s: v_free expecting %lld but got %lld\n", \
+               __LINE__,__FILE__, exp_v_free, v_free); \
+    } \
+    if (r_begin != exp_r_begin) { \
+        nerrs++; \
+        printf("Error at line %d in %s: record begin expecting %lld but got %lld\n", \
+               __LINE__,__FILE__, exp_r_begin, r_begin); \
+    } \
+    /* read variables back and check contents */ \
+    nerrs += check_vars(comm, ncid, varid); \
+    if (nerrs > 0) goto err_out; \
+}
+
+#define GROW_METADATA(growth) { \
+    MPI_Offset len; \
+    err = ncmpi_inq_attlen(ncid, NC_GLOBAL, "attr", &len); \
+    len += growth; \
+    char *attr = (char*) calloc(len + growth, 1); \
+    err = ncmpi_put_att_text(ncid, NC_GLOBAL, "attr", len, attr);\
+    CHECK_ERR \
+    free(attr); \
+    if (verbose && rank == 0) \
+        printf("Line %d: grow header size from %6lld to %6lld\n", \
+               __LINE__,hsize, hsize+growth); \
+}
+
+#define CHECK_ALIGNMENTS { \
+    /* hints set in MPI info precede ncmpi__enddef */ \
+    v_align = (env_v_align) ? env_v_align : \
+              (!has_fix_vars && env_r_align) ? env_r_align : \
+              (info_v_align) ? info_v_align : v_align; \
+    r_align = (env_r_align) ? env_r_align : \
+              (info_r_align) ? info_r_align : r_align; \
+    exp_hsize  = old_hsize + increment; \
+    exp_extent = RNDUP(exp_hsize + h_minfree, v_align); \
+    old_extent = RNDUP(old_extent, v_align); \
+    exp_extent = (exp_extent < old_extent) ? old_extent : exp_extent; \
+    if (has_fix_vars) { \
+        exp_r_begin = RNDUP(exp_extent + fix_v_size + v_minfree, r_align); \
+        old_r_begin = RNDUP(old_r_begin, r_align); \
+    } \
+    else /* v_minfree and r_align are ignored */ \
+        exp_r_begin = exp_extent; \
+    exp_r_begin = (exp_r_begin < old_r_begin) ? old_r_begin : exp_r_begin; \
+    exp_h_free  = exp_extent - exp_hsize; \
+    exp_v_free  = exp_r_begin - (exp_extent + fix_v_size); \
+    CHECK_HEADER_SIZE \
+}
+
+/* test alignments hints
+ * 1. set in environment variable PNETCDF_HINTS,
+ * 2. set in ncmpi__enddef()
+ * 3. set in MPI File info, which is passed into ncmpi_create/ncmpi_open
+ * Note precedence of hints: PNETCDF_HINTS > ncmpi__enddef() > MPI info.
+ */
 static int
-tst_fmt(char *filename, int cmode)
+tst_fmt(char       *filename,
+        int         cmode,
+        int         has_fix_vars,
+        MPI_Offset *env_align,  /* [3] 0 means unset in PNETCDF_HINTS */
+        MPI_Offset *info_align) /* [3] 0 means unset in MPI info */
 {
     int i, rank, nprocs, ncid, err, nerrs=0;
-    int *buf, dimid[3], varid[4], minfree=100;
-    MPI_Offset start[2], count[2];
-    MPI_Offset old_hsize, hsize;
-    MPI_Offset old_extent, extent;
-    MPI_Offset old_var_off, var_off;
-    MPI_Offset v_align, r_align, exp_var_off;
+    int *buf, dimid[3], varid[4];
+    MPI_Info info=MPI_INFO_NULL;
+    MPI_Offset start[2], count[2], increment, fix_v_size;
+
+    MPI_Offset hsize=0, old_hsize, exp_hsize;
+    MPI_Offset extent=0, old_extent, exp_extent;
+    MPI_Offset h_free=0, old_h_free, exp_h_free;
+    MPI_Offset v_free=0, old_v_free, exp_v_free;
+    MPI_Offset r_begin=0, old_r_begin, exp_r_begin;
+    MPI_Offset h_minfree, v_align, v_minfree, r_align;
+    MPI_Offset env_h_align=0, env_v_align=0, env_r_align=0;
+    MPI_Offset info_h_align=0, info_v_align=0, info_r_align=0;
+
     MPI_Comm comm = MPI_COMM_WORLD;
 
     MPI_Comm_rank(comm, &rank);
     MPI_Comm_size(comm, &nprocs);
 
-    unsetenv("PNETCDF_HINTS");
+    if (verbose && rank == 0)
+        printf("---- cmode=%d has_fix_vars=%d env_align=%s info_align=%s\n",
+               cmode,has_fix_vars,(env_align==NULL)?"NULL":"SET",
+               (info_align==NULL)?"NULL":"SET");
+
+    if (env_align != NULL) {
+        env_h_align = env_align[0];  /* 0 means unset in PNETCDF_HINTS */
+        env_v_align = env_align[1];  /* 0 means unset in PNETCDF_HINTS */
+        env_r_align = env_align[2];  /* 0 means unset in PNETCDF_HINTS */
+        if (env_v_align == 0) env_v_align = env_h_align;
+    }
+    if (info_align != NULL) {
+        char str[16];
+        info_h_align = info_align[0]; /* 0 means unset in MPI info */
+        info_v_align = info_align[1]; /* 0 means unset in MPI info */
+        info_r_align = info_align[2]; /* 0 means unset in MPI info */
+        MPI_Info_create(&info);
+        if (info_h_align) {
+            sprintf(str, "%lld", info_h_align);
+            MPI_Info_set(info, "nc_header_align_size", str);
+        }
+        if (info_v_align) {
+            sprintf(str, "%lld", info_v_align);
+            MPI_Info_set(info, "nc_var_align_size", str);
+        }
+        if (info_r_align) {
+            sprintf(str, "%lld", info_r_align);
+            MPI_Info_set(info, "nc_record_align_size", str);
+        }
+        if (info_v_align == 0) info_v_align = info_h_align;
+    }
+    if (verbose && rank == 0)
+        printf("---- cmode=%d has_fix_vars=%d env_align=%lld %lld %lld info_align=%lld %lld %lld\n",
+               cmode,has_fix_vars,env_h_align,env_v_align,env_r_align,
+               info_h_align,info_v_align,info_r_align);
+
 
     /* create a new file */
     cmode |= NC_CLOBBER;
-    err = ncmpi_create(comm, filename, cmode, MPI_INFO_NULL, &ncid); CHECK_ERR
+    err = ncmpi_create(comm, filename, cmode, info, &ncid); CHECK_ERR
 
     err = ncmpi_def_dim(ncid, "time", NC_UNLIMITED, &dimid[0]); CHECK_ERR
     err = ncmpi_def_dim(ncid, "dim", LEN*nprocs, &dimid[1]); CHECK_ERR
-    err = ncmpi_def_var(ncid, "fa", NC_INT, 1, dimid+1, &varid[0]); CHECK_ERR
-    err = ncmpi_def_var(ncid, "fb", NC_INT, 1, dimid+1, &varid[1]); CHECK_ERR
-    err = ncmpi_def_var(ncid, "ta", NC_INT, 2, dimid,   &varid[2]); CHECK_ERR
-    err = ncmpi_def_var(ncid, "tb", NC_INT, 2, dimid,   &varid[3]); CHECK_ERR
+    err = ncmpi_def_var(ncid, "ta", NC_INT, 2, dimid,   &varid[0]); CHECK_ERR
+    err = ncmpi_def_var(ncid, "tb", NC_INT, 2, dimid,   &varid[1]); CHECK_ERR
+    if (has_fix_vars) {
+        err = ncmpi_def_var(ncid, "fa", NC_INT, 1, dimid+1, &varid[2]);
+        CHECK_ERR
+        err = ncmpi_def_var(ncid, "fb", NC_INT, 1, dimid+1, &varid[3]);
+        CHECK_ERR
+    }
+    err = ncmpi_put_att_text(ncid, NC_GLOBAL, "attr", 0, NULL); CHECK_ERR
 
-    /* disable header alignment */
-    err = ncmpi__enddef(ncid, 0, 4, 0, 4); CHECK_ERR
+    err = ncmpi_enddef(ncid); CHECK_ERR
 
+    /* write to all variables, 2 records */
     start[0] = 0; start[1] = rank * LEN;
     count[0] = 2; count[1] = LEN;
 
     buf = (int*) malloc(sizeof(int) * count[0] * count[1]);
 
-    for (i=0; i<LEN; i++) buf[i] = rank + i;
-    err = ncmpi_put_vara_int_all(ncid, varid[0], start+1, count+1, buf); CHECK_ERR
-    for (i=0; i<LEN; i++) buf[i] = rank + i + 100;
-    err = ncmpi_put_vara_int_all(ncid, varid[1], start+1, count+1, buf); CHECK_ERR
-    for (i=0; i<2*LEN; i++) buf[i] = rank + i + 1000;
-    err = ncmpi_put_vara_int_all(ncid, varid[2], start,   count,   buf); CHECK_ERR
-    for (i=0; i<2*LEN; i++) buf[i] = rank + i + 10000;
-    err = ncmpi_put_vara_int_all(ncid, varid[3], start,   count,   buf); CHECK_ERR
+    for (i=0; i<count[0] * count[1]; i++) buf[i] = rank + i + 1000;
+    err = ncmpi_put_vara_int_all(ncid, varid[0], start, count, buf);
+    CHECK_ERR
+    for (i=0; i<count[0] * count[1]; i++) buf[i] = rank + i + 10000;
+    err = ncmpi_put_vara_int_all(ncid, varid[1], start, count, buf);
+    CHECK_ERR
 
-    nerrs += check_fix_vars(comm, ncid, varid);
-    if (nerrs > 0) goto err_out;
-    nerrs += check_rec_vars(comm, ncid, varid+2);
-    if (nerrs > 0) goto err_out;
+    if (has_fix_vars) {
+        for (i=0; i<count[1]; i++) buf[i] = rank + i;
+        err = ncmpi_put_vara_int_all(ncid, varid[2], start+1, count+1, buf);
+        CHECK_ERR
+        for (i=0; i<count[1]; i++) buf[i] = rank + i + 100;
+        err = ncmpi_put_vara_int_all(ncid, varid[3], start+1, count+1, buf);
+        CHECK_ERR
+        fix_v_size = sizeof(int) * LEN * nprocs * 2;
+    }
+    else
+        fix_v_size = 0;
+
+    GET_HEADER_SIZE
+
+    /* PnetCDF default v_align is 512 when no hints given */
+    v_align = (env_v_align) ? env_v_align :
+              (!has_fix_vars && env_r_align) ? env_r_align :
+              (info_v_align) ? info_v_align : 512;
+    r_align = (env_r_align) ? env_r_align : (info_r_align) ? info_r_align : 4;
+    increment = 0;
+    h_minfree = 0;
+    v_minfree = 0;
+
+    exp_hsize = hsize;
+    exp_extent = RNDUP(hsize, v_align);
+    if (has_fix_vars)
+        exp_r_begin = RNDUP(exp_extent + fix_v_size, r_align);
+    else /* r_align and v_minfree are ignored */
+        exp_r_begin = exp_extent;
+    exp_h_free = exp_extent - exp_hsize;
+    exp_v_free = v_free;
+    CHECK_HEADER_SIZE
+
+    /* enter redefine mode -------------------------------------------*/
+    err = ncmpi_redef(ncid); CHECK_ERR
+    increment = 0;
+
+    /* explicitly disable header alignment */
+    h_minfree = 0;  /* header free space */
+    v_align   = 4;  /* alignment for variable section (also header extent) */
+    v_minfree = 0;  /* free space between fixed and record variable sections */
+    r_align   = 4;  /* alignment for record variable section */
+
+    err = ncmpi__enddef(ncid, h_minfree, v_align, v_minfree, r_align);
+    CHECK_ERR
+
+    GET_HEADER_SIZE
+
+    /* expect nothing changed */
+    exp_hsize   = old_hsize;
+    exp_extent  = old_extent;
+    exp_h_free  = old_h_free;
+    exp_v_free  = old_v_free;
+    exp_r_begin = old_r_begin;
+    CHECK_HEADER_SIZE
 
     err = ncmpi_close(ncid); CHECK_ERR
 
     /* reopen the file and check file header size and extent */
-    err = ncmpi_open(comm, filename, NC_WRITE, MPI_INFO_NULL, &ncid); CHECK_ERR
+    err = ncmpi_open(comm, filename, NC_WRITE, info, &ncid); CHECK_ERR
 
-    err = ncmpi_inq_varid(ncid, "fa", &varid[0]); CHECK_ERR
-    err = ncmpi_inq_varid(ncid, "fb", &varid[1]); CHECK_ERR
-    err = ncmpi_inq_varid(ncid, "ta", &varid[2]); CHECK_ERR
-    err = ncmpi_inq_varid(ncid, "tb", &varid[3]); CHECK_ERR
-
-    err = ncmpi_inq_header_size(ncid, &hsize); CHECK_ERR
-    err = ncmpi_inq_header_extent(ncid, &extent); CHECK_ERR
-    if (verbose)
-        printf("File header size = %lld extent = %lld\n", hsize, extent);
-
-    /* make sure header size == extent */
-    if (hsize != extent) {
-        nerrs++;
-        printf("Error at line %d in %s: File header size %lld != extent %lld\n",
-               __LINE__,__FILE__, hsize, extent);
+    err = ncmpi_inq_varid(ncid, "ta", &varid[0]); CHECK_ERR
+    err = ncmpi_inq_varid(ncid, "tb", &varid[1]); CHECK_ERR
+    if (has_fix_vars) {
+        err = ncmpi_inq_varid(ncid, "fa", &varid[2]); CHECK_ERR
+        err = ncmpi_inq_varid(ncid, "fb", &varid[3]); CHECK_ERR
     }
 
-    /* enter redefine mode and add a dimension to grow the header */
+    GET_HEADER_SIZE
+
+    /* expect nothing changed */
+    exp_hsize   = old_hsize;
+    exp_extent  = old_extent;
+    exp_h_free  = old_h_free;
+    exp_v_free  = old_v_free;
+    exp_r_begin = old_r_begin;
+    CHECK_HEADER_SIZE
+
+    /* enter redefine mode -------------------------------------------*/
     err = ncmpi_redef(ncid); CHECK_ERR
 
-    err = ncmpi_def_dim(ncid, "dim_x", 25, &dimid[2]); CHECK_ERR
+    /* grow header size */
+    increment = extent - hsize + 8;
+    GROW_METADATA(increment)
+
+    /* exit define mode */
+    h_minfree = 0;
+    v_minfree = 0;
+    v_align = 4;
+    r_align = 4;
+    err = ncmpi_enddef(ncid); CHECK_ERR
+
+    GET_HEADER_SIZE
+    CHECK_ALIGNMENTS
+
+    /* enter redefine mode -------------------------------------------*/
+    err = ncmpi_redef(ncid); CHECK_ERR
+
+    /* add a header free space, disable header alignment */
+    increment = 0;
+    h_minfree = 76;
+    v_minfree = 44;
+    v_align = 4;
+    r_align = 4;
+    err = ncmpi__enddef(ncid, h_minfree, v_align, v_minfree, r_align);
+    CHECK_ERR
+
+    GET_HEADER_SIZE
+    CHECK_ALIGNMENTS
+
+    /* enter redefine mode -------------------------------------------*/
+    err = ncmpi_redef(ncid); CHECK_ERR
+
+    /* grow header size */
+    increment = extent - hsize - 16;
+    GROW_METADATA(increment);
 
     /* disable header alignment */
-    err = ncmpi__enddef(ncid, 0, 4, 0, 4); CHECK_ERR
+    h_minfree = 0;
+    v_minfree = 31;
+    v_align = 4;
+    r_align = 4;
+    err = ncmpi__enddef(ncid, h_minfree, v_align, v_minfree, r_align);
+    CHECK_ERR
 
-    old_hsize = hsize;
-    old_extent = extent;
-    err = ncmpi_inq_header_size(ncid, &hsize); CHECK_ERR
-    err = ncmpi_inq_header_extent(ncid, &extent); CHECK_ERR
-    if (verbose) {
-        printf("File old header size = %6lld old extent = %6lld\n", old_hsize, old_extent);
-        printf("File new header size = %6lld new extent = %6lld\n", hsize, extent);
-    }
+    GET_HEADER_SIZE
+    CHECK_ALIGNMENTS
 
-    /* make sure header size grows */
-    if (hsize <= old_hsize) {
-        nerrs++;
-        printf("Error at line %d in %s: File header size %lld fails to grow from %lld\n",
-               __LINE__,__FILE__, hsize, old_hsize);
-    }
-    /* make sure header extent grows */
-    if (extent <= old_extent) {
-        nerrs++;
-        printf("Error at line %d in %s: File header extent %lld fails to grow from %lld\n",
-               __LINE__,__FILE__, extent, old_extent);
-    }
-
-    nerrs += check_fix_vars(comm, ncid, varid);
-    if (nerrs > 0) goto err_out;
-    nerrs += check_rec_vars(comm, ncid, varid+2);
-    if (nerrs > 0) goto err_out;
-
-    /* enter redefine mode and add nothing */
+    /* enter redefine mode -------------------------------------------*/
     err = ncmpi_redef(ncid); CHECK_ERR
 
-    /* add free space into header extent */
-    err = ncmpi__enddef(ncid, minfree, 0, 0, 0); CHECK_ERR
+    /* grow header size */
+    increment = extent - hsize - 4;
+    GROW_METADATA(increment);
 
-    old_hsize = hsize;
-    old_extent = extent;
-    err = ncmpi_inq_header_size(ncid, &hsize); CHECK_ERR
-    err = ncmpi_inq_header_extent(ncid, &extent); CHECK_ERR
-    if (verbose) {
-        printf("File old header size = %6lld old extent = %6lld\n", old_hsize, old_extent);
-        printf("File new header size = %6lld new extent = %6lld\n", hsize, extent);
-    }
+    /* exit define mode */
+    h_minfree = 0;
+    v_minfree = 0;
+    v_align = 4;
+    r_align = 4;
+    err = ncmpi_enddef(ncid); CHECK_ERR
 
-    /* make sure header size does not change */
-    if (hsize != old_hsize) {
-        nerrs++;
-        printf("Error at line %d in %s: File header size %lld changed from %lld\n",
-               __LINE__,__FILE__, hsize, old_hsize);
-    }
-    /* make sure header extent grows minfree bytes */
-    if (extent != old_extent + minfree) {
-        nerrs++;
-        printf("Error at line %d in %s: File header extent %lld fails to grow into %lld\n",
-               __LINE__,__FILE__, extent, old_extent + minfree);
-    }
+    GET_HEADER_SIZE
+    CHECK_ALIGNMENTS
 
-    nerrs += check_fix_vars(comm, ncid, varid);
-    if (nerrs > 0) goto err_out;
-    nerrs += check_rec_vars(comm, ncid, varid+2);
-    if (nerrs > 0) goto err_out;
-
-    /* enter redefine mode and add nothing */
+    /* enter redefine mode -------------------------------------------*/
     err = ncmpi_redef(ncid); CHECK_ERR
 
-    /* align header extent to 512 bytes */
-    err = ncmpi__enddef(ncid, 0, 512, 0, 0); CHECK_ERR
+    increment = 0;
+    h_minfree = 0;
+    v_minfree = 31;
+    r_align = 4;
 
-    old_hsize = hsize;
-    old_extent = extent;
-    err = ncmpi_inq_header_size(ncid, &hsize); CHECK_ERR
-    err = ncmpi_inq_header_extent(ncid, &extent); CHECK_ERR
-    if (verbose) {
-        printf("File old header size = %6lld old extent = %6lld\n", old_hsize, old_extent);
-        printf("File new header size = %6lld new extent = %6lld\n", hsize, extent);
-    }
+    /* increase v_align */
+    v_align = extent + 4;
+    err = ncmpi__enddef(ncid, h_minfree, v_align, v_minfree, r_align);
+    CHECK_ERR
 
-    /* make sure header size does not change */
-    if (hsize != old_hsize) {
-        nerrs++;
-        printf("Error at line %d in %s: File header size %lld changed from %lld\n",
-               __LINE__,__FILE__, hsize, old_hsize);
-    }
-    /* make sure header extent grows to 512 bytes */
-    if (extent != 512) {
-        nerrs++;
-        printf("Error at line %d in %s: File header extent %lld fails to grow into 512\n",
-               __LINE__,__FILE__, extent);
-    }
+    GET_HEADER_SIZE
 
-    nerrs += check_fix_vars(comm, ncid, varid);
-    if (nerrs > 0) goto err_out;
-    nerrs += check_rec_vars(comm, ncid, varid+2);
-    if (nerrs > 0) goto err_out;
+    CHECK_ALIGNMENTS
 
-    err = ncmpi_close(ncid); CHECK_ERR
-
-
-    setenv("PNETCDF_HINTS", "nc_header_align_size=700", 1);
-
-    /* reopen the file and check file header size and extent */
-    err = ncmpi_open(comm, filename, NC_WRITE, MPI_INFO_NULL, &ncid); CHECK_ERR
-
-    err = ncmpi_inq_varid(ncid, "fa", &varid[0]); CHECK_ERR
-    err = ncmpi_inq_varid(ncid, "fb", &varid[1]); CHECK_ERR
-    err = ncmpi_inq_varid(ncid, "ta", &varid[2]); CHECK_ERR
-    err = ncmpi_inq_varid(ncid, "tb", &varid[3]); CHECK_ERR
-
-    /* enter redefine mode and add nothing */
+    /* enter redefine mode -------------------------------------------*/
     err = ncmpi_redef(ncid); CHECK_ERR
 
-    /* align header extent to 800 bytes, this should take no effect, as
-     * run-time hints precedes function calls. */
-    err = ncmpi__enddef(ncid, 0, 800, 0, 0); CHECK_ERR
+    increment = 0;
+    h_minfree = 0;
+    v_minfree = 31;
+    v_align = 4;
 
-    old_hsize = hsize;
-    old_extent = extent;
-    err = ncmpi_inq_header_size(ncid, &hsize); CHECK_ERR
-    err = ncmpi_inq_header_extent(ncid, &extent); CHECK_ERR
-    if (verbose) {
-        printf("File old header size = %6lld old extent = %6lld\n", old_hsize, old_extent);
-        printf("File new header size = %6lld new extent = %6lld\n", hsize, extent);
-    }
+    /* increase r_align */
+    r_align = r_begin + 4;
+    err = ncmpi__enddef(ncid, h_minfree, v_align, v_minfree, r_align);
+    CHECK_ERR
 
-    /* make sure header size does not change */
-    if (hsize != old_hsize) {
-        nerrs++;
-        printf("Error at line %d in %s: File header size %lld changed from %lld\n",
-               __LINE__,__FILE__, hsize, old_hsize);
-    }
-    /* make sure header extent grows to 700 bytes */
-    if (extent != 700) {
-        nerrs++;
-        printf("Error at line %d in %s: File header extent %lld fails to grow into 700\n",
-               __LINE__,__FILE__, extent);
-    }
+    GET_HEADER_SIZE
 
-    unsetenv("PNETCDF_HINTS");
+    CHECK_ALIGNMENTS
 
-    nerrs += check_fix_vars(comm, ncid, varid);
-    if (nerrs > 0) goto err_out;
-    nerrs += check_rec_vars(comm, ncid, varid+2);
-    if (nerrs > 0) goto err_out;
-
-    /* enter redefine mode and add nothing */
+    /* enter redefine mode -------------------------------------------*/
     err = ncmpi_redef(ncid); CHECK_ERR
 
-    /* set minfree to the free space, this should not grow the extent */
-    err = ncmpi__enddef(ncid, extent-hsize, 0, 0, 0); CHECK_ERR
+    increment = 0;
+    h_minfree = 0;
+    v_minfree = 0;
+    v_align = 4;
+    r_align = 4;
 
-    old_hsize = hsize;
-    old_extent = extent;
-    err = ncmpi_inq_header_size(ncid, &hsize); CHECK_ERR
-    err = ncmpi_inq_header_extent(ncid, &extent); CHECK_ERR
-    if (verbose) {
-        printf("File old header size = %6lld old extent = %6lld\n", old_hsize, old_extent);
-        printf("File new header size = %6lld new extent = %6lld\n", hsize, extent);
-    }
+    /* add nothing */
+    err = ncmpi_enddef(ncid); CHECK_ERR
 
-    /* make sure header size does not change */
-    if (hsize != old_hsize) {
-        nerrs++;
-        printf("Error at line %d in %s: File header size %lld changed from %lld\n",
-               __LINE__,__FILE__, hsize, old_hsize);
-    }
-    /* make sure header extent remain the same */
-    if (extent != old_extent) {
-        nerrs++;
-        printf("Error at line %d in %s: File header extent %lld changed from %lld\n",
-               __LINE__,__FILE__, extent, old_extent);
-    }
+    GET_HEADER_SIZE
 
-    /* obtain 1st record variable's file offset */
-    err = ncmpi_inq_varoffset(ncid, varid[2], &old_var_off); CHECK_ERR
-
-    nerrs += check_fix_vars(comm, ncid, varid);
-    if (nerrs > 0) goto err_out;
-    nerrs += check_rec_vars(comm, ncid, varid+2);
-    if (nerrs > 0) goto err_out;
-
-    /* enter redefine mode and add nothing */
-    err = ncmpi_redef(ncid); CHECK_ERR
-
-    /* set v_minfree of size 400 */
-    err = ncmpi__enddef(ncid, 0, 0, 400, 0); CHECK_ERR
-
-    /* obtain 1st record variable's file offset */
-    err = ncmpi_inq_varoffset(ncid, varid[2], &var_off); CHECK_ERR
-
-    /* var_off should grows 400 bytes */
-    if (var_off != old_var_off + 400) {
-        nerrs++;
-        printf("Error at line %d in %s: 1st record variable offset %lld (expecting %lld)\n",
-               __LINE__,__FILE__, var_off, old_var_off+400);
-    }
-
-    nerrs += check_fix_vars(comm, ncid, varid);
-    if (nerrs > 0) goto err_out;
-    nerrs += check_rec_vars(comm, ncid, varid+2);
-    if (nerrs > 0) goto err_out;
-
-#if 0
-    err = ncmpi_close(ncid); CHECK_ERR
-
-    /* reopen the file and set r_align */
-    err = ncmpi_open(comm, filename, NC_WRITE, MPI_INFO_NULL, &ncid); CHECK_ERR
-#endif
-
-    /* obtained the old offset of 1st record variable */
-    err = ncmpi_inq_varoffset(ncid, varid[2], &old_var_off); CHECK_ERR
-
-    /* enter redefine mode and add nothing */
-    err = ncmpi_redef(ncid); CHECK_ERR
-
-    /* set r_align to 1500 */
-    r_align = 1500;
-    err = ncmpi__enddef(ncid, 0, 0, 0, r_align); CHECK_ERR
-
-    /* obtain 1st record variable's file offset */
-    err = ncmpi_inq_varoffset(ncid, varid[2], &var_off); CHECK_ERR
-
-    /* round up to r_align */
-    exp_var_off = NUM_RNDUP(old_var_off, r_align);
-
-    /* var_off should grows into 1500 bytes */
-    if (var_off != exp_var_off) {
-        nerrs++;
-        printf("Error at line %d in %s: 1st record variable offset %lld (expecting %lld)\n",
-               __LINE__,__FILE__, var_off, exp_var_off);
-    }
-
-    nerrs += check_fix_vars(comm, ncid, varid);
-    if (nerrs > 0) goto err_out;
-    nerrs += check_rec_vars(comm, ncid, varid+2);
-    if (nerrs > 0) goto err_out;
-
-    err = ncmpi_close(ncid); CHECK_ERR
-
-    unsetenv("PNETCDF_HINTS");
-
-    /* re-create a new file */
-    cmode |= NC_CLOBBER;
-    err = ncmpi_create(comm, filename, cmode, MPI_INFO_NULL, &ncid); CHECK_ERR
-
-    /* define only record variables */
-    err = ncmpi_def_dim(ncid, "time", NC_UNLIMITED, &dimid[0]); CHECK_ERR
-    err = ncmpi_def_dim(ncid, "dim", LEN*nprocs, &dimid[1]); CHECK_ERR
-    err = ncmpi_def_var(ncid, "ta", NC_INT, 2, dimid,   &varid[2]); CHECK_ERR
-    err = ncmpi_def_var(ncid, "tb", NC_INT, 2, dimid,   &varid[3]); CHECK_ERR
-
-    /* set v_align and r_align. Without record variables, r_align will take
-     * effect over v_align
-     */
-    v_align = 100;
-    r_align = 512;
-    err = ncmpi__enddef(ncid, 0, v_align, 0, r_align); CHECK_ERR
-
-    start[0] = 0; start[1] = rank * LEN;
-    count[0] = 2; count[1] = LEN;
-
-    for (i=0; i<2*LEN; i++) buf[i] = rank + i + 1000;
-    err = ncmpi_put_vara_int_all(ncid, varid[2], start,   count,   buf); CHECK_ERR
-    for (i=0; i<2*LEN; i++) buf[i] = rank + i + 10000;
-    err = ncmpi_put_vara_int_all(ncid, varid[3], start,   count,   buf); CHECK_ERR
-
-    err = ncmpi_inq_header_size(ncid, &hsize); CHECK_ERR
-    err = ncmpi_inq_header_extent(ncid, &extent); CHECK_ERR
-    if (verbose)
-        printf("File header size = %lld extent = %lld\n", hsize, extent);
-
-    /* obtain 1st record variable's file offset */
-    err = ncmpi_inq_varoffset(ncid, varid[2], &var_off); CHECK_ERR
-    if (var_off != extent) {
-        nerrs++;
-        printf("Error at line %d in %s: 1st record variable offset %lld (expecting %lld)\n",
-               __LINE__,__FILE__, var_off, extent);
-    }
-
-    /* extent should be r_align */
-    if (extent != r_align) {
-        nerrs++;
-        printf("Error at line %d in %s: file extent %lld (expecting %lld)\n",
-               __LINE__,__FILE__, extent, r_align);
-    }
-
-    nerrs += check_rec_vars(comm, ncid, varid+2);
-    if (nerrs > 0) goto err_out;
+    CHECK_ALIGNMENTS
 
 err_out:
     err = ncmpi_close(ncid); CHECK_ERR
     free(buf);
+    if (info != MPI_INFO_NULL) MPI_Info_free(&info);
 
     return nerrs;
 }
 
 int main(int argc, char** argv)
 {
-    char filename[256];
-    int commsize, rank, err, nerrs=0;
+    char filename[256], str[256];
+    int i, rank, err, nerrs=0, cmode[3], has_fix_vars;
     MPI_Comm comm = MPI_COMM_WORLD;
+    MPI_Offset env_align[3], info_align[3];
 
     MPI_Init(&argc, &argv);
-    MPI_Comm_size(comm, &commsize);
     MPI_Comm_rank(comm, &rank);
 
     verbose = 0;
@@ -497,11 +526,121 @@ int main(int argc, char** argv)
         sprintf(cmd_str, "*** TESTING C   %s for header alignment ", basename(argv[0]));
         printf("%-66s ------ ", cmd_str); fflush(stdout);
         free(cmd_str);
+        if (verbose) printf("\n");
     }
+    cmode[0] = 0;
+    cmode[1] = NC_64BIT_OFFSET;
+    cmode[2] = NC_64BIT_DATA;
 
-    nerrs += tst_fmt(filename, 0);
-    nerrs += tst_fmt(filename, NC_64BIT_OFFSET);
-    nerrs += tst_fmt(filename, NC_64BIT_DATA);
+    for (has_fix_vars=1; has_fix_vars>=0; has_fix_vars--) {
+        /* No hints set in environment variable PNETCDF_HINTS.
+         * No hints set in MPI Info object.
+         */
+        unsetenv("PNETCDF_HINTS");
+        for (i=0; i<3; i++) {
+            nerrs += tst_fmt(filename, cmode[i], has_fix_vars, NULL, NULL);
+            if (nerrs > 0) goto main_exit;
+        }
+
+        info_align[0] = 28;  /*  7 x 4 */
+        info_align[1] = 44;  /* 11 x 4 */
+        info_align[2] = 52;  /* 13 x 4 */
+
+        /* No hints set in environment variable PNETCDF_HINTS.
+         * Hints set in MPI Info object.
+         */
+        for (i=0; i<3; i++) {
+            nerrs += tst_fmt(filename, cmode[i], has_fix_vars, NULL,
+                             info_align);
+            if (nerrs > 0) goto main_exit;
+        }
+
+        env_align[0] = 68;  /* 17 x 4 */
+        env_align[1] = 76;  /* 19 x 4 */
+        env_align[2] = 92;  /* 23 x 4 */
+        sprintf(str, "nc_header_align_size=%lld;nc_var_align_size=%lld;nc_record_align_size=%lld\n",
+                env_align[0], env_align[1], env_align[2]);
+        setenv("PNETCDF_HINTS", str, 1);
+
+        /* Set hints in environment variable PNETCDF_HINTS.
+         * No hints set in MPI Info object.
+         */
+        for (i=0; i<3; i++) {
+            nerrs += tst_fmt(filename, cmode[i], has_fix_vars, env_align, NULL);
+            if (nerrs > 0) goto main_exit;
+        }
+
+        /* Set hints in environment variable PNETCDF_HINTS.
+         * Set hints in MPI Info object.
+         */
+        for (i=0; i<3; i++) {
+            nerrs += tst_fmt(filename, cmode[i], has_fix_vars, env_align,
+                             info_align);
+            if (nerrs > 0) goto main_exit;
+        }
+
+        env_align[0] = 68;  /* 17 x 4 */
+        env_align[1] = 0;
+        env_align[2] = 92;  /* 23 x 4 */
+        sprintf(str, "nc_header_align_size=%lld;nc_record_align_size=%lld\n",
+                env_align[0], env_align[2]);
+        setenv("PNETCDF_HINTS", str, 1);
+
+        /* Set hints in environment variable PNETCDF_HINTS.
+         * No hints set in MPI Info object.
+         */
+        for (i=0; i<3; i++) {
+            nerrs += tst_fmt(filename, cmode[i], has_fix_vars, env_align,
+                             info_align);
+            if (nerrs > 0) goto main_exit;
+        }
+
+        env_align[0] = 0;
+        env_align[1] = 76;  /* 19 x 4 */
+        env_align[2] = 92;  /* 23 x 4 */
+        sprintf(str, "nc_var_align_size=%lld;nc_record_align_size=%lld\n",
+                env_align[1], env_align[2]);
+        setenv("PNETCDF_HINTS", str, 1);
+
+        /* Set hints in environment variable PNETCDF_HINTS.
+         * No hints set in MPI Info object.
+         */
+        for (i=0; i<3; i++) {
+            nerrs += tst_fmt(filename, cmode[i], has_fix_vars, env_align,
+                             info_align);
+            if (nerrs > 0) goto main_exit;
+        }
+
+        env_align[0] = 0;
+        env_align[1] = 76;  /* 19 x 4 */
+        env_align[2] = 0;
+        sprintf(str, "nc_var_align_size=%lld\n", env_align[1]);
+        setenv("PNETCDF_HINTS", str, 1);
+
+        /* Set hints in environment variable PNETCDF_HINTS.
+         * No hints set in MPI Info object.
+         */
+        for (i=0; i<3; i++) {
+            nerrs += tst_fmt(filename, cmode[i], has_fix_vars, env_align,
+                             info_align);
+            if (nerrs > 0) goto main_exit;
+        }
+
+        env_align[0] = 0;  /* 17 x 4 */
+        env_align[1] = 0;
+        env_align[2] = 92;  /* 23 x 4 */
+        sprintf(str, "nc_record_align_size=%lld\n", env_align[2]);
+        setenv("PNETCDF_HINTS", str, 1);
+
+        /* Set hints in environment variable PNETCDF_HINTS.
+         * No hints set in MPI Info object.
+         */
+        for (i=0; i<3; i++) {
+            nerrs += tst_fmt(filename, cmode[i], has_fix_vars, env_align,
+                             info_align);
+            if (nerrs > 0) goto main_exit;
+        }
+    }
 
     /* check if PnetCDF freed all internal malloc */
     MPI_Offset malloc_size, sum_size;
@@ -514,6 +653,7 @@ int main(int argc, char** argv)
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }
 
+main_exit:
     MPI_Allreduce(MPI_IN_PLACE, &nerrs, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
     if (rank == 0) {
         if (nerrs) printf(FAIL_STR,nerrs);
@@ -523,3 +663,4 @@ int main(int argc, char** argv)
     MPI_Finalize();
     return (nerrs > 0);
 }
+


### PR DESCRIPTION
(Text below also appears in sneak_peek.md)
* Clarifications about of PnetCDF hints
  + There are three ways in PnetCDF for user to set hints to align the starting
    file offset for the data section (header extent) and record variable
    section.
    1. through a call to API `nc_header_align_size` by setting arguments of
       `h_minfree`, `v_align`, `v_minfree`, and `r_align`.
    2. through an MPI info object passed to calls of `ncmpi_create()` and
       `ncmpi_open()`. Hints are `nc_header_align_size`, `nc_var_align_size`,
       and `nc_record_align_size`.
    3. through a run-time environment variable `PNETCDF_HINTS`. Hints are
       `nc_header_align_size`, `nc_var_align_size`, and `nc_record_align_size`.
  + As the same hints may be set by one or more of the above methods, PnetCDF
    implements the following hint precedence.
    * `PNETCDF_HINTS` > `ncmpi__enddef()` > `MPI info`.
    * 1st priority: hints set in the environment variable `PNETCDF_HINTS`, e.g.
      `PNETCDF_HINTS="nc_var_align_size=1048576"`. Making this the first
      priority is because it allows to run the same application executable
      without source code modification using different alignment settings
      through a run-time environment variable.
    * 2nd priority: hints set in the MPI info object passed to calls of
      `ncmpi_create()` and `ncmpi_open()`, e.g.
      `MPI_Info_set("nc_var_align_size", "1048576");`. The reasoning is when a
      3rd-party library built on top of PnetCDF implements its codes using
      'ncmpi__enddef'. An application that uses such 3rd-party library can pass
      an MPI info object to it, which further passes the info to PnetCDF. This
      precedence allows that application to exercise different hints without
      changing the 3rd-party library's source codes.
    * 3rd priority: hints used in the arguments of `ncmpi__enddef()`, e.g.
      `ncmpi__enddef(..., v_align=1048576,...)`.
  + PnetCDF I/O hint `nc_header_align_size` is essentially the same as hint
    `nc_var_align_size`, but its name appears to be closer to the hint's
    intent, i.e. to reserve some space for the header growth in the future when
    new data objects are added. Please note when both hints are set, only hint
    `nc_var_align_size` will take effect and `nc_header_align_size` ignored.
  + When there is no fix-sized variable (i.e. non-record variable) defined,
    argument `v_minfree` passed to `ncmpi__enddef()` is ignored. In this
    case, users should set `h_minfree`, if an extra header space is desired.
  + When there is no fix-sized variables defined and none of hints
    `nc_header_align_size`, `nc_var_align_size`, or argument `v_align` is set,
    `nc_record_align_size` or `r_align`, if set, will be used to align the
    header extent.