### PR TITLE
Add --tag=CC option to libtool compile and link command lines

### DIFF
--- a/m4/check_mpi.m4
+++ b/m4/check_mpi.m4
@@ -206,8 +206,9 @@ AC_DEFUN([LT_MPI_CHECK_SHLIB],[
    if test "x$RM" = xrm || test "x$RM" = "x/bin/rm" ; then
       RM="$RM -f"
    fi
-   ac_ltcompile='./libtool --mode=compile $MPICC -c $CFLAGS $CPPFLAGS conftest.$ac_ext -o conftest.lo >&AS_MESSAGE_LOG_FD'
-   ac_ltlink_la='./libtool --mode=link $MPICC -rpath `pwd` $CFLAGS $LDFLAGS -o libconftest.la conftest.lo $LIBS >&AS_MESSAGE_LOG_FD'
+   # must add '--tag=CC', otherwise autotool 2.73 failed.
+   ac_ltcompile='./libtool --tag=CC --mode=compile $MPICC -c $CFLAGS $CPPFLAGS conftest.$ac_ext -o conftest.lo >&AS_MESSAGE_LOG_FD'
+   ac_ltlink_la='./libtool --tag=CC --mode=link $MPICC -rpath `pwd` $CFLAGS $LDFLAGS -o libconftest.la conftest.lo $LIBS >&AS_MESSAGE_LOG_FD'
    AS_IF([AC_TRY_EVAL([ac_ltcompile]) &&
        AC_TRY_EVAL([ac_ltlink_la]) &&
        AC_TRY_COMMAND([test -s libconftest.la])],


### PR DESCRIPTION
When using autoconf (GNU Autoconf) 2.73, an error message appears: 

```
configure:37480: ./libtool --mode=compile
/Users/runner/work/PnetCDF/PnetCDF/MPI/bin/mpicc -c -g -O2  conftest.c -o conftest.lo >&5
libtool: compile: unable to infer tagged configuration
libtool:   error: specify a tag with '--tag'
```