### PR TITLE
New hint nc_data_move_chunk_size

### DIFF
--- a/.github/workflows/mac_mpich.yml
+++ b/.github/workflows/mac_mpich.yml
@@ -115,7 +115,6 @@ jobs:
                         --with-pthread \
                         --disable-fortran \
                         --with-mpi=${GITHUB_WORKSPACE}/MPICH \
-                        MIMIC_LUSTRE=yes \
                         TESTOUTDIR=${GITHUB_WORKSPACE}/pnetcdf_output
             make -j 8 tests
         - name: Print config.log
@@ -139,42 +138,6 @@ jobs:
                fi ; \
             done
         - name: make ptests
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            make ptests
-        - name: Build PnetCDF (default configuration)
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            export PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/bin:${PATH}"
-            export LD_LIBRARY_PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/lib:${LD_LIBRARY_PATH}"
-            make distclean
-            rm -rf pnetcdf_output
-            mkdir -p pnetcdf_output
-            ./configure --disable-fortran \
-                        --with-mpi=${GITHUB_WORKSPACE}/MPICH \
-                        TESTOUTDIR=${GITHUB_WORKSPACE}/pnetcdf_output
-            make -j 8 tests
-        - name: Print config.log (default configuration)
-          if: ${{ always() }}
-          run: |
-            cat ${GITHUB_WORKSPACE}/config.log
-        - name: make check (default configuration)
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            make check
-        - name: Print test log files (default configuration)
-          if: ${{ always() }}
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            fname=`find src test examples benchmarks -type f -name "*.log"`
-            for f in $fname ; do \
-               bname=`basename $f` ; \
-               if test "x$bname" != xconfig.log ; then \
-                  echo "-------- dump $f ----------------------------" ; \
-                  cat $f ; \
-               fi ; \
-            done
-        - name: make ptests (default configuration)
           run: |
             cd ${GITHUB_WORKSPACE}
             make ptests

--- a/.github/workflows/mac_mpich.yml
+++ b/.github/workflows/mac_mpich.yml
@@ -32,7 +32,7 @@ env:
 jobs:
     build:
       runs-on: macos-latest
-      timeout-minutes: 90
+      timeout-minutes: 120
       steps:
         - uses: actions/checkout@v4
         - name: Set up dependencies

--- a/.github/workflows/mac_mpich_lustre.yml
+++ b/.github/workflows/mac_mpich_lustre.yml
@@ -1,25 +1,29 @@
-name: ubuntu_openmpi
+name: Mac OSX with MPICH (MIMIC_LUSTRE)
 
 on:
   push:
-    branches: master
+    branches: [ master, test_github_actions ]
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
       - '**/*.1'
+      - '**/*.jpg'
+      - '**/*.png'
       - 'docs/*'
       - 'test/test_installed/*'
   pull_request:
-    branches: master
+    branches: [ master, test_github_actions ]
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
       - '**/*.1'
+      - '**/*.jpg'
+      - '**/*.png'
       - 'docs/*'
       - 'test/test_installed/*'
 
 env:
-   OPENMPI_VERSION: 5.0.8
+   MPICH_VERSION: 4.3.0
    AUTOCONF_VERSION: 2.71
    AUTOMAKE_VERSION: 1.17
    LIBTOOL_VERSION: 2.5.4
@@ -27,27 +31,16 @@ env:
 
 jobs:
     build:
-      runs-on: ubuntu-latest
+      runs-on: macos-latest
       timeout-minutes: 90
       steps:
         - uses: actions/checkout@v4
         - name: Set up dependencies
           run: |
-            sudo apt-get update
-            # install gfortran
-            version=12
-            sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-            sudo apt-get update
-            sudo apt-get install -y gcc-${version} gfortran-${version}
-            sudo update-alternatives \
-              --install /usr/bin/gcc gcc /usr/bin/gcc-${version} 100 \
-              --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${version} \
-              --slave /usr/bin/gcov gcov /usr/bin/gcov-${version}
-            echo "---- gcc/gfortran version ------------------------------"
-            which gcc
-            which gfortran
-            gcc --version
-            gfortran --version
+            # brew install gcc
+            # which gcc
+            # gcc --version
+            # which gfortran
         - name: Clean up git untracked files
           run: |
             git clean -fx
