### PR TITLE
Obtain the total number of OSTs, given a folder

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1609,6 +1609,8 @@ AC_CHECK_HEADERS([lustre/lustre_user.h linux/lustre/lustre_user.h],
 if test "x$has_lustre" = xyes ; then
    AC_DEFINE(HAVE_LUSTRE, 1, [Define for LUSTRE])
    LIBS="$LIBS -llustreapi"
+   # llapi_get_obd_count() can get the total number of available OSTs
+   AC_CHECK_FUNCS([llapi_get_obd_count])
 fi
 AM_CONDITIONAL(HAVE_LUSTRE, [test x$has_lustre = xyes])
 


### PR DESCRIPTION
Thanks to Andreas Dilger at Lustre, this can be done by calling the Lustre user API
int llapi_get_obd_count(char *dir, int *count, int is_mdt);
