### PR TITLE
man pages - replace "Print date" with "Last modified date"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2964,6 +2964,15 @@ AC_SUBST(LMOD_FAMILY_COMPILER_VERSION)
 AC_SUBST(LMOD_FAMILY_MPI)
 AC_SUBST(LMOD_FAMILY_MPI_VERSION)
 
+# check if command git is available.
+is_srcdir_git_clone=
+AC_CHECK_PROG(GIT_CMD, git, git)
+if test "x$GIT_CMD" != x ; then
+   # Check if folder ${srcdir} is in a git repository clone
+   is_srcdir_git_clone=`git -C ${srcdir} rev-parse --is-inside-work-tree 2>/dev/null`
+fi
+AM_CONDITIONAL(IS_GIT_CLONE, [test "x${is_srcdir_git_clone}" = xtrue])
+
 AC_OUTPUT
 echo "------------------------------------------------------------------------------"
 echo \

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -29,4 +29,10 @@ dist-hook:
 	$(SED_I) -e "s|PNETCDF_RELEASE_DATE|@PNETCDF_RELEASE_DATE@|g"           $(distdir)/pnetcdf.m4
 	$(SED_I) -e "s|PNETCDF_RELEASE_DATE_FULL|@PNETCDF_RELEASE_DATE_FULL@|g" $(distdir)/pnetcdf_f90.m4
 	$(SED_I) -e "s|PNETCDF_RELEASE_DATE|@PNETCDF_RELEASE_DATE@|g"           $(distdir)/pnetcdf_f90.m4
+if IS_GIT_CLONE
+	last_commit_date=`git -C $(abs_top_srcdir) log -1 --format='%cd' --date=short $(abs_srcdir)/pnetcdf.m4` ; \
+	$(SED_I) -e "s|GIT_SRC_LAST_COMMIT|$$last_commit_date|g"                $(distdir)/pnetcdf.m4
+	last_commit_date=`git -C $(abs_top_srcdir) log -1 --format='%cd' --date=short $(abs_srcdir)/pnetcdf_f90.m4` ; \
+	$(SED_I) -e "s|GIT_SRC_LAST_COMMIT|$$last_commit_date|g"                $(distdir)/pnetcdf_f90.m4
+endif
 

--- a/man/pnetcdf.m4
+++ b/man/pnetcdf.m4
@@ -426,10 +426,7 @@ $1(string)>>
 >>)
 
 divert(0)dnl
