### PR TITLE
add a new hint nc_striping

### DIFF
--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -50,6 +50,15 @@ This is essentially a placeholder for the next release note ...
     movement is performed in chunks. This hint allows users to customized the
     chunk size. The default is 1048576 bytes, i.e. 1 MiB.
     See [PR #203](https://github.com/Parallel-NetCDF/PnetCDF/pull/203).
+  + 'nc_striping' -- When creating a new file on the Lustre file system, this
+    hint advises PnetCDF to set the file's striping configuration. The hint
+    value is either "auto" or "inherit". The former sets the striping count to
+    the number of compute nodes found in the MPI communicator passed to
+    `ncmpi_create()`. The latter makes the new file to inherit the folder's
+    striping settings if the folder's striping is set. This hint's default is
+    "auto". Hint 'nc_striping' is ignored when MPI-IO hints `striping_factor`
+    and `striping_unit`, are set.
+    See [PR #222](https://github.com/Parallel-NetCDF/PnetCDF/pull/222).
 
 * New run-time environment variables
   + none

--- a/src/drivers/ncmpio/ncmpio_NC.h
+++ b/src/drivers/ncmpio/ncmpio_NC.h
@@ -409,20 +409,21 @@ struct NC {
 #endif
     int           hdr_chunk;    /* chunk size for reading header, one chunk at a time */
     int           data_chunk;   /* chunk size for moving variables to higher offsets */
-    MPI_Offset    v_align;     /* alignment of the beginning of fixed-size variables */
-    MPI_Offset    r_align;     /* file alignment for record variable section */
-    MPI_Offset    info_v_align;/* v_align set in MPI Info object */
-    MPI_Offset    info_r_align;/* r_align set in MPI Info object */
-    MPI_Offset    h_minfree;   /* pad at the end of the header section */
-    MPI_Offset    v_minfree;   /* pad at the end of the data section for fixed-size variables */
-    MPI_Offset    ibuf_size;   /* packing buffer size for flushing noncontig
-                                  user buffer during wait */
-    MPI_Offset    xsz;         /* size of this file header, <= var[0].begin */
-    MPI_Offset    begin_var;   /* file offset of the first fixed-size variable,
-                                  if no fixed-sized variable, it is the offset
-                                  of first record variable. This value is also
-                                  the size of file header extent. */
-    MPI_Offset    begin_rec;   /* file offset of the first 'record' */
+    int           striping;     /* PNCIO_STRIPING_AUTO or PNCIO_STRIPING_INHERIT */
+    MPI_Offset    v_align;      /* alignment of the beginning of fixed-size variables */
+    MPI_Offset    r_align;      /* file alignment for record variable section */
+    MPI_Offset    info_v_align; /* v_align set in MPI Info object */
+    MPI_Offset    info_r_align; /* r_align set in MPI Info object */
+    MPI_Offset    h_minfree;    /* pad at the end of the header section */
+    MPI_Offset    v_minfree;    /* pad at the end of the data section for fixed-size variables */
+    MPI_Offset    ibuf_size;    /* packing buffer size for flushing noncontig
+                                   user buffer during wait */
+    MPI_Offset    xsz;          /* size of this file header, <= var[0].begin */
+    MPI_Offset    begin_var;    /* file offset of the first fixed-size variable,
+                                   if no fixed-sized variable, it is the offset
+                                   of first record variable. This value is also
+                                   the size of file header extent. */
+    MPI_Offset    begin_rec;    /* file offset of the first 'record' */
 
     MPI_Offset    fix_end;   /* end offset of last fix-sized variable */
     MPI_Offset    recsize;   /* length of 'record': sum of single record sizes

--- a/src/drivers/ncmpio/ncmpio_util.c
+++ b/src/drivers/ncmpio/ncmpio_util.c
@@ -263,6 +263,14 @@ void ncmpio_hint_extract(NC       *ncp,
                 ncp->data_chunk = (int)llval;
         }
     }
+
+    /* When creating a file, inherit file striping from the parent folder or
+     * let PnetCDF to decide.
+     */
+    ncp->striping = PNCIO_STRIPING_AUTO;
+    MPI_Info_get(info, "nc_striping", MPI_MAX_INFO_VAL-1, value, &flag);
+    if (flag && strcasecmp(value, "inherit") == 0)
+        ncp->striping = PNCIO_STRIPING_INHERIT;
 }
 
 /*----< ncmpio_hint_set() >--------------------------------------------------*/
@@ -372,6 +380,14 @@ void ncmpio_hint_set(NC       *ncp,
     }
     else /* Update hint "num_aggrs_per_node" to indicate disabled. */
         MPI_Info_set(info, "nc_num_aggrs_per_node", "0");
+
+    /* When creating a file, inherit file striping from the parent folder or
+     * let PnetCDF to decide.
+     */
+    if (ncp->striping == PNCIO_STRIPING_AUTO)
+        MPI_Info_set(info, "nc_striping", "auto");
+    else
+        MPI_Info_set(info, "nc_striping", "inherit");
 }
 
 /*----< ncmpio_first_offset() >-----------------------------------------------*/

--- a/src/drivers/pncio/pncio.h
+++ b/src/drivers/pncio/pncio.h
@@ -105,7 +105,11 @@
 #define PNCIO_HINT_DISABLE 0
 #define PNCIO_HINT_ENABLE 1
 
+#define PNCIO_STRIPING_AUTO -1
+#define PNCIO_STRIPING_INHERIT 0
+
 typedef struct {
+    int nc_striping;
     int striping_factor;
     int striping_unit;
     int start_iodevice;

--- a/src/drivers/pncio/pncio_hints.c
+++ b/src/drivers/pncio/pncio_hints.c
@@ -41,6 +41,8 @@
             fd->hints->key = PNCIO_HINT_ENABLE; \
         else if (!strcasecmp(value, "disable")) \
             fd->hints->key = PNCIO_HINT_DISABLE; \
+        else if (!strcasecmp(value, "inherit")) \
+            fd->hints->key = PNCIO_STRIPING_INHERIT; \
     } \
 }
 