@@ -87,24 +80,23 @@ jobs:
                         --silent
             make -s -j 8 install > qout 2>&1
             make -s -j 8 distclean >> qout 2>&1
-        - name: Build OPENMPI
+        - name: Build MPICH
           run: |
             cd ${GITHUB_WORKSPACE}
-            echo "Install OPENMPI ${OPENMPI_VERSION} in ${GITHUB_WORKSPACE}/OPENMPI"
-            rm -rf OPENMPI ; mkdir OPENMPI ; cd OPENMPI
-            VER_MAJOR=${OPENMPI_VERSION%.*}
-            wget -q https://download.open-mpi.org/release/open-mpi/v${VER_MAJOR}/openmpi-${OPENMPI_VERSION}.tar.gz
-            gzip -dc openmpi-${OPENMPI_VERSION}.tar.gz | tar -xf -
-            cd openmpi-${OPENMPI_VERSION}
-            ./configure --prefix=${GITHUB_WORKSPACE}/OPENMPI \
+            rm -rf MPICH ; mkdir MPICH ; cd MPICH
+            wget -q https://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz
+            gzip -dc mpich-${MPICH_VERSION}.tar.gz | tar -xf -
+            cd mpich-${MPICH_VERSION}
+            ./configure --prefix=${GITHUB_WORKSPACE}/MPICH \
                         --silent \
-                        --with-io-romio-flags="--with-file-system=ufs" \
-                        CC=gcc \
-                        FC=gfortran \
-                        FCFLAGS=-fallow-argument-mismatch
-            make -s LIBTOOLFLAGS=--silent V=1 -j 4 install > qout 2>&1
-            make -s -j 4 distclean >> qout 2>&1
-        - name: Build PnetCDF
+                        --enable-romio \
+                        --with-file-system=ufs \
+                        --with-device=ch3:sock \
+                        --disable-fortran \
+                        CC=gcc
+            make -s LIBTOOLFLAGS=--silent V=1 -j 8 install > qout 2>&1
+            make -s -j 8 distclean >> qout 2>&1
+        - name: Build PnetCDF with MIMIC_LUSTRE
           run: |
             cd ${GITHUB_WORKSPACE}
             export PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/bin:${PATH}"
@@ -115,15 +107,16 @@ jobs:
             libtool --version
             autoreconf -i
             mkdir -p pnetcdf_output
-            ./configure --prefix=${GITHUB_WORKSPACE}/PnetCDF \
-                        --enable-option-checking=fatal \
+            ./configure --enable-option-checking=fatal \
                         pnc_ac_debug=yes \
                         --enable-burst_buffering \
                         --enable-subfiling \
                         --enable-thread-safe \
                         --with-pthread \
-                        --with-mpi=${GITHUB_WORKSPACE}/OPENMPI \
-                        TESTOUTDIR=${GITHUB_WORKSPACE}/pnetcdf_output
+                        --disable-fortran \
+                        --with-mpi=${GITHUB_WORKSPACE}/MPICH \
+                        TESTOUTDIR=${GITHUB_WORKSPACE}/pnetcdf_output \
+                        MIMIC_LUSTRE=yes
             make -j 8 tests
         - name: Print config.log
           if: ${{ always() }}
@@ -152,7 +145,7 @@ jobs:
         - name: make distcheck
           run: |
             cd ${GITHUB_WORKSPACE}
-            make -j 8 distcheck DISTCHECK_CONFIGURE_FLAGS="--silent --with-mpi=${GITHUB_WORKSPACE}/OPENMPI"
+            make -j 8 distcheck DISTCHECK_CONFIGURE_FLAGS="--silent --with-mpi=${GITHUB_WORKSPACE}/MPICH"
         - name: make install
           run: |
             cd ${GITHUB_WORKSPACE}
@@ -171,7 +164,7 @@ jobs:
             cd ${GITHUB_WORKSPACE}
             make -s distclean
             rm -rf ${GITHUB_WORKSPACE}/pnetcdf_output
-            rm -rf ${GITHUB_WORKSPACE}/OPENMPI
+            rm -rf ${GITHUB_WORKSPACE}/MPICH
             rm -rf ${GITHUB_WORKSPACE}/pnetcdf_install
             rm -rf ${GITHUB_WORKSPACE}/inst
 

