### PR TITLE
Fix errors when building an RPM

### DIFF
--- a/src/packaging/Makefile.am
+++ b/src/packaging/Makefile.am
@@ -12,6 +12,6 @@ pkgconfig_DATA = pnetcdf.pc
 # GNU autoconf allows DESTDIR variable when running 'make install' which will
 # prepend it before all installation names.
 install-data-hook:
-	$(SED_I) -e 's|INSTALL_PREFIX|$(DESTDIR)$(prefix)|g ; s|INSTALL_EXEC_PREFIX|$(DESTDIR)$(exec_prefix)|g' $(DESTDIR)$(libdir)/pkgconfig/pnetcdf.pc
+	$(SED_I) -e 's|INSTALL_PREFIX|$(prefix)|g ; s|INSTALL_EXEC_PREFIX|$(exec_prefix)|g' $(DESTDIR)$(libdir)/pkgconfig/pnetcdf.pc
 
 

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -36,6 +36,6 @@ dist-hook:
 # GNU autoconf allows DESTDIR variable when running 'make install' which will
 # prepend it before all installation names.
 install-exec-hook:
-	$(SED_I) -e 's|INSTALL_PREFIX|$(DESTDIR)$(prefix)|g ; s|INSTALL_EXEC_PREFIX|$(DESTDIR)$(exec_prefix)|g' $(DESTDIR)$(bindir)/pnetcdf-config
+	$(SED_I) -e 's|INSTALL_PREFIX|$(prefix)|g ; s|INSTALL_EXEC_PREFIX|$(exec_prefix)|g' $(DESTDIR)$(bindir)/pnetcdf-config
 	chmod +x $(DESTDIR)$(bindir)/pnetcdf-config
 


### PR DESCRIPTION
Building an RPM for OpenHPC of pnetcdf fails with:
```
+ /usr/lib/rpm/check-buildroot
/home/ohpc/rpmbuild/BUILDROOT/pnetcdf-gnu14-mvapich2-ohpc-1.14.0-19999.ci.ohpc.x86_64/opt/ohpc/pub/libs/gnu14/mvapich2/pnetcdf/1.14.0/bin/pnetcdf-config:prefix=/home/ohpc/rpmbuild/BUILDROOT/pnetcdf-gnu14-mvapich2-ohpc-1.14.0-19999.ci.ohpc.x86_64/opt/ohpc/pub/libs/gnu14/mvapich2/pnetcdf/1.14.0
/home/ohpc/rpmbuild/BUILDROOT/pnetcdf-gnu14-mvapich2-ohpc-1.14.0-19999.ci.ohpc.x86_64/opt/ohpc/pub/libs/gnu14/mvapich2/pnetcdf/1.14.0/bin/pnetcdf-config:exec_prefix=/home/ohpc/rpmbuild/BUILDROOT/pnetcdf-gnu14-mvapich2-ohpc-1.14.0-19999.ci.ohpc.x86_64/opt/ohpc/pub/libs/gnu14/mvapich2/pnetcdf/1.14.0
/home/ohpc/rpmbuild/BUILDROOT/pnetcdf-gnu14-mvapich2-ohpc-1.14.0-19999.ci.ohpc.x86_64/opt/ohpc/pub/libs/gnu14/mvapich2/pnetcdf/1.14.0/lib/pkgconfig/pnetcdf.pc:prefix=/home/ohpc/rpmbuild/BUILDROOT/pnetcdf-gnu14-mvapich2-ohpc-1.14.0-19999.ci.ohpc.x86_64/opt/ohpc/pub/libs/gnu14/mvapich2/pnetcdf/1.14.0
/home/ohpc/rpmbuild/BUILDROOT/pnetcdf-gnu14-mvapich2-ohpc-1.14.0-19999.ci.ohpc.x86_64/opt/ohpc/pub/libs/gnu14/mvapich2/pnetcdf/1.14.0/lib/pkgconfig/pnetcdf.pc:exec_prefix=/home/ohpc/rpmbuild/BUILDROOT/pnetcdf-gnu14-mvapich2-ohpc-1.14.0-19999.ci.ohpc.x86_64/opt/ohpc/pub/libs/gnu14/mvapich2/pnetcdf/1.14.0 
Found '/home/ohpc/rpmbuild/BUILDROOT/pnetcdf-gnu14-mvapich2-ohpc-1.14.0-19999.ci.ohpc.x86_64' in installed files; aborting
```
The reason is that the variable DESTDIR is added to the path of the binary location. This is, however, wrong. DESTDIR is the directory where the files are installed but not where they are located in the final RPM.

Keeping DESTDIR for the file location is correct but not for the path where the files are located.

With this patch applied, it is possible to create an RPM without errors like above.