### PR TITLE
bug fix: condition on info object duplication

### DIFF
--- a/src/drivers/common/dtype_decode.c
+++ b/src/drivers/common/dtype_decode.c
@@ -299,7 +299,7 @@ int ncmpii_dtype_decode(MPI_Datatype  dtype,
     MPI_Datatype ptype, *array_of_dtypes=NULL;
     MPI_Aint *array_of_adds=NULL;
 #ifdef HAVE_MPI_LARGE_COUNT
-    MPI_Count num_ints, num_adds, num_larges, num_dtypes, *array_of_larges;
+    MPI_Count num_ints, num_adds, num_larges, num_dtypes, *array_of_larges=NULL;
     int *distribs, *dargs, *psizes;
     MPI_Count *gzises;
 #else

--- a/src/drivers/ncmpio/ncmpio_enddef.c
+++ b/src/drivers/ncmpio/ncmpio_enddef.c
@@ -166,7 +166,7 @@ move_file_block(NC         *ncp,
 {
     int rank, align_rank, nprocs, status=NC_NOERR, do_coll;
     void *buf;
-    MPI_Offset last_block, mv_amnt, p_units, end_off, end_block;
+    MPI_Offset mv_amnt, p_units, end_off, end_block;
     MPI_Offset off_last, off_from, off_to, rlen, wlen;
     MPI_Comm comm;
     PNCIO_View buf_view;
@@ -182,8 +182,7 @@ move_file_block(NC         *ncp,
     nprocs = (ncp->ina_comm == MPI_COMM_NULL) ? ncp->nprocs : ncp->ina_nprocs;
 
     /* align file access for all ranks */
-    align_rank = rank + (to / ncp->data_chunk);
-    align_rank %= nprocs;
+    align_rank = (to / ncp->data_chunk + rank) % nprocs;
 
     /* Use MPI collective I/O subroutines to move data, only if nproc > 1 and
      * MPI-IO hint "romio_no_indep_rw" is set to true. Otherwise, use MPI

--- a/src/drivers/pncio/pncio_open.c
+++ b/src/drivers/pncio/pncio_open.c
@@ -256,12 +256,7 @@ int PNCIO_File_open(MPI_Comm    comm,
 
     /* create and initialize info object */
     fd->hints = (PNCIO_Hints*) NCI_Calloc(1, sizeof(PNCIO_Hints));
-    if (info == MPI_INFO_NULL)
-        MPI_Info_create(&fd->info);
-    else
-        MPI_Info_dup(info, &fd->info);
-
-    status = PNCIO_File_SetInfo(fd, fd->info);
+    status = PNCIO_File_SetInfo(fd, info);
     if (status != NC_NOERR && status != NC_EMULTIDEFINE_HINTS) {
         /* Inconsistent I/O hints is not a fatal error.
          * In PNCIO_File_SetInfo(), root's hints overwrite local's.


### PR DESCRIPTION
Info objects can only be passed to ncmpi file create/open call once.
Fix the condition when duplicating an info object internally.

Other minor fixes for compilation warnings.