--- a/.github/workflows/mac_mpich_lustre.yml
+++ b/.github/workflows/mac_mpich_lustre.yml
@@ -32,7 +32,7 @@ env:
 jobs:
     build:
       runs-on: macos-latest
-      timeout-minutes: 90
+      timeout-minutes: 120
       steps:
         - uses: actions/checkout@v4
         - name: Set up dependencies

--- a/.github/workflows/mac_openmpi.yml
+++ b/.github/workflows/mac_openmpi.yml
@@ -117,7 +117,6 @@ jobs:
                         --with-pthread \
                         --disable-fortran \
                         --with-mpi=${GITHUB_WORKSPACE}/OPENMPI \
-                        MIMIC_LUSTRE=yes \
                         TESTOUTDIR=${GITHUB_WORKSPACE}/pnetcdf_output
             make -j 8 tests
         - name: Print config.log
@@ -141,42 +140,6 @@ jobs:
                fi ; \
             done
         - name: make ptests
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            make ptests
-        - name: Build PnetCDF (default configuration)
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            export PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/bin:${PATH}"
-            export LD_LIBRARY_PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/lib:${LD_LIBRARY_PATH}"
-            make distclean
-            rm -rf  pnetcdf_output
-            mkdir -p pnetcdf_output
-            ./configure --disable-fortran \
-                        --with-mpi=${GITHUB_WORKSPACE}/OPENMPI \
-                        TESTOUTDIR=${GITHUB_WORKSPACE}/pnetcdf_output
-            make -j 8 tests
-        - name: Print config.log (default configuration)
-          if: ${{ always() }}
-          run: |
-            cat ${GITHUB_WORKSPACE}/config.log
-        - name: make check (default configuration)
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            make check
-        - name: Print test log files (default configuration)
-          if: ${{ always() }}
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            fname=`find src test examples benchmarks -type f -name "*.log"`
-            for f in $fname ; do \
-               bname=`basename $f` ; \
-               if test "x$bname" != xconfig.log ; then \
-                  echo "-------- dump $f ----------------------------" ; \
-                  cat $f ; \
-               fi ; \
-            done
-        - name: make ptests (default configuration)
           run: |
             cd ${GITHUB_WORKSPACE}
             make ptests

--- a/.github/workflows/mac_openmpi.yml
+++ b/.github/workflows/mac_openmpi.yml
@@ -32,7 +32,7 @@ env:
 jobs:
     build:
       runs-on: macos-latest
-      timeout-minutes: 90
+      timeout-minutes: 120
       steps:
         - uses: actions/checkout@v4
         - name: Set up dependencies

--- a/.github/workflows/mac_openmpi_lustre.yml
+++ b/.github/workflows/mac_openmpi_lustre.yml
@@ -1,20 +1,24 @@
-name: ubuntu_openmpi
+name: Mac OSX with OpenMPI (MIMIC_LUSTRE)
 
 on:
   push:
-    branches: master
+    branches: [ master, test_github_actions ]
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
       - '**/*.1'
+      - '**/*.jpg'
+      - '**/*.png'
       - 'docs/*'
       - 'test/test_installed/*'
   pull_request:
-    branches: master
+    branches: [ master, test_github_actions ]
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
       - '**/*.1'
+      - '**/*.jpg'
+      - '**/*.png'
       - 'docs/*'
       - 'test/test_installed/*'
 
@@ -27,27 +31,16 @@ env:
 
 jobs:
     build:
-      runs-on: ubuntu-latest
+      runs-on: macos-latest
       timeout-minutes: 90
       steps:
         - uses: actions/checkout@v4
         - name: Set up dependencies
           run: |
-            sudo apt-get update
-            # install gfortran
-            version=12
-            sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-            sudo apt-get update
-            sudo apt-get install -y gcc-${version} gfortran-${version}
-            sudo update-alternatives \
-              --install /usr/bin/gcc gcc /usr/bin/gcc-${version} 100 \
-              --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${version} \
-              --slave /usr/bin/gcov gcov /usr/bin/gcov-${version}
-            echo "---- gcc/gfortran version ------------------------------"
-            which gcc
-            which gfortran
-            gcc --version
-            gfortran --version
+            # brew install gcc
+            # which gcc
+            # gcc --version
+            # which gfortran
         - name: Clean up git untracked files
           run: |
             git clean -fx