@@ -89,6 +91,7 @@ int hint_consistency_check(PNCIO_File *fd)
         MPI_Bcast(root_hints, sizeof(PNCIO_Hints), MPI_BYTE, 0, fd->comm);
 
         /* check hints individually against root's */
+        CHECK_HINT(nc_striping);
         CHECK_HINT(striping_factor);
         CHECK_HINT(striping_unit);
         CHECK_HINT(start_iodevice);
@@ -177,6 +180,7 @@ PNCIO_File_SetInfo(PNCIO_File *fd,
      * a user's info. Thus, default values used below are to indicate
      * whether or not they have been customized by the users.
      */
+    fd->hints->nc_striping = PNCIO_STRIPING_AUTO;
     fd->hints->striping_unit = 0;
     fd->hints->striping_factor = 0;
     fd->hints->start_iodevice = -1;
@@ -234,6 +238,7 @@ PNCIO_File_SetInfo(PNCIO_File *fd,
     GET_INFO_INT(ind_rd_buffer_size);
 
     /* file striping configuration */
+    GET_INFO_STR(nc_striping);
     GET_INFO_INT(striping_unit);
     GET_INFO_INT(striping_factor);
     GET_INFO_INT(start_iodevice);


### PR DESCRIPTION
'nc_striping' -- When creating a new file on the Lustre file system, this hint advises PnetCDF to set the file's striping configuration. The hint value is either "auto" or "inherit". The former sets the striping count to the number of compute nodes found in the MPI communicator passed to `ncmpi_create()`. The latter makes the new file to inherit the folder's striping settings if the folder's striping is set. This hint's default is "auto". Hint 'nc_striping' is ignored when MPI-IO hints `striping_factor` and `striping_unit`, are set.

This new feature can be tested by running `examples/C/create_open.c` on two compute nodes, while setting the following hints.
```
export PNETCDF_HINTS"=nc_pncio=disable;nc_striping=auto"
srun -n 256 ./create_open $SCRATCH/testfile.nc
export PNETCDF_HINTS"=nc_pncio=disable;nc_striping=auto;striping_factor=8"
srun -n 256 ./create_open $SCRATCH/testfile.nc
export PNETCDF_HINTS"=nc_pncio=disable;nc_striping=inherit"
srun -n 256 ./create_open $SCRATCH/testfile.nc
export PNETCDF_HINTS"=nc_pncio=disable;nc_striping=inherit;striping_factor=8"
srun -n 256 ./create_open $SCRATCH/testfile.nc
export PNETCDF_HINTS"=nc_pncio=disable;nc_striping=auto"
srun -n 256 ./create_open $SCRATCH/FS_1M_64/testfile.nc
export PNETCDF_HINTS"=nc_pncio=disable;nc_striping=auto;striping_factor=8"
srun -n 256 ./create_open $SCRATCH/FS_1M_64/testfile.nc
export PNETCDF_HINTS"=nc_pncio=disable;nc_striping=inherit"
srun -n 256 ./create_open $SCRATCH/FS_1M_64/testfile.nc
export PNETCDF_HINTS"=nc_pncio=disable;nc_striping=inherit;striping_factor=8"
srun -n 256 ./create_open $SCRATCH/FS_1M_64/testfile.nc
export PNETCDF_HINTS"=;nc_striping=auto"
srun -n 256 ./create_open $SCRATCH/testfile.nc
export PNETCDF_HINTS"=;nc_striping=auto;striping_factor=8"
srun -n 256 ./create_open $SCRATCH/testfile.nc
export PNETCDF_HINTS"=;nc_striping=inherit"
srun -n 256 ./create_open $SCRATCH/testfile.nc
export PNETCDF_HINTS"=;nc_striping=inherit;striping_factor=8"
srun -n 256 ./create_open $SCRATCH/testfile.nc
export PNETCDF_HINTS"=;nc_striping=auto"
srun -n 256 ./create_open $SCRATCH/FS_1M_64/testfile.nc
export PNETCDF_HINTS"=;nc_striping=auto;striping_factor=8"
srun -n 256 ./create_open $SCRATCH/FS_1M_64/testfile.nc
export PNETCDF_HINTS"=;nc_striping=inherit"
srun -n 256 ./create_open $SCRATCH/FS_1M_64/testfile.nc
export PNETCDF_HINTS"=;nc_striping=inherit;striping_factor=8"
srun -n 256 ./create_open $SCRATCH/FS_1M_64/testfile.nc
```
The expected file striping counts of newly created file should be:
```
lmm_stripe_count:  2
lmm_stripe_count:  8
lmm_stripe_count:  1
lmm_stripe_count:  8
lmm_stripe_count:  2
lmm_stripe_count:  8
lmm_stripe_count:  64
lmm_stripe_count:  8
lmm_stripe_count:  2
lmm_stripe_count:  8
lmm_stripe_count:  2
lmm_stripe_count:  8
lmm_stripe_count:  2
lmm_stripe_count:  8
lmm_stripe_count:  64
lmm_stripe_count:  8
```