### PR TITLE
ncmpidiff.c fix warnings

### DIFF
--- a/src/utils/ncmpidiff/cdfdiff.c
+++ b/src/utils/ncmpidiff/cdfdiff.c
@@ -396,9 +396,9 @@ int main(int argc, char **argv)
 
     /* compare file header */
     if (check_header) {
-        NC_attr *attr[2];
-        NC_dim  *dim[2];
-        NC_var  *var[2];
+        NC_attr *attr[2]={NULL, NULL};
+        NC_dim  *dim[2]={NULL, NULL};
+        NC_var  *var[2]={NULL, NULL};
 
         /* compare number of dimensions defined */
         if (ndims[0] != ndims[1]) {

--- a/src/utils/ncmpidiff/ncmpidiff.c
+++ b/src/utils/ncmpidiff/ncmpidiff.c
@@ -180,7 +180,7 @@ int main(int argc, char **argv)
                 check_tolerance = 1;
                 free(str);
                 break;
-            case '?':
+            default:
                 usage(rank, argv[0]);
                 break;
         }
@@ -235,6 +235,12 @@ int main(int argc, char **argv)
                              tolerance_ratio);
 
     MPI_Info_free(&info);
+
+    if (num_vars > 0) {
+        for (i=0; i<num_vars; i++)
+            free(var_names[i]);
+        free(var_names);
+    }
 
     MPI_Finalize();
 

--- a/src/utils/ncmpidiff/ncmpidiff_core.c
+++ b/src/utils/ncmpidiff/ncmpidiff_core.c
@@ -308,22 +308,22 @@ get_type(int type)
 }
 
 /*----< ncmpidiff_core() >---------------------------------------------------*/
-int ncmpidiff_core(const char  *file1,
-                   const char  *file2,
-                   MPI_Comm     comm,
-                   MPI_Info     info,
-                   int          verbose,
-                   int          quiet,
-                   int          check_header,
-                   int          check_variable_list,
-                   int          check_entire_file,
-                   int          num_vars,
-                   char       **var_names,
-                   int          check_tolerance,
-                   int          first_diff,
-                   char        *cmd_opts,
-                   double       tolerance_difference,
-                   double       tolerance_ratio)
+MPI_Offset ncmpidiff_core(const char  *file1,
+                          const char  *file2,
+                          MPI_Comm     comm,
+                          MPI_Info     info,
+                          int          verbose,
+                          int          quiet,
+                          int          check_header,
+                          int          check_variable_list,
+                          int          check_entire_file,
+                          int          num_vars,
+                          char       **var_names,
+                          int          check_tolerance,
+                          int          first_diff,
+                          char        *cmd_opts,
+                          double       tolerance_difference,
+                          double       tolerance_ratio)
 {
     char *name[2];
     int i, j, err, rank, nprocs;
@@ -905,17 +905,18 @@ cmp_vars:
         free(dimids[0]);
         free(dimids[1]);
     }
-    free(name[0]);
-    free(name[1]);
 
+cmp_exit:
     /* free up the memory previously allocated */
-    if (num_vars) {
+    if (check_entire_file) {
         for (i=0; i<num_vars; i++)
             free(var_names[i]);
         free(var_names);
     }
 
-cmp_exit:
+    free(name[0]);
+    free(name[1]);
+
     for (i=0; i<2; i++) {
         /* close files */
         if (ncid[i] >= 0) {

--- a/src/utils/ncmpidiff/ncmpidiff_core.h
+++ b/src/utils/ncmpidiff/ncmpidiff_core.h
@@ -3,21 +3,22 @@
  *  See COPYRIGHT notice in top-level directory.
  */
 
-#include <stdlib.h>
+#include <mpi.h>
 
-int ncmpidiff_core(const char  *file1,
-                   const char  *file2,
-                   MPI_Comm     comm,
-                   MPI_Info     info,
-                   int          verbose,
-                   int          quiet,
-                   int          check_header,
-                   int          check_variable_list,
-                   int          check_entire_file,
-                   int          num_vars,
-                   char       **var_names,
-                   int          check_tolerance,
-                   int          first_diff,
-                   char        *cmd_opts,
-                   double       tolerance_difference,
-                   double       tolerance_ratio);
+extern
+MPI_Offset ncmpidiff_core(const char  *file1,
+                          const char  *file2,
+                          MPI_Comm     comm,
+                          MPI_Info     info,
+                          int          verbose,
+                          int          quiet,
+                          int          check_header,
+                          int          check_variable_list,
+                          int          check_entire_file,
+                          int          num_vars,
+                          char       **var_names,
+                          int          check_tolerance,
+                          int          first_diff,
+                          char        *cmd_opts,
+                          double       tolerance_difference,
+                          double       tolerance_ratio);


### PR DESCRIPTION
* ncmpidiff_core() return data type of MPI_Offset (number of differences)
* ncmpidiff.c switch default to call usage()
* free allocated buffers