### PR TITLE
make use of type bool defined in stdbool.h

### DIFF
--- a/src/utils/ncmpidump/ncmpidump.h
+++ b/src/utils/ncmpidump/ncmpidump.h
@@ -15,9 +15,14 @@
 
 #define  Printf  (void) printf
 
+#if defined(HAVE_STDBOOL_H) && HAVE_STDBOOL_H == 1
+#include <stdbool.h> /* type false and true */
+typedef bool boolean;
+#else
 typedef int boolean;
 #if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311L
 enum {false=0, true=1};
+#endif
 #endif
 
 struct ncdim {			/* dimension */


### PR DESCRIPTION
Header file <stdbool.h> defines data type `bool`.
Include it to make use of keywords `false` and `true`.

fix #224