### PR TITLE
Silence malloc compilation warning

### DIFF
--- a/src/drivers/include/common.h
+++ b/src/drivers/include/common.h
@@ -73,19 +73,11 @@ extern void
 NCI_Free_fn(void *ptr, const int lineno, const char *func,
             const char *filename);
 
-#if defined(PNETCDF_DEBUG) || defined(PNC_MALLOC_TRACE)
 #define NCI_Malloc(a)    NCI_Malloc_fn(a,__LINE__,__func__,__FILE__)
 #define NCI_Strdup(a)    NCI_Strdup_fn(a,__LINE__,__func__,__FILE__)
 #define NCI_Calloc(a,b)  NCI_Calloc_fn(a,b,__LINE__,__func__,__FILE__)
 #define NCI_Realloc(a,b) NCI_Realloc_fn(a,b,__LINE__,__func__,__FILE__)
 #define NCI_Free(a)      NCI_Free_fn(a,__LINE__,__func__,__FILE__)
-#else
-#define NCI_Malloc(a)    malloc(a)
-#define NCI_Strdup(a)    strdup(a)
-#define NCI_Calloc(a,b)  calloc(a,b)
-#define NCI_Realloc(a,b) realloc(a,b)
-#define NCI_Free(a)      free(a)
-#endif
 
 extern int
 ncmpii_inq_malloc_size(size_t *size);


### PR DESCRIPTION
Check request size against PTRDIFF_MAX before calling malloc, calloc, and realloc. Otherwise, gcc 9 and later complain with thie warning message.
```
In file included from var_getput.c:17:
var_getput.c: In function 'ncmpi_mput_var':
../../../PnetCDF/src/drivers/include/common.h:83:26: warning: argument 1 range [18446744065119617024, 18446744073709551612] exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
   83 | #define NCI_Malloc(a)    malloc(a)
      |                          ^~~~~~~~~
var_getput.c:20555:19: note: in expansion of macro 'NCI_Malloc'
20555 |     reqs = (int*) NCI_Malloc(sizeof(int) * nvars);
      |                   ^~~~~~~~~~
In file included from var_getput.c:12:
/usr/include/stdlib.h:539:14: note: in a call to allocation function
'malloc' declared here
  539 | extern void *malloc (size_t __size) __THROW __attribute_malloc__ __wur;
      |              ^~~~~~
```