@@ -90,7 +83,6 @@ jobs:
         - name: Build OPENMPI
           run: |
             cd ${GITHUB_WORKSPACE}
-            echo "Install OPENMPI ${OPENMPI_VERSION} in ${GITHUB_WORKSPACE}/OPENMPI"
             rm -rf OPENMPI ; mkdir OPENMPI ; cd OPENMPI
             VER_MAJOR=${OPENMPI_VERSION%.*}
             wget -q https://download.open-mpi.org/release/open-mpi/v${VER_MAJOR}/openmpi-${OPENMPI_VERSION}.tar.gz
@@ -99,12 +91,14 @@ jobs:
             ./configure --prefix=${GITHUB_WORKSPACE}/OPENMPI \
                         --silent \
                         --with-io-romio-flags="--with-file-system=ufs" \
-                        CC=gcc \
-                        FC=gfortran \
-                        FCFLAGS=-fallow-argument-mismatch
-            make -s LIBTOOLFLAGS=--silent V=1 -j 4 install > qout 2>&1
-            make -s -j 4 distclean >> qout 2>&1
-        - name: Build PnetCDF
+                        --with-hwloc=internal \
+                        --with-pmix=internal \
+                        --with-libevent=internal \
+                        --disable-mpi-fortran \
+                        CC=gcc
+            make -s LIBTOOLFLAGS=--silent V=1 -j 8 install > qout 2>&1
+            make -s -j 8 distclean >> qout 2>&1
+        - name: Build PnetCDF (MIMIC_LUSTRE)
           run: |
             cd ${GITHUB_WORKSPACE}
             export PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/bin:${PATH}"
@@ -115,15 +109,16 @@ jobs:
             libtool --version
             autoreconf -i
             mkdir -p pnetcdf_output
-            ./configure --prefix=${GITHUB_WORKSPACE}/PnetCDF \
-                        --enable-option-checking=fatal \
+            ./configure --enable-option-checking=fatal \
                         pnc_ac_debug=yes \
                         --enable-burst_buffering \
                         --enable-subfiling \
                         --enable-thread-safe \
                         --with-pthread \
+                        --disable-fortran \
                         --with-mpi=${GITHUB_WORKSPACE}/OPENMPI \
-                        TESTOUTDIR=${GITHUB_WORKSPACE}/pnetcdf_output
+                        TESTOUTDIR=${GITHUB_WORKSPACE}/pnetcdf_output \
+                        MIMIC_LUSTRE=yes
             make -j 8 tests
         - name: Print config.log
           if: ${{ always() }}

--- a/.github/workflows/mac_openmpi_lustre.yml
+++ b/.github/workflows/mac_openmpi_lustre.yml
@@ -32,7 +32,7 @@ env:
 jobs:
     build:
       runs-on: macos-latest
-      timeout-minutes: 90
+      timeout-minutes: 120
       steps:
         - uses: actions/checkout@v4
         - name: Set up dependencies

--- a/.github/workflows/ubuntu_mpich.yml
+++ b/.github/workflows/ubuntu_mpich.yml
@@ -120,6 +120,7 @@ jobs:
             automake --version
             libtool --version
             autoreconf -i
+            mkdir -p pnetcdf_output
             ./configure --prefix=${GITHUB_WORKSPACE}/PnetCDF \
                         --enable-option-checking=fatal \
                         pnc_ac_debug=yes \
@@ -128,7 +129,7 @@ jobs:
                         --enable-thread-safe \
                         --with-pthread \
                         --with-mpi=${GITHUB_WORKSPACE}/MPICH \
-                        MIMIC_LUSTRE=yes
+                        TESTOUTDIR=${GITHUB_WORKSPACE}/pnetcdf_output
             make -j 8 tests
         - name: Print config.log
           if: ${{ always() }}
