### PR TITLE
check_mpi.m4 - when using classic Intel compilers (icc icpc ifort)

### DIFF
--- a/m4/check_mpi.m4
+++ b/m4/check_mpi.m4
@@ -363,6 +363,10 @@ AC_DEFUN([UD_MPI_COMPILER_BASENAME],[
            # Fujitsu MPI compilers: fccpx, FCCpx, frtpx
            compile_basename=`$compile_cmd -showme | cut -d' ' -f1`
            ;;
+        mpiicc | mpiicx | mpiicpc | mpiifort | mpiifx | *[[\\/]]mpiicc | *[[\\/]]mpiicx | *[[\\/]]mpiicpc | *[[\\/]]mpiifort | *[[\\/]]mpiifx )
+           # Intel MPI classic compilers: icc, icpc, ifort. OneAPI compilers: icx, icpx, ifx.
+           compile_basename=`$compile_cmd --version -c 2>&1 | grep -v '^$' | grep -v "remark" | head -n1 | cut -d' ' -f1 | cut -d':' -f1`
+           ;;
         cc | *[[\\/]]cc )
            # For Cray PrgEnv-intel, cc is a wrapper of icc
            # For Cray PrgEnv-gnu, cc is a wrapper of gcc
@@ -374,9 +378,11 @@ AC_DEFUN([UD_MPI_COMPILER_BASENAME],[
            #    % cc --version
            #      nvc 25.5-0 64-bit target on x86-64 Linux -tp zen3-64
 
-           compile_basename=`$compile_cmd --version -c 2>&1 | grep -v '^$' | head -n1 | cut -d' ' -f1`
+           compile_basename=`$compile_cmd --version -c 2>&1 | grep -v '^$' | grep -v "remark" | head -n1 | cut -d' ' -f1 | cut -d':' -f1`
            case "$compile_basename" in
                "gcc"*)
+                   ;;
+               "icc"*)
                    ;;
                "Intel"*)
                    unset cc_basename
@@ -410,9 +416,11 @@ AC_DEFUN([UD_MPI_COMPILER_BASENAME],[
            #    % CC --version
            #      nvc++ 25.5-0 64-bit target on x86-64 Linux -tp zen3-64
 
-           compile_basename=`$compile_cmd --version -c 2>&1 | grep -v '^$' | head -n1 | cut -d' ' -f1`
+           compile_basename=`$compile_cmd --version -c 2>&1 | grep -v '^$' | grep -v "remark" | head -n1 | cut -d' ' -f1 | cut -d':' -f1`
            case "$compile_basename" in
                "g++"*)
+                   ;;
+               "icpc"*)
                    ;;
                "Intel"*)
                    unset cxx_basename
@@ -446,14 +454,14 @@ AC_DEFUN([UD_MPI_COMPILER_BASENAME],[
            #    % ftn --version
            #      nvfortran 25.5-0 64-bit target on x86-64 Linux -tp zen3-64
 
-           compile_basename=`$compile_cmd --version -c 2>&1 | grep -v '^$' | head -n1 | cut -d' ' -f1`
+           compile_basename=`$compile_cmd --version -c 2>&1 | grep -v '^$' | grep -v "remark" | head -n1 | cut -d' ' -f1 | cut -d':' -f1`
            case "$compile_basename" in
                "gfortran"*)
                    ;;
                "GNU"*)
                    compile_basename="gfortran"
                    ;;
-               "ifx"*)
+               "ifx"* | "ifort"* )
                    ;;
                "Intel"*)
                    unset ftn_basename
@@ -486,7 +494,7 @@ AC_DEFUN([UD_MPI_COMPILER_BASENAME],[
    else
       AC_MSG_RESULT([not found])
    fi
-   ud_vendor_version_$1=`$compile_basename --version -c 2>&1 | grep -v '^$' | head -n1`
+   ud_vendor_version_$1=`$compile_basename --version -c 2>&1 | grep -v '^$' | grep -v "remark" | head -n1`
    unset compile_basename
    unset compile_cmd
 ])# UD_MPI_COMPILER_BASENAME

--- a/sneak_peek.md
+++ b/sneak_peek.md
@@ -62,7 +62,9 @@ This is essentially a placeholder for the next release note ...
     See [PR #230](https://github.com/Parallel-NetCDF/PnetCDF/pull/230).
 
 * Bug fixes
-  + none
+  + Fix utility program `pnetcdf_version` for printing the version string of
+    the base compiler of MPICC when the base is a classic Intel compiler.
+    See [PR #232](https://github.com/Parallel-NetCDF/PnetCDF/pull/232).
 
 * New example programs
   + none


### PR DESCRIPTION
check_mpi.m4 - when using classic Intel compilers (icc icpc ifort), ignore lines with "remark"

Example output from command "icc --version"

icc: remark #10441: The Intel(R) C++ Compiler Classic (ICC) is deprecated and will be removed from product release in the second half of 2023. The Intel(R) oneAPI DPC++/C++ Compiler (ICX) is the recommended compiler moving forward. Please transition to use this compiler. Use '-diag-disable=10441' to disable this message. 
icc (ICC) 2021.10.0 20230609
Copyright (C) 1985-2023 Intel Corporation.  All rights reserved.

Example output from newer oneAPI compiler command "icx --version"

Intel(R) oneAPI DPC++/C++ Compiler 2023.2.0 (2023.2.0.20230622) Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/intel/oneapi/compiler/2023.2.0/linux/bin-llvm Configuration file: /opt/intel/oneapi/compiler/2023.2.0/linux/bin-llvm/../bin/icx.cfg