### PR TITLE
ncadios: Fix compilation error

### DIFF
--- a/src/drivers/ncadios/ncadios_lists.c
+++ b/src/drivers/ncadios/ncadios_lists.c
@@ -73,7 +73,7 @@ int ncadiosi_var_list_add(NC_ad_var_list *list, NC_ad_var data) {
 
     if (list->nalloc == 0){
         list->nalloc = 16;
-        list->data = NCI_Malloc(sizeof(NC_ad_varp) * list->nalloc);
+        list->data = NCI_Malloc(sizeof(NC_ad_var) * list->nalloc);
     }
     else if (list->nalloc == id){
         list->nalloc *= 2;


### PR DESCRIPTION
Fixes a typo introduced in https://github.com/Parallel-NetCDF/PnetCDF/pull/176 which causes an undeclared symbol error when building with ADIOS.