@@ -151,39 +152,6 @@ jobs:
                fi ; \
             done
         - name: make ptests
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            make ptests
-        - name: Build PnetCDF (default configuration)
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            export PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/bin:${PATH}"
-            export LD_LIBRARY_PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/lib:${LD_LIBRARY_PATH}"
-            make distclean
-            ./configure --prefix=${GITHUB_WORKSPACE}/PnetCDF \
-                        --with-mpi=${GITHUB_WORKSPACE}/MPICH
-            make -j 8 tests
-        - name: Print config.log (default configuration)
-          if: ${{ always() }}
-          run: |
-            cat ${GITHUB_WORKSPACE}/config.log
-        - name: make check (default configuration)
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            make check
-        - name: Print test log files (default configuration)
-          if: ${{ always() }}
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            fname=`find src test examples benchmarks -type f -name "*.log"`
-            for f in $fname ; do \
-               bname=`basename $f` ; \
-               if test "x$bname" != xconfig.log ; then \
-                  echo "-------- dump $f ----------------------------" ; \
-                  cat $f ; \
-               fi ; \
-            done
-        - name: make ptests (default configuration)
           run: |
             cd ${GITHUB_WORKSPACE}
             make ptests

--- a/.github/workflows/ubuntu_mpich.yml
+++ b/.github/workflows/ubuntu_mpich.yml
@@ -28,7 +28,7 @@ env:
 jobs:
     build:
       runs-on: ubuntu-latest
-      timeout-minutes: 90
+      timeout-minutes: 120
       steps:
         - uses: actions/checkout@v4
         - name: Set up dependencies

--- a/.github/workflows/ubuntu_mpich_lustre.yml
+++ b/.github/workflows/ubuntu_mpich_lustre.yml
@@ -28,7 +28,7 @@ env:
 jobs:
     build:
       runs-on: ubuntu-latest
-      timeout-minutes: 90
+      timeout-minutes: 120
       steps:
         - uses: actions/checkout@v4
         - name: Set up dependencies

--- a/.github/workflows/ubuntu_mpich_lustre.yml
+++ b/.github/workflows/ubuntu_mpich_lustre.yml
@@ -1,4 +1,4 @@
-name: ubuntu_openmpi
+name: ubuntu_mpich (MIMIC_LUSTRE)
 
 on:
   push:
@@ -19,7 +19,7 @@ on:
       - 'test/test_installed/*'
 
 env:
-   OPENMPI_VERSION: 5.0.8
+   MPICH_VERSION: 4.3.0
    AUTOCONF_VERSION: 2.71
    AUTOMAKE_VERSION: 1.17
    LIBTOOL_VERSION: 2.5.4
@@ -87,24 +87,30 @@ jobs:
                         --silent
             make -s -j 8 install > qout 2>&1
             make -s -j 8 distclean >> qout 2>&1
-        - name: Build OPENMPI
+        - name: Build MPICH
           run: |
             cd ${GITHUB_WORKSPACE}
-            echo "Install OPENMPI ${OPENMPI_VERSION} in ${GITHUB_WORKSPACE}/OPENMPI"
-            rm -rf OPENMPI ; mkdir OPENMPI ; cd OPENMPI
-            VER_MAJOR=${OPENMPI_VERSION%.*}
-            wget -q https://download.open-mpi.org/release/open-mpi/v${VER_MAJOR}/openmpi-${OPENMPI_VERSION}.tar.gz
-            gzip -dc openmpi-${OPENMPI_VERSION}.tar.gz | tar -xf -
-            cd openmpi-${OPENMPI_VERSION}
-            ./configure --prefix=${GITHUB_WORKSPACE}/OPENMPI \
+            echo "Install MPICH ${MPICH_VERSION} in ${GITHUB_WORKSPACE}/MPICH"
+            rm -rf MPICH ; mkdir MPICH ; cd MPICH
+            # git clone -q https://github.com/pmodels/mpich.git
+            # cd mpich
+            # git submodule update --init
+            # ./autogen.sh
+            wget -q https://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz
+            gzip -dc mpich-${MPICH_VERSION}.tar.gz | tar -xf -
+            cd mpich-${MPICH_VERSION}
+            ./configure --prefix=${GITHUB_WORKSPACE}/MPICH \
                         --silent \
-                        --with-io-romio-flags="--with-file-system=ufs" \
-                        CC=gcc \
-                        FC=gfortran \
+                        --enable-romio \
+                        --with-file-system=ufs \
+                        --with-device=ch3:sock \
+                        --enable-fortran \
+                        CC=gcc FC=gfortran \
+                        FFLAGS=-fallow-argument-mismatch \
                         FCFLAGS=-fallow-argument-mismatch
             make -s LIBTOOLFLAGS=--silent V=1 -j 4 install > qout 2>&1
             make -s -j 4 distclean >> qout 2>&1