-.nr yr \n(yr+1900
-.af mo 01
-.af dy 01
-.TH PnetCDF 3<<>>ifelse(API,C,,f) "PnetCDF PNETCDF_VERSION" "Printed: \n(yr-\n(mo-\n(dy" "LIBRARY FUNCTIONS"
+.TH PnetCDF 3<<>>ifelse(API,C,,f) "PnetCDF PNETCDF_VERSION" "Last modified: GIT_SRC_LAST_COMMIT" "LIBRARY FUNCTIONS"
 .SH N<<>>AME
 PnetCDF \- Parallel library for accessing files in Network Common Data Form (CDF, CDF-2 and CDF-5 formats)
 .SH SYNOPSIS

--- a/man/pnetcdf_f90.m4
+++ b/man/pnetcdf_f90.m4
@@ -1,7 +1,4 @@
-.nr yr \n(yr+1900
-.af mo 01
-.af dy 01
-.TH PnetCDF 3f "PnetCDF PNETCDF_VERSION" "Printed: \n(yr.\n(mo.\n(dy" "LIBRARY FUNCTIONS"
+.TH PnetCDF 3f "PnetCDF PNETCDF_VERSION" "Last modified: GIT_SRC_LAST_COMMIT" "LIBRARY FUNCTIONS"
 .SH NAME
 PnetCDF \- Parallel library for accessing files in Network Common Data Form (CDF, CDF-2 and CDF-5 formats)
 .SH SYNOPSIS

--- a/src/utils/ncmpidiff/Makefile.am
+++ b/src/utils/ncmpidiff/Makefile.am
@@ -60,6 +60,12 @@ dist-hook:
 	$(SED_I) -e "s|PNETCDF_RELEASE_DATE|@PNETCDF_RELEASE_DATE@|g"           $(distdir)/cdfdiff.1
 	$(SED_I) -e "s|PNETCDF_RELEASE_VERSION|$(PNETCDF_VERSION)|g"            $(distdir)/cdfdiff.c
 	$(SED_I) -e "s|PNETCDF_RELEASE_DATE|@PNETCDF_RELEASE_DATE@|g"           $(distdir)/cdfdiff.c
+if IS_GIT_CLONE
+	last_commit_date=`git -C $(abs_top_srcdir) log -1 --format='%cd' --date=short $(abs_srcdir)/ncmpidiff.1` ; \
+	$(SED_I) -e "s|GIT_SRC_LAST_COMMIT|$$last_commit_date|g"                $(distdir)/ncmpidiff.1
+	last_commit_date=`git -C $(abs_top_srcdir) log -1 --format='%cd' --date=short $(abs_srcdir)/cdfdiff.1` ; \
+	$(SED_I) -e "s|GIT_SRC_LAST_COMMIT|$$last_commit_date|g"                $(distdir)/cdfdiff.1
+endif
 
 
 tests-local: all

--- a/src/utils/ncmpidiff/cdfdiff.1
+++ b/src/utils/ncmpidiff/cdfdiff.1
@@ -1,8 +1,5 @@
 .\" $Header$
-.nr yr \n(yr+1900
-.af mo 01
-.af dy 01
-.TH cdfdiff 1 "PnetCDF PNETCDF_RELEASE_VERSION" "Printed: \n(yr-\n(mo-\n(dy" "PnetCDF utilities"
+.TH cdfdiff 1 "PnetCDF PNETCDF_RELEASE_VERSION" "Last modified: GIT_SRC_LAST_COMMIT" "PnetCDF utilities"
 .SH NAME
 cdfdiff \- compares two classic netCDF files in parallel
 .SH SYNOPSIS

--- a/src/utils/ncmpidiff/ncmpidiff.1
+++ b/src/utils/ncmpidiff/ncmpidiff.1
@@ -1,8 +1,5 @@
 .\" $Header$
-.nr yr \n(yr+1900
-.af mo 01
-.af dy 01
-.TH ncmpidiff 1 "PnetCDF PNETCDF_RELEASE_VERSION" "Printed: \n(yr-\n(mo-\n(dy" "PnetCDF utilities"
+.TH ncmpidiff 1 "PnetCDF PNETCDF_RELEASE_VERSION" "Last modified: GIT_SRC_LAST_COMMIT" "PnetCDF utilities"
 .SH NAME
 ncmpidiff \- compares two netCDF files in parallel
 .SH SYNOPSIS

--- a/src/utils/ncmpidump/Makefile.am
+++ b/src/utils/ncmpidump/Makefile.am
@@ -45,4 +45,8 @@ dist-hook:
 	$(SED_I) -e "s|PNETCDF_RELEASE_VERSION|$(PNETCDF_VERSION)|g"            $(distdir)/ncmpidump.1
 	$(SED_I) -e "s|PNETCDF_RELEASE_DATE_FULL|@PNETCDF_RELEASE_DATE_FULL@|g" $(distdir)/ncmpidump.1
 	$(SED_I) -e "s|PNETCDF_RELEASE_DATE|@PNETCDF_RELEASE_DATE@|g"           $(distdir)/ncmpidump.1
+if IS_GIT_CLONE
+	last_commit_date=`git -C $(abs_top_srcdir) log -1 --format='%cd' --date=short $(abs_srcdir)/ncmpidump.1` ; \
+	$(SED_I) -e "s|GIT_SRC_LAST_COMMIT|$$last_commit_date|g"                $(distdir)/ncmpidump.1
+endif
 

--- a/src/utils/ncmpidump/ncmpidump.1
+++ b/src/utils/ncmpidump/ncmpidump.1
@@ -1,8 +1,5 @@
 .\" $Header$
-.nr yr \n(yr+1900
-.af mo 01
-.af dy 01
-.TH ncmpidump 1 "PnetCDF PNETCDF_RELEASE_VERSION" "Printed: \n(yr-\n(mo-\n(dy" "PnetCDF utilities"
+.TH ncmpidump 1 "PnetCDF PNETCDF_RELEASE_VERSION" "Last modified: GIT_SRC_LAST_COMMIT" "PnetCDF utilities"
 .SH NAME
 ncmpidump \- Convert netCDF files to ASCII form (CDL)
 .SH SYNOPSIS

--- a/src/utils/ncmpigen/Makefile.am
+++ b/src/utils/ncmpigen/Makefile.am
@@ -80,4 +80,8 @@ dist-hook:
 	$(SED_I) -e "s|PNETCDF_RELEASE_VERSION|$(PNETCDF_VERSION)|g"            $(distdir)/ncmpigen.1
 	$(SED_I) -e "s|PNETCDF_RELEASE_DATE_FULL|@PNETCDF_RELEASE_DATE_FULL@|g" $(distdir)/ncmpigen.1
 	$(SED_I) -e "s|PNETCDF_RELEASE_DATE|@PNETCDF_RELEASE_DATE@|g"           $(distdir)/ncmpigen.1
+if IS_GIT_CLONE
+	last_commit_date=`git -C $(abs_top_srcdir) log -1 --format='%cd' --date=short $(abs_srcdir)/ncmpigen.1` ; \
+	$(SED_I) -e "s|GIT_SRC_LAST_COMMIT|$$last_commit_date|g"                $(distdir)/ncmpigen.1
+endif
 

--- a/src/utils/ncmpigen/ncmpigen.1
+++ b/src/utils/ncmpigen/ncmpigen.1
@@ -1,8 +1,5 @@
 .\" $Header$
-.nr yr \n(yr+1900
-.af mo 01
-.af dy 01
-.TH ncmpigen 1 "PnetCDF PNETCDF_RELEASE_VERSION" "Printed: \n(yr-\n(mo-\n(dy" "PnetCDF utilities"
+.TH ncmpigen 1 "PnetCDF PNETCDF_RELEASE_VERSION" "Last modified: GIT_SRC_LAST_COMMIT" "PnetCDF utilities"
 .SH NAME
 ncmpigen \- From a CDL file generate a netCDF file, a C program, or a Fortran
 program

--- a/src/utils/ncoffsets/Makefile.am
+++ b/src/utils/ncoffsets/Makefile.am
@@ -24,4 +24,9 @@ dist-hook:
 	$(SED_I) -e "s|PNETCDF_RELEASE_VERSION|$(PNETCDF_VERSION)|g"            $(distdir)/ncoffsets.1
 	$(SED_I) -e "s|PNETCDF_RELEASE_DATE_FULL|@PNETCDF_RELEASE_DATE_FULL@|g" $(distdir)/ncoffsets.1
 	$(SED_I) -e "s|PNETCDF_RELEASE_DATE|@PNETCDF_RELEASE_DATE@|g"           $(distdir)/ncoffsets.1
+if IS_GIT_CLONE
+	last_commit_date=`git -C $(abs_top_srcdir) log -1 --format='%cd' --date=short $(abs_srcdir)/ncoffsets.1` ; \
+	$(SED_I) -e "s|GIT_SRC_LAST_COMMIT|$$last_commit_date|g"                $(distdir)/ncoffsets.1
+endif
+
 

--- a/src/utils/ncoffsets/ncoffsets.1
+++ b/src/utils/ncoffsets/ncoffsets.1
@@ -1,8 +1,5 @@
 .\" $Header$
-.nr yr \n(yr+1900
-.af mo 01
-.af dy 01
-.TH ncoffsets 1 "PnetCDF PNETCDF_RELEASE_VERSION" "Printed: \n(yr-\n(mo-\n(dy" "PnetCDF utilities"
+.TH ncoffsets 1 "PnetCDF PNETCDF_RELEASE_VERSION" "Last modified: GIT_SRC_LAST_COMMIT" "PnetCDF utilities"
 .SH NAME
 ncoffsets \- print the starting/ending file offsets for netCDF variables
 .SH SYNOPSIS

--- a/src/utils/ncvalidator/Makefile.am
+++ b/src/utils/ncvalidator/Makefile.am
@@ -112,4 +112,8 @@ dist-hook:
 	$(SED_I) -e "s|PNETCDF_RELEASE_VERSION|$(PNETCDF_VERSION)|g"            $(distdir)/ncvalidator.1
 	$(SED_I) -e "s|PNETCDF_RELEASE_DATE_FULL|@PNETCDF_RELEASE_DATE_FULL@|g" $(distdir)/ncvalidator.1
 	$(SED_I) -e "s|PNETCDF_RELEASE_DATE|@PNETCDF_RELEASE_DATE@|g"           $(distdir)/ncvalidator.1
+if IS_GIT_CLONE
+	last_commit_date=`git -C $(abs_top_srcdir) log -1 --format='%cd' --date=short $(abs_srcdir)/ncvalidator.1` ; \
+	$(SED_I) -e "s|GIT_SRC_LAST_COMMIT|$$last_commit_date|g"                $(distdir)/ncvalidator.1
+endif
 

--- a/src/utils/ncvalidator/ncvalidator.1
+++ b/src/utils/ncvalidator/ncvalidator.1
@@ -1,8 +1,5 @@
 .\" $Header$
-.nr yr \n(yr+1900
-.af mo 01
-.af dy 01
-.TH ncvalidator 1 "PnetCDF PNETCDF_RELEASE_VERSION" "Printed: \n(yr-\n(mo-\n(dy" "PnetCDF utilities"
+.TH ncvalidator 1 "PnetCDF PNETCDF_RELEASE_VERSION" "Last modified: GIT_SRC_LAST_COMMIT" "PnetCDF utilities"
 .SH NAME
 ncvalidator \- validates a classic netCDF file against CDF file formats
 .SH SYNOPSIS

--- a/src/utils/pnetcdf_version/Makefile.am
+++ b/src/utils/pnetcdf_version/Makefile.am
@@ -55,4 +55,8 @@ dist-hook:
 	$(SED_I) -e "s|PNETCDF_RELEASE_VERSION|$(PNETCDF_VERSION)|g"            $(distdir)/pnetcdf_version.1
 	$(SED_I) -e "s|PNETCDF_RELEASE_DATE_FULL|@PNETCDF_RELEASE_DATE_FULL@|g" $(distdir)/pnetcdf_version.1
 	$(SED_I) -e "s|PNETCDF_RELEASE_DATE|@PNETCDF_RELEASE_DATE@|g"           $(distdir)/pnetcdf_version.1
+if IS_GIT_CLONE
+	last_commit_date=`git -C $(abs_top_srcdir) log -1 --format='%cd' --date=short $(abs_srcdir)/pnetcdf_version.1` ; \
+	$(SED_I) -e "s|GIT_SRC_LAST_COMMIT|$$last_commit_date|g"                $(distdir)/pnetcdf_version.1
+endif
 

--- a/src/utils/pnetcdf_version/pnetcdf_version.1
+++ b/src/utils/pnetcdf_version/pnetcdf_version.1
@@ -1,8 +1,5 @@
 .\" $Header$
-.nr yr \n(yr+1900
-.af mo 01
-.af dy 01
-.TH pnetcdf_version 1 "PnetCDF PNETCDF_RELEASE_VERSION" "Printed: \n(yr-\n(mo-\n(dy" "PnetCDF utilities"
+.TH pnetcdf_version 1 "PnetCDF PNETCDF_RELEASE_VERSION" "Last modified: GIT_SRC_LAST_COMMIT" "PnetCDF utilities"
 .SH NAME
 pnetcdf_version \- print the version information of PnetCDF library
 .SH SYNOPSIS


### PR DESCRIPTION
At the bottom of the man page, it shows some information about the software
command, version, and date. This PR replace the string of "Printed:" with
"Last modified:", the last modified date of the man page.

That is, this PR replaces
```
  Printed: 2026-07-11                             PnetCDF 1.15.0                                  ncvalidator(1)
```
with
```
  Last modified: 2026-07-11                   PnetCDF 1.15.0                                  ncvalidator(1)
```