### PR TITLE
cache node IDs in MPI communicator

### DIFF
--- a/src/drivers/common/utils.c
+++ b/src/drivers/common/utils.c
@@ -184,8 +184,14 @@ ncmpii_construct_node_list(MPI_Comm   comm,
         MPI_Gatherv(my_procname, my_procname_len, MPI_CHAR,
                     NULL, NULL, NULL, MPI_CHAR, root, comm);
 
-    /* compute node IDs of each MPI process */
-    node_ids = (int *) NCI_Malloc(sizeof(int) * (nprocs + 1));
+    /* node_ids is an array storing the compute node IDs of all MPI processes
+     * in the MPI communicator supplied by the application program. Here, we
+     * use malloc() instead of NCI_Malloc, because node_ids will be freed when
+     * the communicator is freed. When communicator is MPI_COMM_WORLD or
+     * MPI_COMM_SELF, it is freed at MPI_Finalize() whose calls to free()
+     * cannot be tracked by PnetCDF.
+     */
+    node_ids = (int *) malloc(sizeof(int) * (nprocs + 1));
 
     if (rank == root) {
         /* all_procnames[] can tell us the number of nodes and number of

--- a/src/drivers/nc4io/nc4io_driver.h
+++ b/src/drivers/nc4io/nc4io_driver.h
@@ -31,11 +31,11 @@ struct NC_nc4 {
 
 extern int
 nc4io_create(MPI_Comm comm, const char *path, int cmode, int ncid,
-             int env_mode, MPI_Info info, void **ncdp);
+             int env_mode, MPI_Info info, PNCIO_node_ids node_ids, void **ncdp);
 
 extern int
 nc4io_open(MPI_Comm comm, const char *path, int omode, int ncid,
-           int env_mode, MPI_Info info, void **ncdp);
+           int env_mode, MPI_Info info, PNCIO_node_ids node_ids, void **ncdp);
 
 extern int
 nc4io_close(void *ncdp);

--- a/src/drivers/nc4io/nc4io_file.c
+++ b/src/drivers/nc4io/nc4io_file.c
@@ -50,13 +50,14 @@
 #include <nc4io_driver.h>
 
 int
-nc4io_create(MPI_Comm     comm,
-             const char  *path,
-             int          cmode,
-             int          ncid,
-             int          env_mode,
-             MPI_Info     info,
-             void       **ncpp)  /* OUT */
+nc4io_create(MPI_Comm         comm,
+             const char      *path,
+             int              cmode,
+             int              ncid,
+             int              env_mode,
+             MPI_Info         info,
+             PNCIO_node_ids   node_ids, /* node IDs of all processes */
+             void           **ncpp)     /* OUT */
 {
     char *filename;
     int err, ncidtmp;
@@ -109,13 +110,14 @@ nc4io_create(MPI_Comm     comm,
 }
 
 int
-nc4io_open(MPI_Comm     comm,
-           const char  *path,
-           int          omode,
-           int          ncid,
-           int          env_mode,
-           MPI_Info     info,
-           void       **ncpp)
+nc4io_open(MPI_Comm         comm,
+           const char      *path,
+           int              omode,
+           int              ncid,
+           int              env_mode,
+           MPI_Info         info,
+           PNCIO_node_ids   node_ids, /* node IDs of all processes */
+           void           **ncpp)     /* OUT */
 {
     char *filename;
     int err, ncidtmp;

--- a/src/drivers/ncadios/ncadios_driver.h
+++ b/src/drivers/ncadios/ncadios_driver.h
@@ -92,11 +92,13 @@ struct NC_ad {
 
 extern int
 ncadios_create(MPI_Comm comm, const char *path, int cmode, int ncid,
-               int env_mode, MPI_Info info, void **ncdp);
+               int env_mode, MPI_Info info, PNCIO_node_ids node_ids,
+               void **ncdp);
 
 extern int
 ncadios_open(MPI_Comm comm, const char *path, int omode, int ncid,
-             int env_mode, MPI_Info info, void **ncdp);
+             int env_mode, MPI_Info info, PNCIO_node_ids node_ids,
+             void **ncdp);
 
 extern int
 ncadios_close(void *ncdp);

--- a/src/drivers/ncadios/ncadios_file.c
+++ b/src/drivers/ncadios/ncadios_file.c
@@ -47,26 +47,28 @@
 #include <ncadios_internal.h>
 
 int
-ncadios_create(MPI_Comm     comm,
-             const char  *path,
-             int          cmode,
-             int          ncid,
-             int          env_mode,
-             MPI_Info     info,
-             void       **ncpp)  /* OUT */
+ncadios_create(MPI_Comm         comm,
+               const char      *path,
+               int              cmode,
+               int              ncid,
+               int              env_mode,
+               MPI_Info         info,
+               PNCIO_node_ids   node_ids, /* node IDs of all processes */
+               void           **ncpp)     /* OUT */
 {
     /* Read only driver */
     DEBUG_RETURN_ERROR(NC_ENOTSUPPORT);
 }
 
 int
-ncadios_open(MPI_Comm     comm,
-           const char  *path,
-           int          omode,
-           int          ncid,
-           int          env_mode,
-           MPI_Info     info,
-           void       **ncpp)
+ncadios_open(MPI_Comm       comm,
+           const char      *path,
+           int              omode,
+           int              ncid,
+           int              env_mode,
+           MPI_Info         info,
+           PNCIO_node_ids   node_ids, /* node IDs of all processes */
+           void           **ncpp)     /* OUT */
 {
     int err, parse_done=0;
     NC_ad *ncadp;

--- a/src/drivers/ncbbio/ncbbio_driver.h
+++ b/src/drivers/ncbbio/ncbbio_driver.h
@@ -261,11 +261,13 @@ void ncbbio_export_hint (NC_bb *ncbbp, MPI_Info *info);
 
 extern
 int ncbbio_create(MPI_Comm comm, const char *path, int cmode, int ncid,
-                  int env_mode, MPI_Info info, void **ncdp);
+                  int env_mode, MPI_Info info, PNCIO_node_ids node_ids,
+                  void **ncdp);
 
 extern
 int ncbbio_open(MPI_Comm comm, const char *path, int omode, int ncid,
-                int env_mode, MPI_Info info, void **ncdp);
+                int env_mode, MPI_Info info, PNCIO_node_ids node_ids,
+                void **ncdp);
 
 extern int ncbbio_close (void *ncdp);
 

--- a/src/drivers/ncbbio/ncbbio_file.c
+++ b/src/drivers/ncbbio/ncbbio_file.c
@@ -49,13 +49,14 @@
 #include <ncbbio_driver.h>
 
 int
-ncbbio_create(MPI_Comm     comm,
-              const char  *path,
-              int          cmode,
-              int          ncid,
-              int          env_mode,
-              MPI_Info     info,
-              void       **ncpp)  /* OUT */
+ncbbio_create(MPI_Comm         comm,
+              const char      *path,
+              int              cmode,
+              int              ncid,
+              int              env_mode,
+              MPI_Info         info,
+              PNCIO_node_ids   node_ids, /* node IDs of all processes */
+              void           **ncpp)     /* OUT */
 {
     int err;
     void *ncp=NULL;
@@ -66,7 +67,8 @@ ncbbio_create(MPI_Comm     comm,
     driver = ncmpio_inq_driver();
     if (driver == NULL) DEBUG_RETURN_ERROR(NC_ENOTNC)
 
-    err = driver->create(comm, path, cmode, ncid, env_mode, info, &ncp);
+    err = driver->create(comm, path, cmode, ncid, env_mode, info, node_ids,
+                         &ncp);
     if (err != NC_NOERR) return err;
 
     /* Create a NC_bb object and save its driver pointer */
@@ -105,13 +107,14 @@ ncbbio_create(MPI_Comm     comm,
 }
 
 int
-ncbbio_open(MPI_Comm     comm,
-            const char  *path,
-            int          omode,
-            int          ncid,
-            int          env_mode,
-            MPI_Info     info,
-            void       **ncpp)
+ncbbio_open(MPI_Comm         comm,
+            const char      *path,
+            int              omode,
+            int              ncid,
+            int              env_mode,
+            MPI_Info         info,
+            PNCIO_node_ids   node_ids, /* node IDs of all processes */
+            void           **ncpp)     /* OUT */
 {
     int err;
     void *ncp=NULL;
@@ -121,7 +124,7 @@ ncbbio_open(MPI_Comm     comm,
     driver = ncmpio_inq_driver();
     if (driver == NULL) DEBUG_RETURN_ERROR(NC_ENOTNC)
 
-    err = driver->open(comm, path, omode, ncid, env_mode, info, &ncp);
+    err = driver->open(comm, path, omode, ncid, env_mode, info, node_ids, &ncp);
     if (err != NC_NOERR) return err;
 
     /* Create a NC_bb object and save its driver pointer */

--- a/src/drivers/ncmpio/ncmpio_NC.h
+++ b/src/drivers/ncmpio/ncmpio_NC.h
@@ -409,7 +409,7 @@ struct NC {
 #endif
     int           hdr_chunk;    /* chunk size for reading header, one chunk at a time */
     int           data_chunk;   /* chunk size for moving variables to higher offsets */
-    int           striping;     /* PNCIO_STRIPING_AUTO or PNCIO_STRIPING_INHERIT */
+    int           nc_striping;  /* PNCIO_STRIPING_AUTO or PNCIO_STRIPING_INHERIT */
     MPI_Offset    v_align;      /* alignment of the beginning of fixed-size variables */
     MPI_Offset    r_align;      /* file alignment for record variable section */
     MPI_Offset    info_v_align; /* v_align set in MPI Info object */

--- a/src/drivers/ncmpio/ncmpio_NC.h
+++ b/src/drivers/ncmpio/ncmpio_NC.h
@@ -406,6 +406,7 @@ struct NC {
     int           num_subfiles; /* no. subfiles */
     struct NC    *ncp_sf;       /* ncp of subfile */
     MPI_Comm      comm_sf;      /* subfile MPI communicator */
+    PNCIO_node_ids node_ids_sf; /* node IDs of subfile MPI communicator */
 #endif
     int           hdr_chunk;    /* chunk size for reading header, one chunk at a time */
     int           data_chunk;   /* chunk size for moving variables to higher offsets */
@@ -432,16 +433,15 @@ struct NC {
     MPI_Offset    put_size;  /* amount of writes committed so far in bytes */
     MPI_Offset    get_size;  /* amount of reads  committed so far in bytes */
 
-    MPI_Comm      comm;           /* MPI communicator */
-    int           rank;           /* MPI rank of this process */
-    int           nprocs;         /* no. MPI processes */
-    int           num_nodes;      /* no. unique compute nodes allocated */
-    int          *node_ids;       /* [nprocs] node IDs of each rank */
-    MPI_Info      mpiinfo;        /* used MPI info object */
-    MPI_File      collective_fh;  /* MPI-IO file handle for collective mode */
-    MPI_File      independent_fh; /* MPI-IO file handle for independent mode */
-    PNCIO_File    *pncio_fh;      /* PNCIO file handler */
-    int           fstype;         /* file system type: PNCIO_LUSTRE, PNCIO_UFS */
+    MPI_Comm       comm;           /* MPI communicator */
+    int            rank;           /* MPI rank of this process */
+    int            nprocs;         /* no. MPI processes */
+    PNCIO_node_ids node_ids;       /* node IDs of each rank */
+    MPI_Info       mpiinfo;        /* used MPI info object */
+    MPI_File       collective_fh;  /* MPI-IO file handle for collective mode */
+    MPI_File       independent_fh; /* MPI-IO file handle for independent mode */
+    PNCIO_File    *pncio_fh;       /* PNCIO file handler */
+    int            fstype;         /* file system type: PNCIO_LUSTRE, PNCIO_UFS */
 
     NC_dimarray   dims;     /* dimensions defined */
     NC_attrarray  attrs;    /* global attributes defined */

--- a/src/drivers/ncmpio/ncmpio_create.c
+++ b/src/drivers/ncmpio/ncmpio_create.c
@@ -34,13 +34,14 @@
 
 /*----< ncmpio_create() >----------------------------------------------------*/
 int
-ncmpio_create(MPI_Comm     comm,
-              const char  *path,
-              int          cmode,
-              int          ncid,
-              int          env_mode,
-              MPI_Info     user_info, /* user's and env info combined */
-              void       **ncpp)
+ncmpio_create(MPI_Comm         comm,
+              const char      *path,
+              int              cmode,
+              int              ncid,
+              int              env_mode,
+              MPI_Info         user_info, /* user's and env info combined */
+              PNCIO_node_ids   node_ids,  /* node IDs of all processes */
+              void           **ncpp)      /* OUT */
 {
     char *filename, value[MPI_MAX_INFO_VAL + 1], *mpi_name;
     int rank, nprocs, mpiomode, err, mpireturn, default_format, file_exist=1;
@@ -340,25 +341,27 @@ if (rank == 0) printf("%s at %d fstype=%s\n", __func__,__LINE__,(ncp->fstype == 
     /* initialize unlimited_id as no unlimited dimension yet defined */
     ncp->dims.unlimited_id = -1;
 
-    /* Construct a list of unique IDs of compute nodes allocated to this job
-     * and save it in ncp->node_ids[nprocs], which contains node IDs of each
-     * rank. The node IDs are used either when intra-node aggregation (INA) is
-     * enabled or when using PnetCDF's PNCIO driver.
+    /* node_ids stores a list of unique IDs of compute nodes of all MPI ranks
+     * in the MPI communicator passed from the user application. It is a keyval
+     * attribute cached in the communicator. See src/dispatchers/file.c for
+     * details. The node IDs will be used when the intra-node aggregation (INA)
+     * is enabled and when PnetCDF's PNCIO driver is used.
      *
      * When intra-node aggregation (INA) is enabled, node IDs are used to
      * create a new MPI communicator consisting of the intra-node aggregators
      * only. The communicator will be used to call file open in MPI-IO or
      * PnetCDF's PNCIO driver. This means only intra-node aggregators will
      * perform file I/O in PnetCDF collective put and get operations.
+     *
+     * node_ids will be used to calculate cb_nodes, the number of MPI-IO/PNCIO
+     * aggregators (not INA aggregators).
      */
-    ncp->node_ids = NULL;
-    err = ncmpii_construct_node_list(comm, &ncp->num_nodes, &ncp->node_ids);
-    if (err != NC_NOERR) return err;
+    ncp->node_ids = node_ids;
 
     /* When the total number of aggregators >= number of processes, disable
      * intra-node aggregation.
      */
-    if (ncp->num_aggrs_per_node * ncp->num_nodes >= ncp->nprocs)
+    if (ncp->num_aggrs_per_node * node_ids.num_nodes >= ncp->nprocs)
         ncp->num_aggrs_per_node = 0;
 
     /* ncp->num_aggrs_per_node = 0, or > 0 is an indicator of whether the INA
@@ -370,6 +373,12 @@ if (rank == 0) printf("%s at %d fstype=%s\n", __func__,__LINE__,(ncp->fstype == 
     ncp->ina_rank = -1;
     ncp->ina_node_list = NULL;
     if (ncp->num_aggrs_per_node > 0) {
+        /* Must duplicate node_ids, as node_ids.ids[] will be modified by
+         * ncmpio_ina_init().
+         */
+        ncp->node_ids.ids = (int*) NCI_Malloc(sizeof(int) * ncp->nprocs);
+        memcpy(ncp->node_ids.ids, node_ids.ids, sizeof(int) * ncp->nprocs);
+
         /* Divide all ranks into groups. Each group is assigned one intra-node
          * aggregator. The following metadata related to intra-node aggregation
          * will be set up in ncmpio_ina_init().
@@ -380,7 +389,7 @@ if (rank == 0) printf("%s at %d fstype=%s\n", __func__,__LINE__,(ncp->fstype == 
          * ncp->ina_comm is an MPI communicator consisting of only intra-node
          *     aggregators across all nodes, which will be used when calling
          *     MPI_File_open(). For non-aggregator, it == MPI_COMM_NULL.
-         * ncp->node_ids[] will be modified to contain the nodes IDs of all
+         * ncp->node_ids.ids[] will be modified to contain the nodes IDs of all
          *     intra-node aggregators, and will be passed to pncio_fh.
          */
         err = ncmpio_ina_init(ncp);
@@ -417,7 +426,7 @@ if (rank == 0) printf("%s at %d fstype=%s\n", __func__,__LINE__,(ncp->fstype == 
                     striping_factor = atoi(value);
             }
             if (striping_factor == 0) {
-                sprintf(value, "%d", ncp->num_nodes);
+                sprintf(value, "%d", ncp->node_ids.num_nodes);
                 MPI_Info_set(user_info, "striping_factor", value);
             }
         }
@@ -473,7 +482,6 @@ if (rank == 0) printf("%s at %d fstype=%s\n", __func__,__LINE__,(ncp->fstype == 
         /* When ncp->fstype != PNCIO_FSTYPE_MPIIO, use PnetCDF's PNCIO driver */
         ncp->pncio_fh = (PNCIO_File*) NCI_Calloc(1, sizeof(PNCIO_File));
         ncp->pncio_fh->file_system = ncp->fstype;
-        ncp->pncio_fh->num_nodes   = ncp->num_nodes;
         ncp->pncio_fh->node_ids    = ncp->node_ids;
 
         err = PNCIO_File_open(comm, filename, mpiomode, user_info,
@@ -567,13 +575,16 @@ if (ncp->rank == 0) {
         NCI_Free(ncp->ina_node_list);
         ncp->ina_node_list = NULL;
     }
-    /* node_ids is no longer needed */
-    if (ncp->node_ids != NULL) {
-        NCI_Free(ncp->node_ids);
-        ncp->node_ids = NULL;
+    if (ncp->num_aggrs_per_node > 0) {
+        /* node_ids is no longer needed. Note node_ids is duplicated above from
+         * the MPI communicator's cached keyval attribute when
+         * ncp->num_aggrs_per_node > 0.
+         */
+        NCI_Free(ncp->node_ids.ids);
+        ncp->node_ids.ids = NULL;
     }
     if (ncp->pncio_fh != NULL)
-        ncp->pncio_fh->node_ids = NULL;
+        ncp->pncio_fh->node_ids.ids = NULL;
 
     return NC_NOERR;
 }

--- a/src/drivers/ncmpio/ncmpio_create.c
+++ b/src/drivers/ncmpio/ncmpio_create.c
@@ -408,7 +408,7 @@ if (rank == 0) printf("%s at %d fstype=%s\n", __func__,__LINE__,(ncp->fstype == 
         /* If hint nc_striping is set to "auto" and hint striping_factor is not
          * set by the user, then set hint striping_factor to ncp->num_nodes.
          */
-        if (ncp->striping == PNCIO_STRIPING_AUTO) {
+        if (ncp->nc_striping == PNCIO_STRIPING_AUTO) {
             int striping_factor=0;
             if (user_info != MPI_INFO_NULL) {
                 MPI_Info_get(user_info, "striping_factor", MPI_MAX_INFO_VAL-1,

--- a/src/drivers/ncmpio/ncmpio_driver.h
+++ b/src/drivers/ncmpio/ncmpio_driver.h
@@ -13,11 +13,13 @@
 
 extern int
 ncmpio_create(MPI_Comm comm, const char *path, int cmode, int ncid,
-              int env_mode, MPI_Info info, void **ncdp);
+              int env_mode, MPI_Info info, PNCIO_node_ids node_ids,
+              void **ncdp);
 
 extern int
 ncmpio_open(MPI_Comm comm, const char *path, int omode, int ncid,
-            int env_mode, MPI_Info info, void **ncdp);
+            int env_mode, MPI_Info info, PNCIO_node_ids node_ids,
+            void **ncdp);
 
 extern int
 ncmpio_close(void *ncdp);

--- a/src/drivers/ncmpio/ncmpio_file_misc.c
+++ b/src/drivers/ncmpio/ncmpio_file_misc.c
@@ -172,9 +172,9 @@ ncmpio_begin_indep_data(void *ncdp)
 
         ncp->pncio_fh = (PNCIO_File*) NCI_Calloc(1,sizeof(PNCIO_File));
         ncp->pncio_fh->file_system = ncp->fstype;
-        ncp->pncio_fh->num_nodes = 1;
-        ncp->pncio_fh->node_ids = (int*) NCI_Malloc(sizeof(int));
-        ncp->pncio_fh->node_ids[0] = 0;
+        ncp->pncio_fh->node_ids.num_nodes = 1;
+        ncp->pncio_fh->node_ids.ids = (int*) NCI_Malloc(sizeof(int));
+        ncp->pncio_fh->node_ids.ids[0] = 0;
 
         int omode = fClr(ncp->mpiomode, MPI_MODE_CREATE);
 
@@ -196,8 +196,9 @@ ncmpio_begin_indep_data(void *ncdp)
         /* Add PnetCDF hints into ncp->mpiinfo */
         ncmpio_hint_set(ncp, ncp->mpiinfo);
 
-        NCI_Free(ncp->pncio_fh->node_ids);
-        ncp->pncio_fh->node_ids = NULL;
+        NCI_Free(ncp->pncio_fh->node_ids.ids);
+        ncp->pncio_fh->node_ids.num_nodes = 0;
+        ncp->pncio_fh->node_ids.ids = NULL;
 
         return NC_NOERR;
     }

--- a/src/drivers/ncmpio/ncmpio_util.c
+++ b/src/drivers/ncmpio/ncmpio_util.c
@@ -267,10 +267,10 @@ void ncmpio_hint_extract(NC       *ncp,
     /* When creating a file, inherit file striping from the parent folder or
      * let PnetCDF to decide.
      */
-    ncp->striping = PNCIO_STRIPING_AUTO;
+    ncp->nc_striping = PNCIO_STRIPING_AUTO;
     MPI_Info_get(info, "nc_striping", MPI_MAX_INFO_VAL-1, value, &flag);
     if (flag && strcasecmp(value, "inherit") == 0)
-        ncp->striping = PNCIO_STRIPING_INHERIT;
+        ncp->nc_striping = PNCIO_STRIPING_INHERIT;
 }
 
 /*----< ncmpio_hint_set() >--------------------------------------------------*/
@@ -384,7 +384,7 @@ void ncmpio_hint_set(NC       *ncp,
     /* When creating a file, inherit file striping from the parent folder or
      * let PnetCDF to decide.
      */
-    if (ncp->striping == PNCIO_STRIPING_AUTO)
+    if (ncp->nc_striping == PNCIO_STRIPING_AUTO)
         MPI_Info_set(info, "nc_striping", "auto");
     else
         MPI_Info_set(info, "nc_striping", "inherit");

--- a/src/drivers/ncmpio/ncmpio_util.c
+++ b/src/drivers/ncmpio/ncmpio_util.c
@@ -51,8 +51,10 @@ void ncmpio_hint_extract(NC       *ncp,
     ncp->ibuf_size = PNC_DEFAULT_IBUF_SIZE;
 
 #ifdef ENABLE_SUBFILING
-    ncp->subfile_mode = 0;
-    ncp->num_subfiles = 0;
+    ncp->subfile_mode          = 0;
+    ncp->num_subfiles          = 0;
+    ncp->node_ids_sf.num_nodes = 0;
+    ncp->node_ids_sf.ids       = NULL;
 #endif
 
     ncp->dims.hash_size  = PNC_HSIZE_DIM;

--- a/src/drivers/pncio/pncio.h
+++ b/src/drivers/pncio/pncio.h
@@ -25,6 +25,7 @@
 #define FDTYPE int
 
 #include <pnc_debug.h>
+#include <dispatch.h>
 #include <common.h>
 
 #if defined(PNETCDF_PROFILING) && (PNETCDF_PROFILING == 1)
@@ -155,9 +156,7 @@ typedef struct {
     int file_system;        /* type of file system */
 
     int fd_sys;             /* system file descriptor */
-    int num_nodes;          /* number of unique compute nodes from
-                             * MPI_Get_processor_name() */
-    int *node_ids;          /* [nprocs] node IDs of each rank */
+    PNCIO_node_ids node_ids;/* node IDs of each rank */
     int access_mode;        /* Access mode (sequential, append, etc.),
                              * possibly modified to deal with
                              * data sieving or deferred open */

--- a/src/drivers/pncio/pncio_lustre_open.c
+++ b/src/drivers/pncio/pncio_lustre_open.c
@@ -68,17 +68,17 @@
 static
 int get_total_avail_osts(const char *path)
 {
-    char *dir_name=NULL, *path_dup=NULL;
+    char *dir_path=NULL, *path_copy=NULL;
     int err, ost_count=0, is_mdt=0;
     struct stat sb;
 
-    path_dup = NCI_Strdup(path);
+    path_copy = NCI_Strdup(path);
 
-    err = stat(path_dup, &sb);
+    err = stat(path_copy, &sb);
     if (errno == ENOENT) { /* file does not exist, try folder */
         /* get the parent folder name */
-        dir_name = dirname(path_dup);
-        err = stat(dir_name, &sb);
+        dir_path = dirname(path_copy);
+        err = stat(dir_path, &sb);
     }
     if (err != 0) {
         printf("Warning at %s (%d): path \"%s\" stat() failed (%s)\n",
@@ -88,20 +88,20 @@ int get_total_avail_osts(const char *path)
 
     /* llapi_get_obd_count() only works for directories */
     if (S_ISDIR(sb.st_mode))
-        dir_name = (dir_name == NULL) ? path_dup : dir_name;
+        dir_path = (dir_path == NULL) ? path_copy : dir_path;
     else
         /* get the parent folder name */
-        dir_name = dirname(path_dup);
+        dir_path = dirname(path_copy);
 
-    err = llapi_get_obd_count(dir_name, &ost_count, is_mdt);
+    err = llapi_get_obd_count(dir_path, &ost_count, is_mdt);
     if (err != 0) {
         printf("Warning at %d: path \"%s\" llapi_get_obd_count() failed (%s)\n",
-               __LINE__,dir_name,strerror(errno));
+               __LINE__,dir_path,strerror(errno));
         ost_count = 0;
     }
 
 err_out:
-    if (path_dup != NULL) NCI_Free(path_dup);
+    if (path_copy != NULL) NCI_Free(path_copy);
 
     return ost_count;
 }
@@ -311,7 +311,7 @@ uint64_t get_striping(int         fd,
     if (err != 0) {
 #ifdef PNETCDF_LUSTRE_DEBUG
         snprintf(int_str, 32, "%lu", *pattern);
-        printf("Error at %s (%d) llapi_layout_pattern_get() fails to get patter %s\n",
+        printf("Error at %s (%d) llapi_layout_pattern_get() fails to get pattern %s\n",
                 __FILE__, __LINE__, PATTERN_STR(*pattern, int_str));
 #endif
         goto err_out;
@@ -428,7 +428,7 @@ int set_striping(const char *path,
     err = llapi_layout_stripe_size_set(layout, stripe_size);
     if (err != 0) {
 #ifdef PNETCDF_LUSTRE_DEBUG
-        printf("Error at %s (%d) llapi_layout_stripe_size_set() fails to set strpe size %lu (%s)\n",
+        printf("Error at %s (%d) llapi_layout_stripe_size_set() fails to set stripe size %lu (%s)\n",
                __FILE__, __LINE__, stripe_size, strerror(errno));
 #endif
         goto err_out;
@@ -470,7 +470,7 @@ int set_striping(const char *path,
 #ifdef PNETCDF_LUSTRE_DEBUG
         char int_str[32];
         snprintf(int_str, 32, "%lu", pattern);
-        printf("Error at %s (%d) llapi_layout_pattern_set() fails ito set pattern %s (%s)\n",
+        printf("Error at %s (%d) llapi_layout_pattern_set() fails to set pattern %s (%s)\n",
                __FILE__, __LINE__, PATTERN_STR(pattern, int_str), strerror(errno));
 #endif
         goto err_out;
@@ -816,7 +816,7 @@ int Lustre_set_cb_node_list(PNCIO_File *fd)
  *   2. root sets and obtains striping info
  *   3. root broadcasts striping info
  *   4. non-root processes receive striping info from root
- *   5. non-root processes opens the fie
+ *   5. non-root processes opens the file
  */
 int
 PNCIO_Lustre_create(PNCIO_File *fd,

--- a/src/include/dispatch.h
+++ b/src/include/dispatch.h
@@ -44,10 +44,18 @@ typedef enum {
     API_VARM
 } NC_api;
 
+typedef struct {
+    int  ref_count ; /* reference count */
+    int  num_nodes;  /* number of unique compute nodes */
+    int *ids;        /* [nprocs] node ID of each MPI process */
+} PNCIO_node_ids;
+
 struct PNC_driver {
     /* APIs manipulate files */
-    int (*create)(MPI_Comm, const char*, int, int, int, MPI_Info, void**);
-    int (*open)(MPI_Comm, const char*, int, int, int, MPI_Info, void**);
+    int (*create)(MPI_Comm, const char*, int, int, int, MPI_Info,
+                  PNCIO_node_ids, void**);
+    int (*open)(MPI_Comm, const char*, int, int, int, MPI_Info,
+                PNCIO_node_ids, void**);
     int (*close)(void*);
     int (*enddef)(void*);
     int (*_enddef)(void*,MPI_Offset,MPI_Offset,MPI_Offset,MPI_Offset);


### PR DESCRIPTION
Calculating compute node IDs of MPI processes in a given MPI communicator is
necessary for intra-node aggregation as well as selecting a good value for hint
cb_nodes. Such calculation is done at file create and open time, which requires
MPI communication. Caching the node IDs into the MPI communicator can save
costs when the same communicator is used in successive file create/open calls.