-        - name: Build PnetCDF
+        - name: Build PnetCDF (MIMIC_LUSTRE)
           run: |
             cd ${GITHUB_WORKSPACE}
             export PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/bin:${PATH}"
@@ -122,8 +128,9 @@ jobs:
                         --enable-subfiling \
                         --enable-thread-safe \
                         --with-pthread \
-                        --with-mpi=${GITHUB_WORKSPACE}/OPENMPI \
-                        TESTOUTDIR=${GITHUB_WORKSPACE}/pnetcdf_output
+                        --with-mpi=${GITHUB_WORKSPACE}/MPICH \
+                        TESTOUTDIR=${GITHUB_WORKSPACE}/pnetcdf_output \
+                        MIMIC_LUSTRE=yes
             make -j 8 tests
         - name: Print config.log
           if: ${{ always() }}
@@ -152,7 +159,7 @@ jobs:
         - name: make distcheck
           run: |
             cd ${GITHUB_WORKSPACE}
-            make -j 8 distcheck DISTCHECK_CONFIGURE_FLAGS="--silent --with-mpi=${GITHUB_WORKSPACE}/OPENMPI"
+            make -j 8 distcheck DISTCHECK_CONFIGURE_FLAGS="--silent --with-mpi=${GITHUB_WORKSPACE}/MPICH"
         - name: make install
           run: |
             cd ${GITHUB_WORKSPACE}
@@ -171,7 +178,7 @@ jobs:
             cd ${GITHUB_WORKSPACE}
             make -s distclean
             rm -rf ${GITHUB_WORKSPACE}/pnetcdf_output
-            rm -rf ${GITHUB_WORKSPACE}/OPENMPI
+            rm -rf ${GITHUB_WORKSPACE}/MPICH
             rm -rf ${GITHUB_WORKSPACE}/pnetcdf_install
             rm -rf ${GITHUB_WORKSPACE}/inst
 

--- a/.github/workflows/ubuntu_openmpi.yml
+++ b/.github/workflows/ubuntu_openmpi.yml
@@ -28,7 +28,7 @@ env:
 jobs:
     build:
       runs-on: ubuntu-latest
-      timeout-minutes: 90
+      timeout-minutes: 120
       steps:
         - uses: actions/checkout@v4
         - name: Set up dependencies

--- a/.github/workflows/ubuntu_openmpi_adios.yml
+++ b/.github/workflows/ubuntu_openmpi_adios.yml
@@ -29,7 +29,7 @@ env:
 jobs:
     build:
       runs-on: ubuntu-latest
-      timeout-minutes: 90
+      timeout-minutes: 120
       steps:
         - uses: actions/checkout@v4
         - name: Set up dependencies

--- a/.github/workflows/ubuntu_openmpi_adios.yml
+++ b/.github/workflows/ubuntu_openmpi_adios.yml
@@ -139,7 +139,6 @@ jobs:
                         --with-pthread \
                         --with-mpi=${GITHUB_WORKSPACE}/OPENMPI \
                         --with-adios=${GITHUB_WORKSPACE}/ADIOS \
-                        MIMIC_LUSTRE=yes \
                         TESTOUTDIR=${GITHUB_WORKSPACE}/pnetcdf_output
             make -j 8 tests
         - name: Print config.log
