### PR TITLE
Handle GCC 15 errors

### DIFF
--- a/src/utils/ncmpidump/ncmpidump.h
+++ b/src/utils/ncmpidump/ncmpidump.h
@@ -16,7 +16,9 @@
 #define  Printf  (void) printf
 
 typedef int boolean;
+#if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311L
 enum {false=0, true=1};
+#endif
 
 struct ncdim {			/* dimension */
     char name[NC_MAX_NAME];


### PR DESCRIPTION
Without this patch GCC 15 will create this error:

```
 In file included from ncmpidump.c:22:
 ncmpidump.h:19:7: error: cannot use keyword 'false' as enumeration constant
    19 | enum {false=0, true=1};
       |       ^~~~~
 ncmpidump.h:19:7: note: 'false' is a keyword with '-std=c23' onwards
```