### PR TITLE
printf format for MPI_Offset

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1284,6 +1284,47 @@ if test "$ac_cv_sizeof_MPI_Offset" -lt "8"; then
    -----------------------------------------------------------------------])
 fi
 
+MPI_OFFSET_FMT="%lld"
+if test "x$GCC" = xyes ; then
+   # check if MPI_Offset is long long int or long int.
+   AC_MSG_CHECKING([MPI_Offset type])
+   saved_CFLAGS=$CFLAGS
+   MPI_Offset_type="unknown"
+   CFLAGS="$CFLAGS -Werror=format"
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>
+                                        #include <mpi.h>]],
+                                      [[printf("%lld\n", (MPI_Offset)1);]])],
+                     [MPI_Offset_is_long_long=yes],
+                     [MPI_Offset_is_long_long=no])
+   if test $MPI_Offset_is_long_long = no ; then
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>
+                                           #include <mpi.h>]],
+                                         [[printf("%ld\n", (MPI_Offset)1);]])],
+                        [MPI_Offset_is_long=yes],
+                        [MPI_Offset_is_long=no])
+      if test $MPI_Offset_is_long = no ; then
+         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>
+                                              #include <mpi.h>]],
+                                            [[printf("%d\n", (MPI_Offset)1);]])],
+                           [MPI_Offset_is_int=yes],
+                           [MPI_Offset_is_int=no])
+         if test $MPI_Offset_is_int = yes ; then
+            MPI_Offset_type="int"
+            MPI_OFFSET_FMT="%d"
+         fi
+      else
+         MPI_Offset_type="long"
+         MPI_OFFSET_FMT="%ld"
+      fi
+   else
+      MPI_Offset_type="long long"
+      MPI_OFFSET_FMT="%lld"
+   fi
+   AC_MSG_RESULT([$MPI_Offset_type])
+   CFLAGS=$saved_CFLAGS
+fi
+AC_DEFINE_UNQUOTED([OFFFMT], ["$MPI_OFFSET_FMT"], [MPI_Offset printf format])
+
 AC_CHECK_SIZEOF([MPI_Aint], [], [#include <mpi.h>])
 AM_CONDITIONAL(SIZEOF_MPI_AINT_IS_4, [test x$ac_cv_sizeof_MPI_Aint = x4])
 

--- a/src/dispatchers/cdl_header_parser.c
+++ b/src/dispatchers/cdl_header_parser.c
@@ -63,6 +63,7 @@ typedef long long MPI_Offset;
 #define NC_ENFILE   (-34)  /**< Too many netcdfs open */
 #define NC_EBADDIM  (-46)  /**< Invalid dimension id or name */
 #define NC_ENOTNC   (-51)  /**< Not a netcdf file */
+#define NC_ENOMEM   (-61)  /**< Memory allocation (malloc) failure */
 #define NC_EFILE    (-204) /**< Unknown error in file operation */
 #define NC_ENOENT   (-220) /**< File does not exist */
 
@@ -1015,7 +1016,7 @@ int main(int argc, char **argv)
     /* retrieve metadata of each dimension defined in the CDL file */
     for (i=0; i<ndims; i++) {
         err = cdl_hdr_inq_dim(hid, i, &name, &size); ERR
-        printf("\t name %s size %lld\n",name, size);
+        printf("\t name %s size " OFFFMT "\n",name, size);
     }
 
     /* retrieve number of variables defined in the CDL file */
@@ -1039,10 +1040,10 @@ int main(int argc, char **argv)
             err = cdl_hdr_inq_attr(hid, i, j, &name, &xtype, &nelems, &value);
             ERR
             if (xtype == NC_CHAR)
-                printf("\t\tattr %s type %d nelems %lld (%s)\n",
+                printf("\t\tattr %s type %d nelems "OFFFMT" (%s)\n",
                        name, xtype,nelems,(char*)value);
             else
-                printf("\t\tattr %s type %d nelems %lld\n",
+                printf("\t\tattr %s type %d nelems "OFFFMT"\n",
                        name, xtype, nelems);
         }
     }
@@ -1058,10 +1059,10 @@ int main(int argc, char **argv)
         err = cdl_hdr_inq_attr(hid, NC_GLOBAL, i, &name, &xtype, &nelems, &value);
         ERR
         if (xtype == NC_CHAR)
-            printf("\t name %s type %d nelems %lld (%s)\n",
+            printf("\t name %s type %d nelems "OFFFMT" (%s)\n",
                     name, xtype, nelems,(char*)value);
         else
-            printf("\t name %s type %d nelems %lld\n",
+            printf("\t name %s type %d nelems "OFFFMT"\n",
                     name, xtype, nelems);
     }
 

--- a/src/dispatchers/var_getput.m4
+++ b/src/dispatchers/var_getput.m4
@@ -116,10 +116,10 @@ int check_EEDGE(const MPI_Offset *start,
             pncp->driver->inq_var(pncp->ncp, varid, name, NULL, NULL,       \
                                   NULL, NULL, NULL, NULL, NULL);            \
             if (stride != NULL)                                             \
-                fprintf(stderr, "Rank %d: NC_EEDGE variable %s: shape[%d]=%lld but start[%d]=%lld count[%d]=%lld stride[%d]=%lld\n", \
+                fprintf(stderr, "Rank %d: NC_EEDGE variable %s: shape[%d]="OFFFMT" but start[%d]="OFFFMT" count[%d]="OFFFMT" stride[%d]="OFFFMT"\n", \
                 _rank, name, dim, shape[dim], dim, start[dim], dim, count[dim], dim, stride[dim]); \
             else                                                            \
-                fprintf(stderr, "Rank %d: NC_EEDGE variable %s: shape[%d]=%lld but start[%d]=%lld count[%d]=%lld\n", \
+                fprintf(stderr, "Rank %d: NC_EEDGE variable %s: shape[%d]="OFFFMT" but start[%d]="OFFFMT" count[%d]="OFFFMT"\n", \
                 _rank, name, dim, shape[dim], dim, start[dim], dim, count[dim]); \
         }                                                                   \
     }                                                                       \

--- a/src/drivers/ncmpio/ncmpio_enddef.c
+++ b/src/drivers/ncmpio/ncmpio_enddef.c
@@ -118,7 +118,7 @@ move_file_block(NC         *ncp,
             get_size = pread(fd, buf, chunk_size, off_from);
             if (get_size < 0) {
                 fprintf(stderr,
-                "Error at %s line %d: pread file %s offset %lld size %zd (%s)\n",
+                "Error at %s line %d: pread file %s offset "OFFFMT" size %zd (%s)\n",
                 __func__,__LINE__,path,off_from,chunk_size,strerror(errno));
                 DEBUG_RETURN_ERROR(NC_EREAD)
             }
@@ -138,7 +138,7 @@ move_file_block(NC         *ncp,
             put_size = pwrite(fd, buf, get_size, off_to);
             if (put_size < 0) {
                 fprintf(stderr,
-                "Error at %s line %d: pwrite file %s offset %lld size %zd (%s)\n",
+                "Error at %s line %d: pwrite file %s offset "OFFFMT" size %zd (%s)\n",
                 __func__,__LINE__,path,off_to,get_size,strerror(errno));
                 DEBUG_RETURN_ERROR(NC_EREAD)
             }
@@ -953,7 +953,7 @@ ncmpio_NC_check_voffs(NC *ncp)
         NC_var *varp = ncp->vars.value[i];
         if (varp->begin < ncp->xsz) {
             if (ncp->safe_mode) {
-                printf("Variable %s begin offset (%lld) is less than file header extent (%lld)\n",
+                printf("Variable %s begin offset ("OFFFMT") is less than file header extent ("OFFFMT")\n",
                        varp->name, varp->begin, ncp->xsz);
             }
             NCI_Free(var_off_len);
@@ -982,7 +982,7 @@ ncmpio_NC_check_voffs(NC *ncp)
             if (ncp->safe_mode) {
                 NC_var *var_cur = ncp->vars.value[var_off_len[i].ID];
                 NC_var *var_prv = ncp->vars.value[var_off_len[i-1].ID];
-                printf("Variable %s begin offset (%lld) overlaps variable %s (begin=%lld, length=%lld)\n",
+                printf("Variable %s begin offset ("OFFFMT") overlaps variable %s (begin="OFFFMT", length="OFFFMT")\n",
                        var_cur->name, var_cur->begin, var_prv->name, var_prv->begin, var_prv->len);
             }
             NCI_Free(var_off_len);
@@ -994,7 +994,7 @@ ncmpio_NC_check_voffs(NC *ncp)
 
     if (ncp->begin_rec < max_var_end) {
         if (ncp->safe_mode)
-            printf("Record variable section begin (%lld) is less than fixed-size variable section end (%lld)\n",
+            printf("Record variable section begin ("OFFFMT") is less than fixed-size variable section end ("OFFFMT")\n",
                    ncp->begin_rec, max_var_end);
         NCI_Free(var_off_len);
         DEBUG_RETURN_ERROR(NC_ENOTNC)
@@ -1030,7 +1030,7 @@ check_rec_var:
             if (ncp->safe_mode) {
                 NC_var *var_cur = ncp->vars.value[var_off_len[i].ID];
                 NC_var *var_prv = ncp->vars.value[var_off_len[i-1].ID];
-                printf("Variable %s begin offset (%lld) overlaps variable %s (begin=%lld, length=%lld)\n",
+                printf("Variable %s begin offset ("OFFFMT") overlaps variable %s (begin="OFFFMT", length="OFFFMT")\n",
                        var_cur->name, var_cur->begin, var_prv->name, var_prv->begin, var_prv->len);
             }
             NCI_Free(var_off_len);
@@ -1052,10 +1052,10 @@ check_rec_var:
         if (varp->begin < prev_off) {
             if (ncp->safe_mode) {
                 if (i == 0)
-                    printf("Variable \"%s\" begin offset (%lld) is less than header extent (%lld)\n",
+                    printf("Variable \"%s\" begin offset ("OFFFMT") is less than header extent ("OFFFMT")\n",
                            varp->name, varp->begin, prev_off);
                 else
-                    printf("Variable \"%s\" begin offset (%lld) is less than previous variable \"%s\" end offset (%lld)\n",
+                    printf("Variable \"%s\" begin offset ("OFFFMT") is less than previous variable \"%s\" end offset ("OFFFMT")\n",
                            varp->name, varp->begin, ncp->vars.value[prev]->name, prev_off);
             }
             DEBUG_RETURN_ERROR(NC_ENOTNC)
@@ -1066,7 +1066,7 @@ check_rec_var:
 
     if (ncp->begin_rec < prev_off) {
         if (ncp->safe_mode)
-            printf("Record variable section begin offset (%lld) is less than fixed-size variable section end offset (%lld)\n",
+            printf("Record variable section begin offset ("OFFFMT") is less than fixed-size variable section end offset ("OFFFMT")\n",
                    ncp->begin_rec, prev_off);
         DEBUG_RETURN_ERROR(NC_ENOTNC)
     }
@@ -1083,13 +1083,13 @@ check_rec_var:
 
         if (varp->begin < prev_off) {
             if (ncp->safe_mode) {
-                printf("Variable \"%s\" begin offset (%lld) is less than previous variable end offset (%lld)\n",
+                printf("Variable \"%s\" begin offset ("OFFFMT") is less than previous variable end offset ("OFFFMT")\n",
                            varp->name, varp->begin, prev_off);
                 if (i == 0)
-                    printf("Variable \"%s\" begin offset (%lld) is less than record variable section begin offset (%lld)\n",
+                    printf("Variable \"%s\" begin offset ("OFFFMT") is less than record variable section begin offset ("OFFFMT")\n",
                            varp->name, varp->begin, prev_off);
                 else
-                    printf("Variable \"%s\" begin offset (%lld) is less than previous variable \"%s\" end offset (%lld)\n",
+                    printf("Variable \"%s\" begin offset ("OFFFMT") is less than previous variable \"%s\" end offset ("OFFFMT")\n",
                            varp->name, varp->begin, ncp->vars.value[prev]->name, prev_off);
             }
             DEBUG_RETURN_ERROR(NC_ENOTNC)
@@ -1312,9 +1312,9 @@ ncmpio__enddef(void       *ncdp,
     /* reflect the hint changes to the MPI info object, so the user can inquire
      * what the true hint values are being used
      */
-    sprintf(value, "%lld", ncp->v_align);
+    sprintf(value, OFFFMT, ncp->v_align);
     MPI_Info_set(ncp->mpiinfo, "nc_var_align_size", value);
-    sprintf(value, "%lld", ncp->r_align);
+    sprintf(value, OFFFMT, ncp->r_align);
     MPI_Info_set(ncp->mpiinfo, "nc_record_align_size", value);
 
 #ifdef ENABLE_SUBFILING

--- a/src/drivers/ncmpio/ncmpio_file_io.c
+++ b/src/drivers/ncmpio/ncmpio_file_io.c
@@ -56,7 +56,7 @@ ncmpio_read_write(NC           *ncp,
     }
     else if (btype_size == MPI_UNDEFINED) {
 #ifdef PNETCDF_DEBUG
-        fprintf(stderr,"%d: %s line %d: btype_size MPI_UNDEFINED buf_count=%lld\n",
+        fprintf(stderr,"%d: %s line %d: btype_size MPI_UNDEFINED buf_count="OFFFMT"\n",
                 ncp->rank, __func__,__LINE__,buf_count);
 #endif
         DEBUG_ASSIGN_ERROR(err, NC_EINTOVERFLOW)
@@ -99,7 +99,7 @@ ncmpio_read_write(NC           *ncp,
         if (buf_count > NC_MAX_INT) {
             if (coll_indep == NC_REQ_COLL) {
 #ifdef PNETCDF_DEBUG
-                fprintf(stderr,"%d: %s line %d:  NC_EINTOVERFLOW buf_count=%lld\n",
+                fprintf(stderr,"%d: %s line %d:  NC_EINTOVERFLOW buf_count="OFFFMT"\n",
                         ncp->rank, __func__,__LINE__,buf_count);
 #endif
                 DEBUG_ASSIGN_ERROR(status, NC_EINTOVERFLOW)
@@ -221,7 +221,7 @@ ncmpio_read_write(NC           *ncp,
         if (buf_count > NC_MAX_INT) {
             if (coll_indep == NC_REQ_COLL) {
 #ifdef PNETCDF_DEBUG
-                fprintf(stderr,"%d: %s line %d:  NC_EINTOVERFLOW buf_count=%lld\n",
+                fprintf(stderr,"%d: %s line %d:  NC_EINTOVERFLOW buf_count="OFFFMT"\n",
                         ncp->rank, __func__,__LINE__,buf_count);
 #endif
                 DEBUG_ASSIGN_ERROR(status, NC_EINTOVERFLOW)

--- a/src/drivers/ncmpio/ncmpio_file_misc.c
+++ b/src/drivers/ncmpio/ncmpio_file_misc.c
@@ -382,10 +382,10 @@ ncmpio_inq_misc(void       *ncdp,
          * user.
          */
 
-        sprintf(value, "%lld", ncp->v_align);
+        sprintf(value, OFFFMT, ncp->v_align);
         MPI_Info_set(*info_used, "nc_var_align_size", value);
 
-        sprintf(value, "%lld", ncp->r_align);
+        sprintf(value, OFFFMT, ncp->r_align);
         MPI_Info_set(*info_used, "nc_record_align_size", value);
 
         sprintf(value, "%d", ncp->chunk);
@@ -398,7 +398,7 @@ ncmpio_inq_misc(void       *ncdp,
         else
             MPI_Info_set(*info_used, "nc_in_place_swap", "auto");
 
-        sprintf(value, "%lld", ncp->ibuf_size);
+        sprintf(value, OFFFMT, ncp->ibuf_size);
         MPI_Info_set(*info_used, "nc_ibuf_size", value);
 
 #ifdef ENABLE_SUBFILING

--- a/src/drivers/ncmpio/ncmpio_subfile.c
+++ b/src/drivers/ncmpio/ncmpio_subfile.c
@@ -378,7 +378,7 @@ int ncmpio_subfile_partition(NC *ncp)
                     max = (MPI_Offset)yy-(yy-(MPI_Offset)yy==0.0?1:0);
                     if (max >= dim_sz0) max = dim_sz0-1;
 #ifdef SUBFILE_DEBUG
-                    if (myrank == 0) printf("subfile(%d): min=%lld, max=%lld\n", jj, min, max);
+                    if (myrank == 0) printf("subfile(%d): min="OFFFMT", max="OFFFMT"\n", jj, min, max);
 #endif
                     if (j == par_dim_id) { /* partitioning dims? */
                         sf_range[jj][j][0] = min;
@@ -621,12 +621,12 @@ ncmpio_subfile_getput_vars(NC               *ncp,
                     jj++;
                 else {
 #ifdef SUBFILE_DEBUG
-                    printf("rank(%d): var(%s): i=%d, j=%d, ii=%lld, jj=%lld, kk=%lld, jx=%d\n", myrank, varp->name, i, j, ii, jj, kk, jx);
+                    printf("rank(%d): var(%s): i=%d, j=%d, ii="OFFFMT", jj="OFFFMT", kk="OFFFMT", jx=%d\n", myrank, varp->name, i, j, ii, jj, kk, jx);
 #endif
                     if (kk == 0) {
                         my_req[aproc].start[jx] = ii;
 #ifdef SUBFILE_DEBUG
-                        printf("rank(%d): var(%s): my_req[%d].start[%d]=%lld\n",
+                        printf("rank(%d): var(%s): my_req[%d].start[%d]="OFFFMT"\n",
                                myrank, varp->name, aproc, jx, ii);
 #endif
                     }
@@ -817,7 +817,7 @@ ncmpio_subfile_getput_vars(NC               *ncp,
         /* making diff is necessary?? */
         diff[i] = ABS(my_req[myrank].start_org[i]-start[i])/stride_count;
 #ifdef SUBFILE_DEBUG
-        if (myrank == 0) printf("rank(%d): my_req[%d].start_org[%d]=%d, start[%d]=%d, diff[%d]=%lld\n", myrank,
+        if (myrank == 0) printf("rank(%d): my_req[%d].start_org[%d]=%d, start[%d]=%d, diff[%d]="OFFFMT"\n", myrank,
                myrank, i, my_req[myrank].start_org[i], i, start[i], i, diff[i]);
 #endif
     }

--- a/src/drivers/ncmpio/ncmpio_util.c
+++ b/src/drivers/ncmpio/ncmpio_util.c
@@ -57,7 +57,7 @@ void ncmpio_set_pnetcdf_hints(NC *ncp,
     if (ncp->info_v_align == -1)
         sprintf(value, "%d", FILE_ALIGNMENT_DEFAULT);
     else
-        sprintf(value, "%lld", ncp->info_v_align);
+        sprintf(value, OFFFMT, ncp->info_v_align);
     MPI_Info_set(info_used, "nc_var_align_size", value);
 
     if (user_info != MPI_INFO_NULL) {
@@ -78,7 +78,7 @@ void ncmpio_set_pnetcdf_hints(NC *ncp,
          */
         if (info_h_align >= 0 && ncp->info_v_align == -1) {
             ncp->info_v_align = info_h_align;
-            sprintf(value, "%lld", ncp->info_v_align);
+            sprintf(value, OFFFMT, ncp->info_v_align);
             MPI_Info_set(info_used, "nc_var_align_size", value);
         }
     }
@@ -98,7 +98,7 @@ void ncmpio_set_pnetcdf_hints(NC *ncp,
     if (ncp->info_r_align == -1)
         sprintf(value, "%d", FILE_ALIGNMENT_DEFAULT);
     else
-        sprintf(value, "%lld", ncp->info_r_align);
+        sprintf(value, OFFFMT, ncp->info_r_align);
     MPI_Info_set(info_used, "nc_record_align_size", value);
 
     ncp->chunk = PNC_DEFAULT_CHUNKSIZE;
@@ -154,7 +154,7 @@ void ncmpio_set_pnetcdf_hints(NC *ncp,
             if (errno == 0 && ibuf_size >= 0) ncp->ibuf_size = ibuf_size;
         }
     }
-    sprintf(value, "%lld", ncp->ibuf_size);
+    sprintf(value, OFFFMT, ncp->ibuf_size);
     MPI_Info_set(info_used, "nc_ibuf_size", value);
 
 #ifdef ENABLE_SUBFILING

--- a/src/utils/ncmpidiff/ncmpidiff.c
+++ b/src/utils/ncmpidiff/ncmpidiff.c
@@ -237,13 +237,13 @@
                 pos /= shape[_i];                                            \
             }                                                                \
             if (worst == -1)                                                 \
-                printf("DIFF: variable \"%s\" of type \"%s\" at element [%lld", \
+                printf("DIFF: variable \"%s\" of type \"%s\" at element ["OFFFMT, \
                        name[0], get_type(xtype[0]), diffStart[0]);           \
             else                                                             \
-                printf("DIFF (tolerance): variable \"%s\" of type \"%s\" at element [%lld", \
+                printf("DIFF (tolerance): variable \"%s\" of type \"%s\" at element ["OFFFMT, \
                        name[0], get_type(xtype[0]), diffStart[0]);           \
             for (_i=1; _i<ndims[0]; _i++)                                    \
-                printf(", %lld", diffStart[_i]);                             \
+                printf(", "OFFFMT, diffStart[_i]);                           \
             printf("] of value %g vs %g (difference = %e)\n", v1,v2,v1-v2);  \
             free(diffStart);                                                 \
         }                                                                    \
@@ -569,13 +569,13 @@ int main(int argc, char **argv)
             /* compare attribute length */
             if (attlen[0] != attlen[1]) {
                 if (!quiet)
-                    printf("DIFF: global attribute \"%s\" length (%lld) != (%lld)\n",
+                    printf("DIFF: global attribute \"%s\" length ("OFFFMT") != ("OFFFMT")\n",
                            name[0],attlen[0],attlen[1]);
                 numHeadDIFF++;
                 continue; /* loop i */
             }
             else if (verbose)
-                printf("\tSAME: length (%lld)\n",attlen[0]);
+                printf("\tSAME: length ("OFFFMT")\n",attlen[0]);
 
             /* compare attribute contents */
             switch (xtype[0]) {
@@ -634,13 +634,13 @@ int main(int argc, char **argv)
             if (dimlen[0] != dimlen[1]) {
                 /* cast to quiet warning on 32 bit platforms */
                 if (!quiet)
-                    printf("DIFF: dimension \"%s\" length (%lld) != (%lld)\n",
-                           name[0],(long long int)dimlen[0],(long long int)dimlen[1]);
+                    printf("DIFF: dimension \"%s\" length ("OFFFMT") != ("OFFFMT")\n",
+                           name[0],dimlen[0],dimlen[1]);
                 numHeadDIFF++;
             }
             else if (verbose)
-                printf("\tSAME: dimension \"%s\" length (%lld)\n",
-                       name[0],(long long int)dimlen[0]);
+                printf("\tSAME: dimension \"%s\" length ("OFFFMT")\n",
+                       name[0],dimlen[0]);
         }
 
         /* check dimensions in 2nd file but not in 1st file */
@@ -739,12 +739,12 @@ cmp_vars:
                     /* compare variable dimension j's length */
                     if (dimlen[0] != dimlen[1]) {
                         if (!quiet)
-                            printf("DIFF: variable \"%s\" of type \"%s\" dimension %d's length (%lld) != (%lld)\n",
-                                   name[0],get_type(xtype[0]),j,(long long int)dimlen[0],(long long int)dimlen[1]);
+                            printf("DIFF: variable \"%s\" of type \"%s\" dimension %d's length ("OFFFMT") != ("OFFFMT")\n",
+                                   name[0],get_type(xtype[0]),j,dimlen[0],dimlen[1]);
                         numHeadDIFF++;
                     }
                     else if (verbose)
-                        printf("\t\tSAME: length (%lld)\n",(long long int)dimlen[0]);
+                        printf("\t\tSAME: length ("OFFFMT")\n",dimlen[0]);
                 }
             }
 
@@ -791,13 +791,13 @@ cmp_vars:
                 /* compare attribute nelems */
                 if (attlen[0] != attlen[1]) {
                     if (!quiet)
-                        printf("DIFF: variable \"%s\" attribute \"%s\" length (%lld) != (%lld)\n",
-                               name[0],attrname,(long long int)attlen[0],(long long int)attlen[1]);
+                        printf("DIFF: variable \"%s\" attribute \"%s\" length ("OFFFMT") != ("OFFFMT")\n",
+                               name[0],attrname,attlen[0],attlen[1]);
                     numHeadDIFF++;
                     continue; /* skip this attribute */
                 }
                 else if (verbose)
-                    printf("\t\tSAME: length (%lld)\n",(long long int)attlen[0]);
+                    printf("\t\tSAME: length ("OFFFMT")\n",attlen[0]);
 
                 /* compare attribute contents */
                 switch (xtype[0]) {
@@ -959,15 +959,15 @@ cmp_vars:
             if (dimlen[0] != dimlen[1]) {
                 if (!check_header) { /* if header has not been checked */
                     if (!rank && !quiet)
-                        printf("DIFF: variable \"%s\" of type \"%s\" dimension %d's length (%lld) != (%lld)\n",
-                               name[0],get_type(xtype[0]),j,(long long int)dimlen[0],(long long int)dimlen[1]);
+                        printf("DIFF: variable \"%s\" of type \"%s\" dimension %d's length ("OFFFMT") != ("OFFFMT")\n",
+                               name[0],get_type(xtype[0]),j,dimlen[0],dimlen[1]);
                     numHeadDIFF++;
                     numVarDIFF++;
                 }
                 break; /* skip this variable */
             }
             else if (!check_header && !rank && verbose)
-                printf("\t\tSAME: length (%lld)\n",(long long int)dimlen[0]);
+                printf("\t\tSAME: length ("OFFFMT")\n",dimlen[0]);
             shape[j] = dimlen[0];
         }
         if (j != ndims[0]) {

--- a/src/utils/ncmpidump/vardata.c
+++ b/src/utils/ncmpidump/vardata.c
@@ -298,14 +298,14 @@ annotate(
       case LANG_C:
 	/* C variable indices */
 	for (id = 0; id < vrank-1; id++)
-	  Printf("%lld,", cor[id]);
-	Printf("%lld", cor[id] + iel);
+	  Printf(OFFFMT",", cor[id]);
+	Printf(OFFFMT, cor[id] + iel);
 	break;
       case LANG_F:
 	/* Fortran variable indices */
-	Printf("%lld", cor[vrank-1] + iel + 1);
+	Printf(OFFFMT, cor[vrank-1] + iel + 1);
 	for (id = vrank-2; id >=0 ; id--) {
-	    Printf(",%lld", 1 + cor[id]);
+	    Printf(","OFFFMT, 1 + cor[id]);
 	}
 	break;
     }

--- a/src/utils/ncvalidator/tst_open.c
+++ b/src/utils/ncvalidator/tst_open.c
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
     MPI_Offset malloc_size;
     err = ncmpi_inq_malloc_size(&malloc_size);
     if (err == NC_NOERR && malloc_size > 0) /* this test is for running 1 process */
-        printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+        printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                malloc_size);
 
 fn_exit:

--- a/test/C/pres_temp_4D_rd.c
+++ b/test/C/pres_temp_4D_rd.c
@@ -210,7 +210,7 @@ fn_exit:
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/C/pres_temp_4D_wr.c
+++ b/test/C/pres_temp_4D_wr.c
@@ -244,7 +244,7 @@ int main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/CXX/nctst.cpp
+++ b/test/CXX/nctst.cpp
@@ -568,7 +568,7 @@ main(int argc, char* argv[])	// test new netCDF interface
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/CXX/test_classic.cpp
+++ b/test/CXX/test_classic.cpp
@@ -88,7 +88,7 @@ int main( int argc, char *argv[] )
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/adios/header.c
+++ b/test/adios/header.c
@@ -122,7 +122,7 @@ int main(int argc, char** argv) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0,
                     MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/adios/var.c
+++ b/test/adios/var.c
@@ -132,7 +132,7 @@ int main(int argc, char** argv) {
     err = ncmpi_get_vara_double_all(ncid, 0, start, count, data); CHECK_ERR
     for(i = 0; i < NY; i++){
         if (fabs(data[i] - (((double)start[0]) + ((double)i) / 100)) > 0.0001){
-            printf("Rank %d: Expect Var 0 [%lld][%d] = %lf, but got %lf\n",
+            printf("Rank %d: Expect Var 0 ["OFFFMT"][%d] = %lf, but got %lf\n",
                     rank, start[0], i, ((double)start[0]) + ((double)i) / 100,
                     data[i]);
             nerrs++;
@@ -143,7 +143,7 @@ int main(int argc, char** argv) {
     count[0] = 1;
     err = ncmpi_get_vara_double_all(ncid, 1, start, count, data); CHECK_ERR
     if (fabs(data[0] - ((double)start[0])) > 0.0001){
-        printf("Rank %d: Expect Var 1 [%lld] = %lf, but got %lf\n", rank,
+        printf("Rank %d: Expect Var 1 ["OFFFMT"] = %lf, but got %lf\n", rank,
                 start[0], ((double)start[0]), data[0]);
         nerrs++;
     }

--- a/test/burst_buffer/bb_bsize.c
+++ b/test/burst_buffer/bb_bsize.c
@@ -179,7 +179,7 @@ int main(int argc, char *argv[]) {
     if (ret == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n", sum_size);
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n", sum_size);
     }
 
 ERROR:

--- a/test/burst_buffer/bb_hints.c
+++ b/test/burst_buffer/bb_hints.c
@@ -109,7 +109,7 @@ int main(int argc, char** argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/burst_buffer/bb_many_reqs.c
+++ b/test/burst_buffer/bb_many_reqs.c
@@ -136,7 +136,7 @@ int main(int argc, char *argv[]) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n", sum_size);
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n", sum_size);
     }
 
     MPI_Allreduce(MPI_IN_PLACE, &nerrs, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);

--- a/test/burst_buffer/bb_nonblocking.c
+++ b/test/burst_buffer/bb_nonblocking.c
@@ -113,7 +113,7 @@ int main(int argc, char *argv[]) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n", sum_size);
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n", sum_size);
     }
 
     MPI_Allreduce(MPI_IN_PLACE, &nerrs, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);

--- a/test/burst_buffer/highdim.c
+++ b/test/burst_buffer/highdim.c
@@ -213,7 +213,7 @@ int main(int argc, char *argv[])
     if (ret == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n", sum_size);
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n", sum_size);
     }
 
 ERROR:

--- a/test/burst_buffer/varn.c
+++ b/test/burst_buffer/varn.c
@@ -125,7 +125,7 @@ int main(int argc, char *argv[]) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n", sum_size);
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n", sum_size);
     }
 
     MPI_Allreduce(MPI_IN_PLACE, &nerrs, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);

--- a/test/cdf_format/cdf_type.c
+++ b/test/cdf_format/cdf_type.c
@@ -176,7 +176,7 @@ int main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/cdf_format/dim_cdf12.c
+++ b/test/cdf_format/dim_cdf12.c
@@ -265,7 +265,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/cdf_format/test_inq_format.c
+++ b/test/cdf_format/test_inq_format.c
@@ -144,7 +144,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/cdf_format/tst_corrupt.c
+++ b/test/cdf_format/tst_corrupt.c
@@ -160,7 +160,7 @@ int main(int argc, char** argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/cdf_format/tst_open_cdf5.c
+++ b/test/cdf_format/tst_open_cdf5.c
@@ -88,7 +88,7 @@ int main(int argc, char** argv) {
     err = ncmpi_inq_malloc_size(&malloc_size);
     if (err == NC_NOERR && malloc_size > 0) {
         /* this test is for running 1 process */
-        printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+        printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                malloc_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/cdl/tst_cdl_hdr_parser.c
+++ b/test/cdl/tst_cdl_hdr_parser.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
         int dimid;
 
         err = cdl_hdr_inq_dim(hid, i, &name, &size); CHECK_ERR
-        if (verbose) printf("\t name %s size %lld\n",name, size);
+        if (verbose) printf("\t name %s size "OFFFMT"\n",name, size);
 
         err = ncmpi_def_dim(ncid, name, size, &dimid); CHECK_ERR
     }
@@ -141,10 +141,10 @@ int main(int argc, char **argv)
             err = cdl_hdr_inq_attr(hid, i, j, &name, &xtype, &nelems, &value); CHECK_ERR
             if (verbose) {
                 if (xtype == NC_CHAR)
-                    printf("\t\tattr %s type %d nelems %lld (%s)\n",
+                    printf("\t\tattr %s type %d nelems "OFFFMT" (%s)\n",
                             name, xtype,nelems,(char*)value);
                 else
-                    printf("\t\tattr %s type %d nelems %lld\n",
+                    printf("\t\tattr %s type %d nelems "OFFFMT"\n",
                            name, xtype, nelems);
             }
 
@@ -160,10 +160,10 @@ int main(int argc, char **argv)
         err = cdl_hdr_inq_attr(hid, NC_GLOBAL, i, &name, &xtype, &nelems, &value);
         if (verbose) {
             if (xtype == NC_CHAR)
-                printf("\t name %s type %d nelems %lld (%s)\n",
+                printf("\t name %s type %d nelems "OFFFMT" (%s)\n",
                         name, xtype, nelems,(char*)value);
             else
-                printf("\t name %s type %d nelems %lld\n",
+                printf("\t name %s type %d nelems "OFFFMT"\n",
                         name, xtype, nelems);
         }
 
@@ -182,7 +182,7 @@ int main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/fandc/csnap.c
+++ b/test/fandc/csnap.c
@@ -150,7 +150,7 @@ int main(int argc, char *argv[]) {
   MPI_Barrier(comm_cart);
 
   if (verbose)
-  printf("%3d   %2d %2d %2d  %4lld %4lld %4lld    %4lld %4lld %4lld   %6lld %6lld %6lld\n",
+  printf("%3d   %2d %2d %2d  "OFFFMT OFFFMT OFFFMT OFFFMT OFFFMT OFFFMT OFFFMT OFFFMT OFFFMT"\n",
          mype, pe_coords[0], pe_coords[1], pe_coords[2],
          totsiz_3d[0], totsiz_3d[1], totsiz_3d[2],
          locsiz_3d[0], locsiz_3d[1], locsiz_3d[2],
@@ -191,7 +191,7 @@ int main(int argc, char *argv[]) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (mype == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/fandc/pnctest.c
+++ b/test/fandc/pnctest.c
@@ -53,7 +53,7 @@ int main (int argc, char *argv[])
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/header/header_consistency.c
+++ b/test/header/header_consistency.c
@@ -395,7 +395,7 @@ int main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/largefile/high_dim_var.c
+++ b/test/largefile/high_dim_var.c
@@ -179,7 +179,7 @@ fn_exit:
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
     if (malloc_size > 0)  ncmpi_inq_malloc_list();

--- a/test/largefile/large_attr.c
+++ b/test/largefile/large_attr.c
@@ -86,7 +86,7 @@ int main(int argc, char** argv)
 
     err = ncmpi_inq_attlen(ncid, NC_GLOBAL, "large_attr", &inq_nelems);
     if (inq_nelems != nelems) {
-        printf("Error at %s line %d: expecting attr nelems %lld but got %lld\n",
+        printf("Error at %s line %d: expecting attr nelems "OFFFMT" but got "OFFFMT"\n",
                __FILE__,__LINE__,nelems,inq_nelems);
         nerrs++;
     }
@@ -139,7 +139,7 @@ int main(int argc, char** argv)
 
     err = ncmpi_inq_attlen(ncid, varid, "large_attr", &inq_nelems);
     if (inq_nelems != nelems) {
-        printf("Error at %s line %d: expecting attr len %lld but got %lld\n",
+        printf("Error at %s line %d: expecting attr len "OFFFMT" but got "OFFFMT"\n",
                __FILE__,__LINE__,nelems,inq_nelems);
         nerrs++;
     }
@@ -190,7 +190,7 @@ int main(int argc, char** argv)
     name = "large_attr_0";
     err = ncmpi_inq_attlen(ncid, NC_GLOBAL, name, &inq_nelems);
     if (inq_nelems != nelems) {
-        printf("Error at %s line %d: expecting attr %s nelems %lld but got %lld\n",
+        printf("Error at %s line %d: expecting attr %s nelems "OFFFMT" but got "OFFFMT"\n",
                __FILE__,__LINE__,name, nelems,inq_nelems);
         nerrs++;
     }
@@ -212,7 +212,7 @@ int main(int argc, char** argv)
     name = "large_attr_1";
     err = ncmpi_inq_attlen(ncid, NC_GLOBAL, name, &inq_nelems);
     if (inq_nelems != nelems) {
-        printf("Error at %s line %d: expecting attr %s nelems %lld but got %lld\n",
+        printf("Error at %s line %d: expecting attr %s nelems "OFFFMT" but got "OFFFMT"\n",
                __FILE__,__LINE__,name, nelems,inq_nelems);
         nerrs++;
     }
@@ -273,7 +273,7 @@ int main(int argc, char** argv)
     name = "large_attr_0";
     err = ncmpi_inq_attlen(ncid, varid, name, &inq_nelems);
     if (inq_nelems != nelems) {
-        printf("Error at %s line %d: expecting attr %s len %lld but got %lld\n",
+        printf("Error at %s line %d: expecting attr %s len "OFFFMT" but got "OFFFMT"\n",
                __FILE__,__LINE__,name,nelems,inq_nelems);
         nerrs++;
     }
@@ -295,7 +295,7 @@ int main(int argc, char** argv)
     name = "large_attr_1";
     err = ncmpi_inq_attlen(ncid, varid, name, &inq_nelems);
     if (inq_nelems != nelems) {
-        printf("Error at %s line %d: expecting attr %s len %lld but got %lld\n",
+        printf("Error at %s line %d: expecting attr %s len "OFFFMT" but got "OFFFMT"\n",
                __FILE__,__LINE__,name,nelems,inq_nelems);
         nerrs++;
     }
@@ -326,7 +326,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0) {
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         }
     }

--- a/test/largefile/large_coalesce.c
+++ b/test/largefile/large_coalesce.c
@@ -59,7 +59,7 @@ int main(int argc, char** argv)
 
     buf = (unsigned char*) calloc(TWO_G+1024,1);
     if (buf == NULL) {
-        printf("malloc failed for size %lld\n", TWO_G+1024);
+        printf("malloc failed for size "OFFFMT"\n", TWO_G+1024);
         MPI_Finalize();
         return 1;
     }
@@ -200,7 +200,7 @@ int main(int argc, char** argv)
     CHECK_ERR
     for (i=0; i<20; i++) {
         if (buf[i] != 'a'+i) {
-            printf("%d (at line %d): expect buf[%lld]=%zd but got %d\n",
+            printf("%d (at line %d): expect buf["OFFFMT"]=%zd but got %d\n",
                    rank, __LINE__, ONE_G-10+i, i+'a', buf[i]);
             nerrs++;
         }
@@ -213,7 +213,7 @@ int main(int argc, char** argv)
     CHECK_ERR
     for (i=0; i<20; i++) {
         if (buf[i] != 'A'+i) {
-            printf("%d (at line %d): expect buf[%lld]=%zd but got %d\n",
+            printf("%d (at line %d): expect buf["OFFFMT"]=%zd but got %d\n",
                    rank, __LINE__, TWO_G-10+i, i+'A', buf[i]);
             nerrs++;
         }
@@ -242,7 +242,7 @@ int main(int argc, char** argv)
 
     for (i=0; i<20; i++) {
         if (buf[ONE_G-10+i] != 'a'+i) {
-            printf("%d (at line %d): expect buf[%lld]=%zd but got %d\n",
+            printf("%d (at line %d): expect buf["OFFFMT"]=%zd but got %d\n",
                    rank, __LINE__, ONE_G-10+i, i+'a', buf[i]);
             nerrs++;
         }
@@ -250,7 +250,7 @@ int main(int argc, char** argv)
 
     for (i=0; i<20; i++) {
         if (buf[TWO_G-10+i] != 'A'+i) {
-            printf("%d (at line %d): expect buf[%lld]=%zd but got %d\n",
+            printf("%d (at line %d): expect buf["OFFFMT"]=%zd but got %d\n",
                    rank, __LINE__, TWO_G-10+i, i+'A', buf[i]);
             nerrs++;
         }
@@ -271,7 +271,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
     if (malloc_size > 0) ncmpi_inq_malloc_list();

--- a/test/largefile/large_dims_vars_attrs.c
+++ b/test/largefile/large_dims_vars_attrs.c
@@ -141,7 +141,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0) {
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         }
     }

--- a/test/largefile/large_header.c
+++ b/test/largefile/large_header.c
@@ -108,7 +108,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0) {
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         }
     }

--- a/test/largefile/large_reqs.c
+++ b/test/largefile/large_reqs.c
@@ -75,7 +75,7 @@ int tst_one_var(char *filename, MPI_Comm comm)
             printf("\nglobal array is of size %d x %d = %.1f GiB\n",
                    NY*psize[0], NX*psize[1], len/1073741824);
         }
-        printf("rank %d start=%lld %lld\n", rank, start[1],start[2]);
+        printf("rank %d start="OFFFMT" "OFFFMT"\n", rank, start[1],start[2]);
     }
 
     /* user buffer is contiguous */
@@ -226,7 +226,7 @@ int tst_vars(char *filename, MPI_Comm comm)
     count[2] = lsize[1];
 
     if (verbose)
-        printf("rank %d start=%lld %lld count=%lld %lld\n",
+        printf("rank %d start="OFFFMT" "OFFFMT" count="OFFFMT" "OFFFMT"\n",
                rank, start[1],start[2], count[1],count[2]);
 
     if (verbose)
@@ -328,7 +328,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
     if (malloc_size > 0) ncmpi_inq_malloc_list();

--- a/test/largefile/large_var.c
+++ b/test/largefile/large_var.c
@@ -554,7 +554,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
     if (malloc_size > 0) ncmpi_inq_malloc_list();

--- a/test/largefile/tst_cdf5_begin.c
+++ b/test/largefile/tst_cdf5_begin.c
@@ -154,7 +154,7 @@ int main(int argc, char** argv) {
     MPI_Offset malloc_size;
     err = ncmpi_inq_malloc_size(&malloc_size);
     if (err == NC_NOERR && malloc_size > 0) /* this test is for running 1 process */
-        printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+        printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                malloc_size);
     if (malloc_size > 0) ncmpi_inq_malloc_list();
 #endif

--- a/test/largefile/tst_hash_large_ndims.c
+++ b/test/largefile/tst_hash_large_ndims.c
@@ -121,7 +121,7 @@ int main(int argc, char** argv)
                (float)max_size[1]/1048576);
         printf("After ncmpi_enddef,  PnetCDF memory footprint                %6.1f MB\n",
                (float)max_size[0]/1048576);
-        printf("NetCDF file header size %lld extent %lld\n",header_size,header_extent);
+        printf("NetCDF file header size "OFFFMT" extent "OFFFMT"\n",header_size,header_extent);
     }
     fflush(stdout);
 #endif
@@ -152,7 +152,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size[0], &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0) {
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         }
     }

--- a/test/largefile/tst_hash_large_ngattrs.c
+++ b/test/largefile/tst_hash_large_ngattrs.c
@@ -121,7 +121,7 @@ int main(int argc, char** argv)
                (float)max_size[1]/1048576);
         printf("After ncmpi_enddef,  PnetCDF memory footprint                %6.1f MB\n",
                (float)max_size[0]/1048576);
-        printf("NetCDF file header size %lld extent %lld\n",header_size,header_extent);
+        printf("NetCDF file header size "OFFFMT" extent "OFFFMT"\n",header_size,header_extent);
     }
     fflush(stdout);
 #endif
@@ -152,7 +152,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size[0], &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0) {
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         }
     }

--- a/test/largefile/tst_hash_large_nvars.c
+++ b/test/largefile/tst_hash_large_nvars.c
@@ -153,7 +153,7 @@ int main(int argc, char** argv)
                (float)max_size[1]/1048576);
         printf("After ncmpi_enddef,  PnetCDF memory footprint                %6.1f MB\n",
                (float)max_size[0]/1048576);
-        printf("NetCDF file header size %lld extent %lld\n",header_size,header_extent);
+        printf("NetCDF file header size "OFFFMT" extent "OFFFMT"\n",header_size,header_extent);
     }
     fflush(stdout);
 #endif
@@ -186,7 +186,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size[0], &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0) {
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         }
     }

--- a/test/nc4/compressed.c
+++ b/test/nc4/compressed.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc4/interoperability_rd.m4
+++ b/test/nc4/interoperability_rd.m4
@@ -223,7 +223,7 @@ err_out:
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc4/interoperability_wr.m4
+++ b/test/nc4/interoperability_wr.m4
@@ -227,7 +227,7 @@ foreach(`dt', (`(`0', `schar', `char')', dnl
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc4/noclobber.c
+++ b/test/nc4/noclobber.c
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                 sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/nc4/notsupport.c
+++ b/test/nc4/notsupport.c
@@ -138,7 +138,7 @@ int main(int argc, char** argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, comm);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc4/pres_temp_4D.c
+++ b/test/nc4/pres_temp_4D.c
@@ -413,7 +413,7 @@ main(int argc, char ** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc4/put_get_all_kinds.m4
+++ b/test/nc4/put_get_all_kinds.m4
@@ -238,7 +238,7 @@ int main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc4/rd_compressed.c
+++ b/test/nc4/rd_compressed.c
@@ -166,7 +166,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc4/simple_xy.c
+++ b/test/nc4/simple_xy.c
@@ -158,7 +158,7 @@ int main(int argc, char** argv) {
     MPI_Offset malloc_size;
     err = ncmpi_inq_malloc_size(&malloc_size);
     if (err == NC_NOERR && malloc_size > 0) /* this test is for running 1 process */
-        printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+        printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                malloc_size);
 
 fn_exit:

--- a/test/nc4/tst_2_rec_dims.c
+++ b/test/nc4/tst_2_rec_dims.c
@@ -95,7 +95,7 @@ int main(int argc, char** argv) {
 
     err = ncmpi_inq_recsize(ncid, &recsize);  CHECK_ERR
     if (recsize != 4){
-        printf("Error at line %d of %s: expect recsize %lld but got %lld\n",
+        printf("Error at line %d of %s: expect recsize "OFFFMT" but got "OFFFMT"\n",
                 __LINE__,__FILE__, (MPI_Offset)4, recsize);
         nerrs++;
     }  
@@ -108,7 +108,7 @@ int main(int argc, char** argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, comm);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc4/tst_get_put_size.c
+++ b/test/nc4/tst_get_put_size.c
@@ -72,7 +72,7 @@ int main(int argc, char** argv) {
         err = ncmpi_put_var1_int_all(ncid, varid[0], start, buf); CHECK_ERR
         err = ncmpi_inq_put_size(ncid, &size); CHECK_ERR
         if (size != sizeof(int) * (i + 1)){
-            printf("Error at line %d of %s: expect put_size = %ld but got %lld\n",
+            printf("Error at line %d of %s: expect put_size = %ld but got "OFFFMT"\n",
                 __LINE__,__FILE__,sizeof(int) * (i + 1),size);
             nerrs++;
         }
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
         err = ncmpi_get_var1_int_all(ncid, varid[0], start, buf); CHECK_ERR
         err = ncmpi_inq_get_size(ncid, &size); CHECK_ERR
         if (size != sizeof(int) * (i + 1)){
-            printf("Error at line %d of %s: expect put_size = %ld but got %lld\n",
+            printf("Error at line %d of %s: expect put_size = %ld but got "OFFFMT"\n",
                 __LINE__,__FILE__,sizeof(int) * (i + 1),size);
             nerrs++;
         }
@@ -94,7 +94,7 @@ int main(int argc, char** argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, comm);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc4/tst_rec_vars.c
+++ b/test/nc4/tst_rec_vars.c
@@ -74,7 +74,7 @@ int main(int argc, char** argv) {
 
     err = ncmpi_inq_dimlen(ncid, dimid[0], start); CHECK_ERR
     if (start[0] != (MPI_Offset)nprocs){
-        printf("Error at line %d of %s: expect NC_UNLIMITED dimension X of len %lld but got %lld\n",
+        printf("Error at line %d of %s: expect NC_UNLIMITED dimension X of len "OFFFMT" but got "OFFFMT"\n",
                 __LINE__,__FILE__,(MPI_Offset)nprocs,start[0]);
         nerrs++;
     }
@@ -95,7 +95,7 @@ int main(int argc, char** argv) {
 
     err = ncmpi_inq_recsize(ncid, start);  CHECK_ERR
     if (start[0] != 8){
-        printf("Error at line %d of %s: expect recsize %lld but got %lld\n",
+        printf("Error at line %d of %s: expect recsize "OFFFMT" but got "OFFFMT"\n",
                 __LINE__,__FILE__, (MPI_Offset)8, start[0]);
         nerrs++;
     }  
@@ -132,7 +132,7 @@ int main(int argc, char** argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, comm);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc4/tst_zero_req.c
+++ b/test/nc4/tst_zero_req.c
@@ -67,7 +67,7 @@ tst_fmt(char *filename, int cmode)
 
     err = ncmpi_inq_dimlen(ncid, dimid[0], &num_records); CHECK_ERR
     if (num_records != Y_LEN) {
-        printf("Error at %s:%d: expect num_records=%d but got %lld\n",
+        printf("Error at %s:%d: expect num_records=%d but got "OFFFMT"\n",
                __FILE__,__LINE__,Y_LEN,num_records);
         nerrs++;
     }
@@ -77,7 +77,7 @@ tst_fmt(char *filename, int cmode)
 
     err = ncmpi_inq_dimlen(ncid, dimid[0], &num_records); CHECK_ERR
     if (num_records != Y_LEN) {
-        printf("Error at %s:%d: expect num_records=%d but got %lld\n",
+        printf("Error at %s:%d: expect num_records=%d but got "OFFFMT"\n",
                __FILE__,__LINE__,Y_LEN,num_records);
         nerrs++;
     }
@@ -172,7 +172,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/nc_test/t_nc.c
+++ b/test/nc_test/t_nc.c
@@ -656,7 +656,7 @@ int main(int argc, char *argv[])
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc_test/tst_atts.c
+++ b/test/nc_test/tst_atts.c
@@ -2068,7 +2068,7 @@ create_file(char *filename, int cmode)
 
     err=ncmpi_inq_dimlen(ncid, Dr_dim, &num_records); ERR
     if (num_records != 2) {
-        printf("Error at %s:%d expecting number of records = 2, but got %lld\n",
+        printf("Error at %s:%d expecting number of records = 2, but got "OFFFMT"\n",
                __FILE__,__LINE__,num_records);
         return 1;
     }
@@ -2242,7 +2242,7 @@ int main(int argc, char *argv[])
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc_test/tst_atts3.c
+++ b/test/nc_test/tst_atts3.c
@@ -800,7 +800,7 @@ int main(int argc, char *argv[])
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc_test/tst_misc.c
+++ b/test/nc_test/tst_misc.c
@@ -101,7 +101,7 @@ main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc_test/tst_names.c
+++ b/test/nc_test/tst_names.c
@@ -317,7 +317,7 @@ main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc_test/tst_nofill.c
+++ b/test/nc_test/tst_nofill.c
@@ -472,7 +472,7 @@ main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc_test/tst_norm.c
+++ b/test/nc_test/tst_norm.c
@@ -205,7 +205,7 @@ main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nc_test/tst_small.c
+++ b/test/nc_test/tst_small.c
@@ -486,7 +486,7 @@ int main(int argc, char *argv[])
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/nonblocking/bput_varn.m4
+++ b/test/nonblocking/bput_varn.m4
@@ -134,14 +134,14 @@ int check_attached_buffer_usage(int ncid,
     err = ncmpi_inq_buffer_size(ncid, &buf_size);
     CHECK_ERR
     if (expected_size != buf_size) {
-        printf("Error at line %d in %s: expect buffer size %lld but got %lld\n",
+        printf("Error at line %d in %s: expect buffer size "OFFFMT" but got "OFFFMT"\n",
                lineno, __FILE__,expected_size, buf_size);
         nerrs++;
     }
 
     err = ncmpi_inq_buffer_usage(ncid, &usage); CHECK_ERR
     if (expected_usage != usage) {
-        printf("Error at line %d in %s: expect buffer usage %lld but got %lld\n",
+        printf("Error at line %d in %s: expect buffer usage "OFFFMT" but got "OFFFMT"\n",
                lineno, __FILE__,expected_usage, usage);
         nerrs++;
     }
@@ -640,7 +640,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/nonblocking/column_wise.m4
+++ b/test/nonblocking/column_wise.m4
@@ -348,7 +348,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/nonblocking/flexible_bput.c
+++ b/test/nonblocking/flexible_bput.c
@@ -261,7 +261,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0) {
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         }
         if (malloc_size > 0) ncmpi_inq_malloc_list();

--- a/test/nonblocking/i_varn_indef.c
+++ b/test/nonblocking/i_varn_indef.c
@@ -673,7 +673,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0) {
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         }
         if (malloc_size > 0) ncmpi_inq_malloc_list();

--- a/test/nonblocking/i_varn_int64.c
+++ b/test/nonblocking/i_varn_int64.c
@@ -622,7 +622,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0) {
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         }
         if (malloc_size > 0) ncmpi_inq_malloc_list();

--- a/test/nonblocking/interleaved.c
+++ b/test/nonblocking/interleaved.c
@@ -322,7 +322,7 @@ int main(int argc, char** argv)
     MPI_Offset malloc_size;
     err = ncmpi_inq_malloc_size(&malloc_size);
     if (err == NC_NOERR && malloc_size > 0) {
-        printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n", malloc_size);
+        printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n", malloc_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }
 

--- a/test/nonblocking/large_num_reqs.c
+++ b/test/nonblocking/large_num_reqs.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0) {
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         }
         if (malloc_size > 0) ncmpi_inq_malloc_list();

--- a/test/nonblocking/mcoll_perf.c
+++ b/test/nonblocking/mcoll_perf.c
@@ -153,7 +153,7 @@ int ncmpi_diff(char *filename1, char *filename2)
             sprintf(str,"attribute[%d] %s: type1(%d) != type2(%d)",i,name1,type1,type2);
         HANDLE_DIFF(str)
         if (attlen1 != attlen2)
-            sprintf(str,"attribute[%d] %s: attlen1(%lld) != attlen2(%lld)",i,name1, attlen1, attlen2);
+            sprintf(str,"attribute[%d] %s: attlen1("OFFFMT") != attlen2("OFFFMT")",i,name1, attlen1, attlen2);
         HANDLE_DIFF(str)
         switch (type1) {
             case NC_CHAR:   CHECK_GLOBAL_ATT_DIFF(char,   ncmpi_get_att_text,   NC_CHAR)
@@ -172,7 +172,7 @@ int ncmpi_diff(char *filename1, char *filename2)
         err = ncmpi_inq_dim(ncid2, i, name2, &dimlen2);
         CHECK_ERR
         if (dimlen1 != dimlen2)
-            sprintf(str,"dimension[%d] %s: dimlen1(%lld) != dimlen2(%lld)",i,name1,dimlen1,dimlen2);
+            sprintf(str,"dimension[%d] %s: dimlen1("OFFFMT") != dimlen2("OFFFMT")",i,name1,dimlen1,dimlen2);
         HANDLE_DIFF(str)
     }
 
@@ -227,7 +227,7 @@ int ncmpi_diff(char *filename1, char *filename2)
                 sprintf(str,"variable[%d] %s: attr type[%d] (%d) != (%d)",i,name,j,type1,type2);
             HANDLE_DIFF(str)
             if (attlen1 != attlen2)
-                sprintf(str,"variable[%d] %s: attr attlen[%d] (%lld) != (%lld)",i,name,j, attlen1, attlen2);
+                sprintf(str,"variable[%d] %s: attr attlen[%d] ("OFFFMT") != ("OFFFMT")",i,name,j, attlen1, attlen2);
             HANDLE_DIFF(str)
 
             switch (type1) {
@@ -423,7 +423,7 @@ int main(int argc, char **argv)
     for (i=0; i<ndims; i++)
         array_of_starts[i] = length * rank_dim[i];
     if (verbose)
-        printf("rank %d: array_of_starts[3]=%lld %lld %lld\n",
+        printf("rank %d: array_of_starts[3]="OFFFMT" "OFFFMT" "OFFFMT"\n",
                rank,array_of_starts[0],array_of_starts[1],array_of_starts[2]);
 
     for (i=0; i<nvars; i++) {
@@ -435,7 +435,7 @@ int main(int argc, char **argv)
         datatype_list[i] = MPI_INT;
     }
     if (verbose)
-        printf("rank %d: starts[0][3]=%lld %lld %lld counts[0][3]=%lld %lld %lld\n",
+        printf("rank %d: starts[0][3]="OFFFMT" "OFFFMT" "OFFFMT" counts[0][3]="OFFFMT" "OFFFMT" "OFFFMT"\n",
                rank,starts[0][0],starts[0][1],starts[0][2], counts[0][0],counts[0][1],counts[0][2]);
 
     buf[0] = (int *) malloc(sizeof(int) * bufcount * nvars);
@@ -720,7 +720,7 @@ printf("filename2=%s filename3=%s\n",filename2, filename3);
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0) {
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         }
         if (malloc_size > 0) ncmpi_inq_malloc_list();

--- a/test/nonblocking/req_all.c
+++ b/test/nonblocking/req_all.c
@@ -156,7 +156,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0) {
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         }
         if (malloc_size > 0) ncmpi_inq_malloc_list();

--- a/test/nonblocking/test_bput.c
+++ b/test/nonblocking/test_bput.c
@@ -173,7 +173,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0) {
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         }
         if (malloc_size > 0) ncmpi_inq_malloc_list();

--- a/test/nonblocking/wait_after_indep.c
+++ b/test/nonblocking/wait_after_indep.c
@@ -110,7 +110,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0) {
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         }
         if (malloc_size > 0) ncmpi_inq_malloc_list();

--- a/test/subfile/test_subfile.c
+++ b/test/subfile/test_subfile.c
@@ -402,7 +402,7 @@ end:
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
     }
 

--- a/test/testcases/add_var.c
+++ b/test/testcases/add_var.c
@@ -141,7 +141,7 @@ int main(int argc, char** argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/alignment_test.c
+++ b/test/testcases/alignment_test.c
@@ -202,30 +202,30 @@ int main(int argc, char** argv) {
     err = ncmpi_inq_header_extent(ncid, &header_extent[1]); CHECK_ERR
     if (rank == 0 && verbose) {
         printf("NX = %d (integer type)\n",NX);
-        printf("old header_size  =%lld new header_size  =%lld\n",header_size[0],header_size[1]);
-        printf("old header_extent=%lld new header_extent=%lld\n",header_extent[0],header_extent[1]);
+        printf("old header_size  ="OFFFMT" new header_size  ="OFFFMT"\n",header_size[0],header_size[1]);
+        printf("old header_extent="OFFFMT" new header_extent="OFFFMT"\n",header_extent[0],header_extent[1]);
 
 #ifdef TEST_FIXED_VAR
         for (i=1; i<NVARS; i+=2) {
             err = ncmpi_inq_varoffset(ncid, varid[i], &new_var_off[i]); CHECK_ERR
-            printf("old fixed  var[%2d] old offset=%4lld new offset=%4lld\n",i,old_var_off[i],new_var_off[i]);
+            printf("old fixed  var[%2d] old offset="OFFFMT" new offset="OFFFMT"\n",i,old_var_off[i],new_var_off[i]);
         }
         for (i=NVARS; i<2*NVARS; i++) {
             if (i%2 == 0) {
                 err = ncmpi_inq_varoffset(ncid, new_varid[i-NVARS], &new_var_off[i]); CHECK_ERR
-                printf("new fixed  var[%2d]                 new offset=%4lld\n",i,new_var_off[i]);
+                printf("new fixed  var[%2d]                 new offset="OFFFMT"\n",i,new_var_off[i]);
             }
         }
 #endif
 #ifdef TEST_RECORD_VAR
         for (i=0; i<NVARS; i+=2) {
             err = ncmpi_inq_varoffset(ncid, varid[i], &new_var_off[i]); CHECK_ERR
-            printf("old record var[%2d] old offset=%4lld new offset=%4lld\n",i,old_var_off[i],new_var_off[i]);
+            printf("old record var[%2d] old offset="OFFFMT" new offset="OFFFMT"\n",i,old_var_off[i],new_var_off[i]);
         }
         for (i=NVARS; i<2*NVARS; i++) {
             if (i%2) {
                 err = ncmpi_inq_varoffset(ncid, new_varid[i-NVARS], &new_var_off[i]); CHECK_ERR
-                printf("new record var[%2d]                 new offset=%4lld\n",i,new_var_off[i]);
+                printf("new record var[%2d]                 new offset="OFFFMT"\n",i,new_var_off[i]);
             }
         }
 #endif
@@ -323,7 +323,7 @@ int main(int argc, char** argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/buftype_free.c
+++ b/test/testcases/buftype_free.c
@@ -121,7 +121,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/check_striping.c
+++ b/test/testcases/check_striping.c
@@ -112,7 +112,7 @@ int main(int argc, char** argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/check_type.c
+++ b/test/testcases/check_type.c
@@ -219,7 +219,7 @@ int main(int argc, char* argv[])
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/collective_error.c
+++ b/test/testcases/collective_error.c
@@ -216,7 +216,7 @@ int main(int argc, char *argv[])
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/erange_fill.m4
+++ b/test/testcases/erange_fill.m4
@@ -438,7 +438,7 @@ int main(int argc, char** argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/error_precedence.m4
+++ b/test/testcases/error_precedence.m4
@@ -515,7 +515,7 @@ int main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/file_create_open.c
+++ b/test/testcases/file_create_open.c
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/flexible.c
+++ b/test/testcases/flexible.c
@@ -124,7 +124,7 @@ int main(int argc, char **argv) {
 
     start[0] = 0; start[1] = NX*rank;
     count[0] = 2; count[1] = NX;
-    if (debug) printf("put start=%lld %lld count=%lld %lld\n",start[0],start[1],count[0],count[1]);
+    if (debug) printf("put start="OFFFMT" "OFFFMT" count="OFFFMT" "OFFFMT"\n",start[0],start[1],count[0],count[1]);
 
     /* call flexible API */
     err = ncmpi_put_vara_all(ncid, varid1, start, count, bufptr, 1, buftype); CHECK_ERR
@@ -209,7 +209,7 @@ int main(int argc, char **argv) {
     /* read back variable */
     start[0] = 0; start[1] = NX*rank;
     count[0] = 2; count[1] = NX;
-    if (debug) printf("get start=%lld %lld count=%lld %lld\n",start[0],start[1],count[0],count[1]);
+    if (debug) printf("get start="OFFFMT" "OFFFMT" count="OFFFMT" "OFFFMT"\n",start[0],start[1],count[0],count[1]);
 
     err = ncmpi_get_vara_int_all(ncid, varid1, start, count, buf[0]); CHECK_ERR
 
@@ -328,7 +328,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/flexible2.c
+++ b/test/testcases/flexible2.c
@@ -267,7 +267,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/flexible_large_count.c
+++ b/test/testcases/flexible_large_count.c
@@ -487,7 +487,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/flexible_var.c
+++ b/test/testcases/flexible_var.c
@@ -491,7 +491,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/flexible_varm.c
+++ b/test/testcases/flexible_varm.c
@@ -231,7 +231,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/inq_num_vars.c
+++ b/test/testcases/inq_num_vars.c
@@ -167,7 +167,7 @@ int main(int argc, char** argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/inq_recsize.c
+++ b/test/testcases/inq_recsize.c
@@ -75,7 +75,7 @@ tst_fmt(char *filename, int cmode)
 
     err = ncmpi_inq_recsize(ncid, &recsize); CHECK_ERR
     if (expected_recsize != recsize) {
-        printf("Error at line %d in %s: expecting record size %lld but got %lld\n",
+        printf("Error at line %d in %s: expecting record size "OFFFMT" but got "OFFFMT"\n",
         __LINE__,__FILE__,expected_recsize, recsize);
         nerrs++;
     }
@@ -130,7 +130,7 @@ int main(int argc, char** argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/iput_all_kinds.m4
+++ b/test/testcases/iput_all_kinds.m4
@@ -243,7 +243,7 @@ int main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/ivarn.c
+++ b/test/testcases/ivarn.c
@@ -459,7 +459,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/large_var_cdf5.c
+++ b/test/testcases/large_var_cdf5.c
@@ -73,7 +73,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/last_large_var.c
+++ b/test/testcases/last_large_var.c
@@ -404,7 +404,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/mix_collectives.c
+++ b/test/testcases/mix_collectives.c
@@ -283,7 +283,7 @@ err_out:
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/modes.c
+++ b/test/testcases/modes.c
@@ -219,7 +219,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/ncmpi_vars_null_stride.c
+++ b/test/testcases/ncmpi_vars_null_stride.c
@@ -287,7 +287,7 @@ int main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/noclobber.c
+++ b/test/testcases/noclobber.c
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/nonblocking.c
+++ b/test/testcases/nonblocking.c
@@ -150,7 +150,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/null_args.m4
+++ b/test/testcases/null_args.m4
@@ -368,7 +368,7 @@ int main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/one_record.c
+++ b/test/testcases/one_record.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/profile.c
+++ b/test/testcases/profile.c
@@ -418,7 +418,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/put_all_kinds.m4
+++ b/test/testcases/put_all_kinds.m4
@@ -253,7 +253,7 @@ int main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/record.c
+++ b/test/testcases/record.c
@@ -62,7 +62,7 @@ int test_only_record_var_1D(char *filename, int cmode)
 
     err = ncmpi_inq_dimlen(ncid, dimid, &length); CHECK_ERR
     if (length != 2) {
-        printf("Error at line %d in %s: expecting 2 records, but got %lld record(s)\n",
+        printf("Error at line %d in %s: expecting 2 records, but got "OFFFMT" record(s)\n",
         __LINE__,__FILE__,length);
         nerrs++;
     }
@@ -81,7 +81,7 @@ int test_only_record_var_1D(char *filename, int cmode)
 
         err = ncmpi_inq_dimlen(ncid, dimid, &length); CHECK_ERR
         if (length != 4) {
-            printf("Error at line %d in %s: expecting 4 records, but got %lld record(s)\n",
+            printf("Error at line %d in %s: expecting 4 records, but got "OFFFMT" record(s)\n",
                    __LINE__,__FILE__,length);
             nerrs++;
         }
@@ -123,7 +123,7 @@ int test_only_record_var_3D(char *filename, int cmode)
 
     err = ncmpi_inq_dimlen(ncid, dimid[0], &length); CHECK_ERR
     if (length != 2) {
-        printf("Error at line %d in %s: expecting 2 records, but got %lld record(s)\n",
+        printf("Error at line %d in %s: expecting 2 records, but got "OFFFMT" record(s)\n",
         __LINE__,__FILE__,length);
         nerrs++;
     }
@@ -142,7 +142,7 @@ int test_only_record_var_3D(char *filename, int cmode)
 
         err = ncmpi_inq_dimlen(ncid, dimid[0], &length); CHECK_ERR
         if (length != 4) {
-            printf("Error at line %d in %s: expecting 4 records, but got %lld record(s)\n",
+            printf("Error at line %d in %s: expecting 4 records, but got "OFFFMT" record(s)\n",
                    __LINE__,__FILE__,length);
             nerrs++;
         }
@@ -183,7 +183,7 @@ int test_two_record_var(char *filename, int cmode)
 
     err = ncmpi_inq_dimlen(ncid, dimid[0], &length); CHECK_ERR
     if (length != 2) {
-        printf("Error at line %d in %s: expecting 2 records, but got %lld record(s)\n",
+        printf("Error at line %d in %s: expecting 2 records, but got "OFFFMT" record(s)\n",
         __LINE__,__FILE__,length);
         nerrs++;
     }
@@ -214,7 +214,7 @@ int test_two_record_var(char *filename, int cmode)
 
         err = ncmpi_inq_dimlen(ncid, dimid[0], &length); CHECK_ERR
         if (length != 4) {
-            printf("Error at line %d in %s: expecting 4 records, but got %lld record(s)\n",
+            printf("Error at line %d in %s: expecting 4 records, but got "OFFFMT" record(s)\n",
                    __LINE__,__FILE__,length);
             nerrs++;
         }
@@ -237,7 +237,7 @@ int test_two_record_var(char *filename, int cmode)
 
     err = ncmpi_inq_dimlen(ncid, dimid[0], &length); CHECK_ERR
     if (length != 4) {
-        printf("Error at line %d in %s: expecting 4 records, but got %lld record(s)\n",
+        printf("Error at line %d in %s: expecting 4 records, but got "OFFFMT" record(s)\n",
         __LINE__,__FILE__,length);
         nerrs++;
     }
@@ -268,7 +268,7 @@ int test_two_record_var(char *filename, int cmode)
 
         err = ncmpi_inq_dimlen(ncid, dimid[0], &length); CHECK_ERR
         if (length != 4) {
-            printf("Error at line %d in %s: expecting 4 records, but got %lld record(s)\n",
+            printf("Error at line %d in %s: expecting 4 records, but got "OFFFMT" record(s)\n",
                    __LINE__,__FILE__,length);
             nerrs++;
         }
@@ -353,7 +353,7 @@ int main(int argc, char** argv) {
     MPI_Offset malloc_size;
     err = ncmpi_inq_malloc_size(&malloc_size);
     if (err == NC_NOERR && malloc_size > 0) { /* this test is for running 1 process */
-        printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+        printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                malloc_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/redef1.c
+++ b/test/testcases/redef1.c
@@ -192,7 +192,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/scalar.c
+++ b/test/testcases/scalar.c
@@ -215,7 +215,7 @@ int main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/test_erange.c
+++ b/test/testcases/test_erange.c
@@ -300,7 +300,7 @@ int main(int argc, char* argv[])
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/test_fillvalue.c
+++ b/test/testcases/test_fillvalue.c
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/test_get_varn.c
+++ b/test/testcases/test_get_varn.c
@@ -166,7 +166,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/test_vard.c
+++ b/test/testcases/test_vard.c
@@ -285,7 +285,7 @@ int main(int argc, char **argv) {
     if (rank == 0) expected_put_size += (format == NC_FORMAT_CDF5) ? 8 : 4;
      */
     if (expected_put_size != new_put_size - put_size) {
-        printf("Error at line %d in %s: unexpected put size (%lld) reported, expecting %d\n",
+        printf("Error at line %d in %s: unexpected put size ("OFFFMT") reported, expecting %d\n",
                __LINE__,__FILE__,new_put_size-put_size, expected_put_size);
         nerrs++;
     }
@@ -305,7 +305,7 @@ int main(int argc, char **argv) {
     err = ncmpi_inq_put_size(ncid, &new_put_size); CHECK_ERR
     expected_put_size = buftype_size;
     if (expected_put_size != new_put_size - put_size) {
-        printf("Error at line %d in %s: unexpected put size (%lld) reported, expecting %d\n",
+        printf("Error at line %d in %s: unexpected put size ("OFFFMT") reported, expecting %d\n",
                __LINE__,__FILE__,new_put_size-put_size, expected_put_size);
         nerrs++;
     }
@@ -506,7 +506,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/test_vard_multiple.c
+++ b/test/testcases/test_vard_multiple.c
@@ -300,7 +300,7 @@ int main(int argc, char **argv) {
     err = ncmpi_inq_unlimdim(ncid, &unlimit_dimid); CHECK_ERR
     err = ncmpi_inq_dimlen(ncid, unlimit_dimid, &len); CHECK_ERR
     if (len != 2)
-        printf("Error at line %d in %s: number of records should be 2 but got %lld\n",
+        printf("Error at line %d in %s: number of records should be 2 but got "OFFFMT"\n",
         __LINE__,__FILE__,len);
 
     MPI_Type_free(&vtype[0]);
@@ -317,7 +317,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/test_vard_rec.c
+++ b/test/testcases/test_vard_rec.c
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
     /* check if the number of records changed to 1 */
     err = ncmpi_inq_dimlen(ncid, unlimit_dimid, &len); CHECK_ERR
     if (len != 1)
-        printf("Error at line %d in %s: number of records should be 1 but got %lld\n",
+        printf("Error at line %d in %s: number of records should be 1 but got "OFFFMT"\n",
         __LINE__,__FILE__,len);
 
     /* create a file type for writing 2nd record */
@@ -132,7 +132,7 @@ int main(int argc, char **argv) {
     /* check if the number of records changed to 2 */
     err = ncmpi_inq_dimlen(ncid, unlimit_dimid, &len); CHECK_ERR
     if (len != 2)
-        printf("Error at line %d in %s: number of records should be 2 but got %lld\n",
+        printf("Error at line %d in %s: number of records should be 2 but got "OFFFMT"\n",
         __LINE__,__FILE__,len);
 
     err = ncmpi_close(ncid); CHECK_ERR
@@ -186,7 +186,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/test_varm.c
+++ b/test/testcases/test_varm.c
@@ -291,7 +291,7 @@ int main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/tst_def_var_fill.c
+++ b/test/testcases/tst_def_var_fill.c
@@ -224,7 +224,7 @@ int main(int argc, char** argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/tst_del_attr.c
+++ b/test/testcases/tst_del_attr.c
@@ -124,7 +124,7 @@ tst_fmt(char *filename, int cmode)
             file_size = lseek(fd, 0, SEEK_END);
 
             if (!(cmode & NC_NETCDF4) && file_size != header_size)
-                printf("Warning: expected file size %lld but got %lld\n",
+                printf("Warning: expected file size "OFFFMT" but got %lld\n",
                        header_size, (long long)file_size);
 
             close(fd);
@@ -179,7 +179,7 @@ int main(int argc, char* argv[])
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/tst_dimsizes.c
+++ b/test/testcases/tst_dimsizes.c
@@ -91,7 +91,7 @@ main(int argc, char **argv)
     err = ncmpi_inq_dimid(ncid, "testdim", &dimid); CHECK_ERR
     err = ncmpi_inq_dimlen(ncid, dimid, &dimsize); CHECK_ERR
     if (dimsize != DIMMAXCLASSIC) {
-        printf("Error at line %d in %s: expecting dimsize %d but got %lld\n", __LINE__,__FILE__,DIMMAXCLASSIC,dimsize);
+        printf("Error at line %d in %s: expecting dimsize %d but got "OFFFMT"\n", __LINE__,__FILE__,DIMMAXCLASSIC,dimsize);
         nerrs++;
     }
     err = ncmpi_close(ncid); CHECK_ERR
@@ -111,7 +111,7 @@ main(int argc, char **argv)
     err = ncmpi_inq_dimid(ncid, "testdim", &dimid); CHECK_ERR
     err = ncmpi_inq_dimlen(ncid, dimid, &dimsize); CHECK_ERR
     if (dimsize != DIMMAX64OFFSET) {
-        printf("Error at line %d in %s: expecting dimsize %d but got %lld\n", __LINE__,__FILE__,DIMMAX64OFFSET,dimsize);
+        printf("Error at line %d in %s: expecting dimsize %d but got "OFFFMT"\n", __LINE__,__FILE__,DIMMAX64OFFSET,dimsize);
         nerrs++;
     }
     err = ncmpi_close(ncid); CHECK_ERR
@@ -129,7 +129,7 @@ main(int argc, char **argv)
     err = ncmpi_inq_dimid(ncid, "testdim", &dimid); CHECK_ERR
     err = ncmpi_inq_dimlen(ncid, dimid, &dimsize); CHECK_ERR
     if (dimsize != DIMMAX64DATA) {
-        printf("Error at line %d in %s: expecting dimsize %lld but got %lld\n", __LINE__,__FILE__,DIMMAX64DATA,dimsize);
+        printf("Error at line %d in %s: expecting dimsize %lld but got "OFFFMT"\n", __LINE__,__FILE__,(long long)DIMMAX64DATA,dimsize);
         nerrs++;
     }
     err = ncmpi_close(ncid); CHECK_ERR
@@ -140,7 +140,7 @@ main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/tst_free_comm.c
+++ b/test/testcases/tst_free_comm.c
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/tst_grow_header.c
+++ b/test/testcases/tst_grow_header.c
@@ -121,9 +121,9 @@ err_out:
     err = ncmpi_inq_header_size(ncid, &hsize); CHECK_ERR \
     err = ncmpi_inq_header_extent(ncid, &extent); CHECK_ERR \
     if (verbose && rank == 0) { \
-        printf("Line %d: header size   old = %6lld new = %6lld\n", \
+        printf("Line %d: header size   old = "OFFFMT" new = "OFFFMT"\n", \
                __LINE__,old_hsize, hsize); \
-        printf("Line %d: header extent old = %6lld new = %6lld\n", \
+        printf("Line %d: header extent old = "OFFFMT" new = "OFFFMT"\n", \
                __LINE__,old_extent, extent); \
     } \
 }
@@ -131,12 +131,12 @@ err_out:
 #define CHECK_HEADER_SIZE { \
     if (hsize != exp_hsize) { \
         nerrs++; \
-        printf("Error at line %d in %s: header size expecting %lld but got %lld\n", \
+        printf("Error at line %d in %s: header size expecting "OFFFMT" but got "OFFFMT"\n", \
                __LINE__,__FILE__, exp_hsize, hsize); \
     } \
     if (extent != exp_extent) { \
         nerrs++; \
-        printf("Error at line %d in %s: header extent expecting %lld but got %lld\n", \
+        printf("Error at line %d in %s: header extent expecting "OFFFMT" but got "OFFFMT"\n", \
                __LINE__,__FILE__, exp_extent, extent); \
     } \
     /* read variables back and check contents */ \
@@ -157,7 +157,7 @@ err_out:
     CHECK_ERR \
     free(attr); \
     if (verbose && rank == 0) \
-        printf("Line %d: grow header size from %6lld to %6lld\n", \
+        printf("Line %d: grow header size from "OFFFMT" to "OFFFMT"\n", \
                __LINE__,hsize, hsize+growth); \
 }
 
@@ -429,7 +429,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/tst_info.c
+++ b/test/testcases/tst_info.c
@@ -146,8 +146,8 @@ int main(int argc, char** argv) {
 
 #ifdef VERBOSE
     if (rank == 0) {
-        printf("\nheader_size = %lld\n",header_size);
-        printf("header_extent=%lld\n\n",header_extent);
+        printf("\nheader_size = "OFFFMT"\n",header_size);
+        printf("header_extent="OFFFMT"\n\n",header_extent);
     }
 #endif
 
@@ -156,7 +156,7 @@ int main(int argc, char** argv) {
         MPI_Info_get(info_used, "nc_var_align_size", len+1, value, &flag);
         expect = PNETCDF_RNDUP(197, 4);
         if (expect != strtoll(value,NULL,10)) {
-            printf("Error: nc_var_align_size expect %lld but got %lld\n",
+            printf("Error: nc_var_align_size expect "OFFFMT" but got %lld\n",
                    expect, strtoll(value,NULL,10));
             nerrs++;
         }
@@ -220,7 +220,7 @@ int main(int argc, char** argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/tst_max_var_dims.c
+++ b/test/testcases/tst_max_var_dims.c
@@ -81,7 +81,7 @@ int main(int argc, char** argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/tst_pthread.c
+++ b/test/testcases/tst_pthread.c
@@ -374,7 +374,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/tst_redefine.c
+++ b/test/testcases/tst_redefine.c
@@ -118,15 +118,15 @@ err_out:
     err = ncmpi_inq_varoffset(ncid, varid[0], &r_begin); CHECK_ERR \
     v_free = r_begin - (extent + fix_v_size); \
     if (verbose && rank == 0) { \
-        printf("Line %d: header size   old = %6lld new = %6lld\n", \
+        printf("Line %d: header size   old = "OFFFMT" new = "OFFFMT"\n", \
                __LINE__,old_hsize, hsize); \
-        printf("Line %d: header extent old = %6lld new = %6lld\n", \
+        printf("Line %d: header extent old = "OFFFMT" new = "OFFFMT"\n", \
                __LINE__,old_extent, extent); \
-        printf("Line %d: header free   old = %6lld new = %6lld\n", \
+        printf("Line %d: header free   old = "OFFFMT" new = "OFFFMT"\n", \
                __LINE__,old_h_free, h_free); \
-        printf("Line %d: record begin  old = %6lld new = %6lld\n", \
+        printf("Line %d: record begin  old = "OFFFMT" new = "OFFFMT"\n", \
                __LINE__,old_r_begin, r_begin); \
-        printf("Line %d: var free      old = %6lld new = %6lld\n", \
+        printf("Line %d: var free      old = "OFFFMT" new = "OFFFMT"\n", \
                __LINE__,old_v_free, v_free); \
     } \
 }
@@ -134,27 +134,27 @@ err_out:
 #define CHECK_HEADER_SIZE { \
     if (hsize != exp_hsize) { \
         nerrs++; \
-        printf("Error at line %d in %s: header size expecting %lld but got %lld\n", \
+        printf("Error at line %d in %s: header size expecting "OFFFMT" but got "OFFFMT"\n", \
                __LINE__,__FILE__, exp_hsize, hsize); \
     } \
     if (extent != exp_extent) { \
         nerrs++; \
-        printf("Error at line %d in %s: header extent expecting %lld but got %lld\n", \
+        printf("Error at line %d in %s: header extent expecting "OFFFMT" but got "OFFFMT"\n", \
                __LINE__,__FILE__, exp_extent, extent); \
     } \
     if (extent - hsize < exp_h_free) { \
         nerrs++; \
-        printf("Error at line %d in %s: header free expecting %lld but got %lld\n", \
+        printf("Error at line %d in %s: header free expecting "OFFFMT" but got "OFFFMT"\n", \
                __LINE__,__FILE__, exp_h_free, extent - hsize); \
     } \
     if (has_fix_vars && v_free != exp_v_free) { \
         nerrs++; \
-        printf("Error at line %d in %s: v_free expecting %lld but got %lld\n", \
+        printf("Error at line %d in %s: v_free expecting "OFFFMT" but got "OFFFMT"\n", \
                __LINE__,__FILE__, exp_v_free, v_free); \
     } \
     if (r_begin != exp_r_begin) { \
         nerrs++; \
-        printf("Error at line %d in %s: record begin expecting %lld but got %lld\n", \
+        printf("Error at line %d in %s: record begin expecting "OFFFMT" but got "OFFFMT"\n", \
                __LINE__,__FILE__, exp_r_begin, r_begin); \
     } \
     /* read variables back and check contents */ \
@@ -175,7 +175,7 @@ err_out:
     CHECK_ERR \
     free(attr); \
     if (verbose && rank == 0) \
-        printf("Line %d: grow header size from %6lld to %6lld\n", \
+        printf("Line %d: grow header size from "OFFFMT" to "OFFFMT"\n", \
                __LINE__,hsize, hsize+growth); \
 }
 
@@ -252,21 +252,21 @@ tst_fmt(char       *filename,
         info_r_align = info_align[2]; /* 0 means unset in MPI info */
         MPI_Info_create(&info);
         if (info_h_align) {
-            sprintf(str, "%lld", info_h_align);
+            sprintf(str, OFFFMT, info_h_align);
             MPI_Info_set(info, "nc_header_align_size", str);
         }
         if (info_v_align) {
-            sprintf(str, "%lld", info_v_align);
+            sprintf(str, OFFFMT, info_v_align);
             MPI_Info_set(info, "nc_var_align_size", str);
         }
         if (info_r_align) {
-            sprintf(str, "%lld", info_r_align);
+            sprintf(str, OFFFMT, info_r_align);
             MPI_Info_set(info, "nc_record_align_size", str);
         }
         if (info_v_align == 0) info_v_align = info_h_align;
     }
     if (verbose && rank == 0)
-        printf("---- cmode=%d has_fix_vars=%d env_align=%lld %lld %lld info_align=%lld %lld %lld\n",
+        printf("---- cmode=%d has_fix_vars=%d env_align="OFFFMT" "OFFFMT" "OFFFMT" info_align="OFFFMT" "OFFFMT" "OFFFMT"\n",
                cmode,has_fix_vars,env_h_align,env_v_align,env_r_align,
                info_h_align,info_v_align,info_r_align);
 
@@ -562,7 +562,7 @@ int main(int argc, char** argv)
         env_align[0] = 68;  /* 17 x 4 */
         env_align[1] = 76;  /* 19 x 4 */
         env_align[2] = 92;  /* 23 x 4 */
-        sprintf(str, "nc_header_align_size=%lld;nc_var_align_size=%lld;nc_record_align_size=%lld\n",
+        sprintf(str, "nc_header_align_size="OFFFMT";nc_var_align_size="OFFFMT";nc_record_align_size="OFFFMT"\n",
                 env_align[0], env_align[1], env_align[2]);
         setenv("PNETCDF_HINTS", str, 1);
 
@@ -586,7 +586,7 @@ int main(int argc, char** argv)
         env_align[0] = 68;  /* 17 x 4 */
         env_align[1] = 0;
         env_align[2] = 92;  /* 23 x 4 */
-        sprintf(str, "nc_header_align_size=%lld;nc_record_align_size=%lld\n",
+        sprintf(str, "nc_header_align_size="OFFFMT";nc_record_align_size="OFFFMT"\n",
                 env_align[0], env_align[2]);
         setenv("PNETCDF_HINTS", str, 1);
 
@@ -602,7 +602,7 @@ int main(int argc, char** argv)
         env_align[0] = 0;
         env_align[1] = 76;  /* 19 x 4 */
         env_align[2] = 92;  /* 23 x 4 */
-        sprintf(str, "nc_var_align_size=%lld;nc_record_align_size=%lld\n",
+        sprintf(str, "nc_var_align_size="OFFFMT";nc_record_align_size="OFFFMT"\n",
                 env_align[1], env_align[2]);
         setenv("PNETCDF_HINTS", str, 1);
 
@@ -618,7 +618,7 @@ int main(int argc, char** argv)
         env_align[0] = 0;
         env_align[1] = 76;  /* 19 x 4 */
         env_align[2] = 0;
-        sprintf(str, "nc_var_align_size=%lld\n", env_align[1]);
+        sprintf(str, "nc_var_align_size="OFFFMT"\n", env_align[1]);
         setenv("PNETCDF_HINTS", str, 1);
 
         /* Set hints in environment variable PNETCDF_HINTS.
@@ -633,7 +633,7 @@ int main(int argc, char** argv)
         env_align[0] = 0;  /* 17 x 4 */
         env_align[1] = 0;
         env_align[2] = 92;  /* 23 x 4 */
-        sprintf(str, "nc_record_align_size=%lld\n", env_align[2]);
+        sprintf(str, "nc_record_align_size="OFFFMT"\n", env_align[2]);
         setenv("PNETCDF_HINTS", str, 1);
 
         /* Set hints in environment variable PNETCDF_HINTS.
@@ -652,7 +652,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/tst_symlink.c
+++ b/test/testcases/tst_symlink.c
@@ -136,7 +136,7 @@ int main(int argc, char **argv) {
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/tst_vars_fill.m4
+++ b/test/testcases/tst_vars_fill.m4
@@ -195,7 +195,7 @@ int main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/tst_version.c
+++ b/test/testcases/tst_version.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/varn_contig.c
+++ b/test/testcases/varn_contig.c
@@ -238,7 +238,7 @@ int main(int argc, char** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/varn_int.c
+++ b/test/testcases/varn_int.c
@@ -342,7 +342,7 @@ err_out:
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }

--- a/test/testcases/vectors.c
+++ b/test/testcases/vectors.c
@@ -126,7 +126,7 @@ int main(int argc, char ** argv)
     if (err == NC_NOERR) {
         MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, MPI_COMM_WORLD);
         if (rank == 0 && sum_size > 0)
-            printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+            printf("heap memory allocated by PnetCDF internally has "OFFFMT" bytes yet to be freed\n",
                    sum_size);
         if (malloc_size > 0) ncmpi_inq_malloc_list();
     }


### PR DESCRIPTION
MPI_Offset is usually typedef-ed as `long long`.
In some rare cases, it is typedef-ed as `long`.
To silence most of the compile warnings when using `%lld`
in printf statement, we first check MPI_Offset and define `OFFFMT`
to be used in all printf statements.