@@ -163,42 +162,6 @@ jobs:
                fi ; \
             done
         - name: make ptests
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            make ptests
-        - name: Build PnetCDF (default configuration)
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            export PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/bin:${PATH}"
-            export LD_LIBRARY_PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/lib:${LD_LIBRARY_PATH}"
-            make distclean
-            mkdir -p pnetcdf_output
-            ./configure --prefix=${GITHUB_WORKSPACE}/PnetCDF \
-                        --with-mpi=${GITHUB_WORKSPACE}/OPENMPI \
-                        --with-adios=${GITHUB_WORKSPACE}/ADIOS \
-                        TESTOUTDIR=${GITHUB_WORKSPACE}/pnetcdf_output
-            make -j 8 tests
-        - name: Print config.log (default configuration)
-          if: ${{ always() }}
-          run: |
-            cat ${GITHUB_WORKSPACE}/config.log
-        - name: make check (default configuration)
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            make check
-        - name: Print test log files (default configuration)
-          if: ${{ always() }}
-          run: |
-            cd ${GITHUB_WORKSPACE}
-            fname=`find src test examples benchmarks -type f -name "*.log"`
-            for f in $fname ; do \
-               bname=`basename $f` ; \
-               if test "x$bname" != xconfig.log ; then \
-                  echo "-------- dump $f ----------------------------" ; \
-                  cat $f ; \
-               fi ; \
-            done
-        - name: make ptests (default configuration)
           run: |
             cd ${GITHUB_WORKSPACE}
             make ptests

--- a/.github/workflows/ubuntu_openmpi_lustre.yml
+++ b/.github/workflows/ubuntu_openmpi_lustre.yml
@@ -28,7 +28,7 @@ env:
 jobs:
     build:
       runs-on: ubuntu-latest
-      timeout-minutes: 90
+      timeout-minutes: 120
       steps:
         - uses: actions/checkout@v4
         - name: Set up dependencies

--- a/.github/workflows/ubuntu_openmpi_lustre.yml
+++ b/.github/workflows/ubuntu_openmpi_lustre.yml
@@ -1,4 +1,4 @@
-name: ubuntu_openmpi
+name: ubuntu_openmpi (MIMIC_LUSTRE)
 
 on:
   push:
@@ -104,7 +104,7 @@ jobs:
                         FCFLAGS=-fallow-argument-mismatch
             make -s LIBTOOLFLAGS=--silent V=1 -j 4 install > qout 2>&1
             make -s -j 4 distclean >> qout 2>&1
-        - name: Build PnetCDF
+        - name: Build PnetCDF (MIMIC_LUSTRE)
           run: |
             cd ${GITHUB_WORKSPACE}
             export PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/bin:${PATH}"
@@ -123,7 +123,8 @@ jobs:
                         --enable-thread-safe \
                         --with-pthread \
                         --with-mpi=${GITHUB_WORKSPACE}/OPENMPI \
-                        TESTOUTDIR=${GITHUB_WORKSPACE}/pnetcdf_output
+                        TESTOUTDIR=${GITHUB_WORKSPACE}/pnetcdf_output \
+                        MIMIC_LUSTRE=yes
             make -j 8 tests
         - name: Print config.log
           if: ${{ always() }}

--- a/benchmarks/WRF-IO/wrf_io.c
+++ b/benchmarks/WRF-IO/wrf_io.c
@@ -1190,7 +1190,7 @@ err_out:
 static
 int grow_header_benchmark(char *in_file)
 {
-    char value[MPI_MAX_INFO_VAL], *attr;
+    char value[MPI_MAX_INFO_VAL], cb_node_list[MPI_MAX_INFO_VAL], *attr;
     int i, err=NC_NOERR, nprocs, rank, ncid, ndims, dimid[3];
     int varid, unlimdimid, nvars, fix_nvars, rec_nvars, len, flag;
     double timing, max_t;
@@ -1350,6 +1350,12 @@ int grow_header_benchmark(char *in_file)
     } else
         nc_data_move_chunk_size = 0;
 
+    MPI_Info_get_valuelen(info, "cb_node_list", &len, &flag);
+    if (flag)
+        MPI_Info_get(info, "cb_node_list", len+1, cb_node_list, &flag);
+    else
+        *cb_node_list = '\0';
+
     MPI_Info_free(&info);
 
     /* close file */
@@ -1384,6 +1390,8 @@ int grow_header_benchmark(char *in_file)
         printf("Write bandwidth:                %.2f MiB/s\n", bw/max_t);
         printf("                                %.2f GiB/s\n", bw/1024.0/max_t);
         printf("Hint nc_data_move_chunk_size    %lld\n", nc_data_move_chunk_size);
+        if (*cb_node_list != '\0')
+            printf("Hint cb_node_list =             %s\n", cb_node_list);
         printf("-----------------------------------------------------------\n");
     }
 

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -45,7 +45,11 @@ This is essentially a placeholder for the next release note ...
   + none
 
 * New PnetCDF hints
-  + none
+  + 'nc_data_move_chunk_size' -- When adding new data objects into an existing
+    file, the data section may need to be moved to a higher file offset. The
+    movement is performed in chunks. This hint allows users to customized the
+    chunk size. The default is 1048576 bytes, i.e. 1 MiB.
+    See [PR #203](https://github.com/Parallel-NetCDF/PnetCDF/pull/203).
 
 * New run-time environment variables
   + none

--- a/src/drivers/ncmpio/ncmpio_file_misc.c
+++ b/src/drivers/ncmpio/ncmpio_file_misc.c
@@ -456,8 +456,11 @@ ncmpio_inq_misc(void       *ncdp,
         sprintf(value, OFFFMT, ncp->r_align);
         MPI_Info_set(*info_used, "nc_record_align_size", value);
 
-        sprintf(value, "%d", ncp->chunk);
+        sprintf(value, "%d", ncp->hdr_chunk);
         MPI_Info_set(*info_used, "nc_header_read_chunk_size", value);
+
+        sprintf(value, "%d", ncp->data_chunk);
+        MPI_Info_set(*info_used, "nc_data_move_chunk_size", value);
 
         if (fIsSet(ncp->flags, NC_MODE_SWAP_ON))
             MPI_Info_set(*info_used, "nc_in_place_swap", "enable");

--- a/src/drivers/ncmpio/ncmpio_util.c
+++ b/src/drivers/ncmpio/ncmpio_util.c
@@ -45,7 +45,7 @@ void ncmpio_hint_extract(NC       *ncp,
     ncp->hdr_chunk = PNC_HDR_READ_CHUNK_SIZE;
 
     /* chunk size for moving variables to higher offsets */
-    ncp->data_chunk = PNC_DATA_MOVE_CHUNK_SIZE;
+    ncp->data_chunk = -1;
 
     /* buffer to pack noncontiguous user buffers when calling wait() */
     ncp->ibuf_size = PNC_DEFAULT_IBUF_SIZE;
@@ -256,7 +256,7 @@ void ncmpio_hint_extract(NC       *ncp,
         llval = strtoll(value, NULL, 10);
         if (errno == 0) {
             if (llval < 0)
-                ncp->data_chunk = PNC_DATA_MOVE_CHUNK_SIZE;
+                ncp->data_chunk = -1;
             else if (llval > NC_MAX_INT) /* limit to NC_MAX_INT */
                 ncp->data_chunk = NC_MAX_INT;
             else

--- a/test/parallel_run.sh
+++ b/test/parallel_run.sh
@@ -12,11 +12,27 @@ VERBOSE=no
 
 exe_cmd() {
    local lineno=${BASH_LINENO[$((${#BASH_LINENO[@]} - 2))]}
+
+   saved_PNETCDF_HINTS=
+   cmd=`basename $1`
+   if test "x$MIMIC_LUSTRE" = x1 && test "x$cmd" = xncmpidiff ; then
+      # echo "export MIMIC_STRIPE_SIZE=1048576"
+      export MIMIC_STRIPE_SIZE=1048576
+      saved_PNETCDF_HINTS=$PNETCDF_HINTS
+      unset PNETCDF_HINTS
+   fi
+
    if test "x$VERBOSE" = xyes || test "x$DRY_RUN" = xyes ; then
       echo "Line $lineno CMD: $MPIRUN $@"
    fi
    if test "x$DRY_RUN" = xno ; then
       $MPIRUN $@
+   fi
+
+   if test "x$MIMIC_LUSTRE" = x1 && test "x$cmd" = xncmpidiff ; then
+      # echo "unset MIMIC_STRIPE_SIZE"
+      unset MIMIC_STRIPE_SIZE
+      export PNETCDF_HINTS=$saved_PNETCDF_HINTS
    fi
 }
 


### PR DESCRIPTION
When adding new data objects into an existing file, the data section may need to be moved to a higher file offset.  The movement is performed in chunks. This hint allows users to customized the chunk size. The default is 1048576 bytes, i.e. 1 MiB.

When file striping unit size is known after file create/open, and the hint nc_data_move_chunk_size is not set by users, the chunk size will be set to the striping size.

When moving variable sections, starting file offsets of all read and write chunks will be aligned with the hint nc_data_move_chunk_size.